### PR TITLE
Update random_walk_metropolis.py

### DIFF
--- a/tensorflow_probability/python/mcmc/random_walk_metropolis.py
+++ b/tensorflow_probability/python/mcmc/random_walk_metropolis.py
@@ -249,7 +249,7 @@ class RandomWalkMetropolis(kernel_base.TransitionKernel):
   # Then the target log-density is defined as follows:
   def target_log_prob(x, y):
     # Stack the input tensors together
-    z = tf.stack([x, y], axis=-1) - true_mean
+    z = tf.stack([x, y], axis=-1)
     return target.log_prob(tf.squeeze(z))
 
   # Initial state of the chain


### PR DESCRIPTION
There is no need for one to substract `true_mean` here. It is because the `target = tfd.MultivariateNormalTriL(loc=true_mean, scale_tril=L)` already contains the `loc`.