### PR TITLE
Accept string as valid argument for activation [Fixes #32]

### DIFF
--- a/tensorflow_probability/python/layers/conv_variational.py
+++ b/tensorflow_probability/python/layers/conv_variational.py
@@ -177,7 +177,7 @@ class _ConvVariational(tf.keras.layers.Layer):
     self.data_format = tf_layers_util.normalize_data_format(data_format)
     self.dilation_rate = tf_layers_util.normalize_tuple(
         dilation_rate, rank, 'dilation_rate')
-    self.activation = activation
+    self.activation = tf.keras.activations.get(activation)
     self.input_spec = tf.layers.InputSpec(ndim=self.rank + 2)
     self.kernel_posterior_fn = kernel_posterior_fn
     self.kernel_posterior_tensor_fn = kernel_posterior_tensor_fn
@@ -534,7 +534,7 @@ class _ConvReparameterization(_ConvVariational):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -688,7 +688,7 @@ class Conv1DReparameterization(_ConvReparameterization):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -843,7 +843,7 @@ class Conv2DReparameterization(_ConvReparameterization):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -999,7 +999,7 @@ class Conv3DReparameterization(_ConvReparameterization):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -1123,7 +1123,7 @@ class _ConvFlipout(_ConvVariational):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -1347,7 +1347,7 @@ class Conv1DFlipout(_ConvFlipout):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -1510,7 +1510,7 @@ class Conv2DFlipout(_ConvFlipout):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,
@@ -1674,7 +1674,7 @@ class Conv3DFlipout(_ConvFlipout):
         padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
-        activation=activation,
+        activation=tf.keras.activations.get(activation),
         activity_regularizer=activity_regularizer,
         kernel_posterior_fn=kernel_posterior_fn,
         kernel_posterior_tensor_fn=kernel_posterior_tensor_fn,

--- a/tensorflow_probability/python/layers/dense_variational.py
+++ b/tensorflow_probability/python/layers/dense_variational.py
@@ -130,7 +130,7 @@ class _DenseVariational(tf.keras.layers.Layer):
         activity_regularizer=activity_regularizer,
         **kwargs)
     self.units = units
-    self.activation = activation
+    self.activation = tf.keras.activations.get(activation)
     self.input_spec = tf.layers.InputSpec(min_ndim=2)
     self.kernel_posterior_fn = kernel_posterior_fn
     self.kernel_posterior_tensor_fn = kernel_posterior_tensor_fn


### PR DESCRIPTION
Uses `tf.keras.activations.get` method to get the callable activation function from strings.