### PR TITLE
Don't globally set warning filters

### DIFF
--- a/tensorflow_probability/python/mcmc/metropolis_hastings.py
+++ b/tensorflow_probability/python/mcmc/metropolis_hastings.py
@@ -32,12 +32,6 @@ __all__ = [
     'MetropolisHastings',
 ]
 
-
-# Cause all warnings to always be triggered.
-# Not having this means subsequent calls wont trigger the warning.
-warnings.simplefilter('always')
-
-
 MetropolisHastingsKernelResults = collections.namedtuple(
     'MetropolisHastingsKernelResults',
     [

--- a/tensorflow_probability/python/mcmc/sample.py
+++ b/tensorflow_probability/python/mcmc/sample.py
@@ -32,10 +32,6 @@ __all__ = [
     "sample_chain",
 ]
 
-# Cause all warnings to always be triggered.
-# Not having this means subsequent calls wont trigger the warning.
-warnings.simplefilter("always")
-
 
 def sample_chain(
     num_results,

--- a/tensorflow_probability/python/util/variables.py
+++ b/tensorflow_probability/python/util/variables.py
@@ -27,11 +27,6 @@ __all__ = [
 ]
 
 
-# Cause all warnings to always be triggered.
-# Not having this means subsequent calls wont trigger the warning.
-warnings.simplefilter("always")
-
-
 def externalize_variables_as_args(fn,
                                   fn_args=(),
                                   ancestor_variables=None,


### PR DESCRIPTION
### Reference Issues/PRs
Fixes https://github.com/tensorflow/probability/issues/237

### What does this Pull Request accomplish?

- We shouldn't have been setting the global warning filters
- Do not call `warnings.simplefilter()` as part of the API
- It is now up to the user of the API to set the warnings filter appropriately for them