### PR TITLE
Fix T-distribution sampling parameter

### DIFF
--- a/tensorflow_probability/python/distributions/student_t.py
+++ b/tensorflow_probability/python/distributions/student_t.py
@@ -245,7 +245,7 @@ class StudentT(distribution.Distribution):
     gamma_sample = tf.random_gamma(
         [n],
         0.5 * df,
-        beta=0.5,
+        beta=2,
         dtype=self.dtype,
         seed=seed())
     samples = normal_sample * tf.rsqrt(gamma_sample / df)


### PR DESCRIPTION
As title, this is proposed as a bug-fix initially in tensorflow/tensorflow, which I then realized it was deprecated. The pull request has been reviewed and for reference: https://github.com/tensorflow/tensorflow/pull/23301