### PR TITLE
Fix doc typo in `tfd.GaussianProcess`

### DIFF
--- a/tensorflow_probability/python/distributions/gaussian_process.py
+++ b/tensorflow_probability/python/distributions/gaussian_process.py
@@ -178,10 +178,10 @@ class GaussianProcess(mvn_linear_operator.MultivariateNormalLinearOperator):
     sess.run(tf.global_variables_initializer())
 
     for i in range(1000):
-      _, nll_ = sess.run([optimize, nll])
+      _, neg_log_likelihood_ = sess.run([optimize, neg_log_likelihood])
       if i % 100 == 0:
-        print("Step {}: NLL = {}".format(i, nll_))
-    print("Final NLL = {}".format(nll_))
+        print("Step {}: NLL = {}".format(i, neg_log_likelihood_))
+    print("Final NLL = {}".format(neg_log_likelihood_))
   ```
 
   """


### PR DESCRIPTION
As discussed in #261. I kept the `NLL` string in the print statements to avoid making it overly verbose, but let me know if you want it changed too and I can update the PR :)