### PR TITLE
Fix typo: edward2 README

### DIFF
--- a/tensorflow_probability/python/edward2/README.md
+++ b/tensorflow_probability/python/edward2/README.md
@@ -208,7 +208,7 @@ states, kernel_results = tfp.mcmc.sample_chain(
     num_burnin_steps=500)
 
 with tf.Session() as sess:
-  states_, results_ = sess.run([states, kernels_results])
+  states_, results_ = sess.run([states, kernel_results])
 ```
 
 The returned `states_[0]` and `states_[1]` contain 1,000 posterior samples for


### PR DESCRIPTION
Just fix typo from `kernels_results` to `kernel_results` as `kernel_results` is declared few lines of code before (not `kernels_results`).