### PR TITLE
Delete inappropriate tags in sample code.

### DIFF
--- a/tensorflow_probability/g3doc/api_docs/python/tfp/glm/fit.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/glm/fit.md
@@ -121,7 +121,8 @@ def make_dataset(n, d, link, scale=1., dtype=np.float32):
         dtype)
   elif link == 'logit':
     response = tfd.Bernoulli(logits=linear_response).sample(seed=44)
-* <b>`else`</b>:     raise ValueError('unrecognized true link: {}'.format(link))
+  else:
+    raise ValueError('unrecognized true link: {}'.format(link))
   return model_matrix, response, model_coefficients
 
 X, Y, w_true = make_dataset(n=int(1e6), d=100, link='probit')


### PR DESCRIPTION
Fixed a typo where syntax highlighting was not performed correctly because inappropriate tags were mixed in the sample code.
I do not know why this tag exists.
I am sorry if it is an incorrect fix or if it has already been fixed.