### PR TITLE
Fix typo in sample_chain docstring.

### DIFF
--- a/tensorflow_probability/python/mcmc/sample.py
+++ b/tensorflow_probability/python/mcmc/sample.py
@@ -102,7 +102,7 @@ def sample_chain(
   ##### Sample from a diagonal-variance Gaussian.
 
   ```python
-  import tensorflow tf
+  import tensorflow as tf
   import tensorflow_probability as tfp
   tfd = tfp.distributions
 


### PR DESCRIPTION
Fixes a typo in the `sample_chain` docstring.