### PR TITLE
Remove --config=opt from build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ https://bazel.build/) build system.
 # sudo apt-get install bazel git python-pip  # Ubuntu; others, see above links.
 git clone https://github.com/tensorflow/probability.git
 cd probability
-bazel build --config=opt --copt=-O3 --copt=-march=native :pip_pkg
+bazel build --copt=-O3 --copt=-march=native :pip_pkg
 PKGDIR=$(mktemp -d)
 ./bazel-bin/pip_pkg $PKGDIR
 pip install --user --upgrade $PKGDIR/*.whl


### PR DESCRIPTION
Build by Bazel fails with `--config=opt` option as follows.

```
$ bazel build --config=opt --copt=-O3 --copt=-march=native :pip_pkg
INFO: Options provided by the client:
  Inherited 'common' options: --isatty=1 --terminal_columns=106
INFO: Reading rc options for 'build' from /home/probability/tools/bazel.rc:
  Inherited 'common' options: --color=yes
ERROR: Config value opt is not defined in any .rc file
```

Bazel expects `build:opt` configuration in `tools/bazel.rc` as the error message states ([reference](https://stackoverflow.com/questions/46319386/whats-the-difference-between-c-opt-and-config-opt-when-building-tensorflow-f)), but there isn't one. If there are no options to be added, I think the `--config=opt` option in the instruction should be removed.