### PR TITLE
Handle deprecated method inspect.getargspec()

### DIFF
--- a/tensorflow_probability/python/edward2/program_transformations.py
+++ b/tensorflow_probability/python/edward2/program_transformations.py
@@ -129,8 +129,11 @@ def _get_function_inputs(f, **kwargs):
     Dict of key-value pairs in `kwargs` which exist in `f`'s signature.
   """
   if hasattr(f, "_func"):  # functions returned by tf.make_template
-    argspec = inspect.getargspec(f._func)  # pylint: disable=protected-access
-  else:
+    f = f._func  # pylint: disable=protected-access
+
+  try:  # getargspec was deprecated in Python 3.6
+    argspec = inspect.getfullargspec(f)
+  except AttributeError:
     argspec = inspect.getargspec(f)
 
   fkwargs = {k: v for k, v in six.iteritems(kwargs) if k in argspec.args}


### PR DESCRIPTION
This PR is related to the issue: [DeprecationWarning: inspect.getargspec() is deprecated #78](https://github.com/tensorflow/probability/issues/78).

As in Python 3.6, inspect.getargspec() was deprecated, and using inspect.signature() or inspect.getfullargspec() is encouraged.

With this PR changes, program_transformations.py uses inspect.getfullargspec() when it's available, i.e. when Python 3 is used, and fallback on inspect.getargspec() otherwise. The attributes in the returned object are slightly different, but we only care about the `args` attribute and it's unchanged.