### PR TITLE
Support dynamic shape in `sqrt_with_finite_grads`.

### DIFF
--- a/tensorflow_probability/python/positive_semidefinite_kernels/internal/util.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/internal/util.py
@@ -147,7 +147,7 @@ def sqrt_with_finite_grads(x, name=None):
       large_float_like_x = np.sqrt(np.finfo(x.dtype.as_numpy_dtype()).max)
       safe_grads = tf.where(
           tf.equal(x, 0),
-          tf.fill(x.shape, large_float_like_x),
+          tf.fill(tf.shape(x), large_float_like_x),
           0.5 * tf.rsqrt(x))
       return grad_ys * safe_grads
     return tf.sqrt(x), grad

--- a/tensorflow_probability/python/positive_semidefinite_kernels/internal/util_test.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/internal/util_test.py
@@ -136,5 +136,11 @@ class UtilTest(tf.test.TestCase):
         self.evaluate(tf.gradients(safe_sqrt, xs)[0]),
         rtol=1e-10)
 
+  def testSqrtWithFiniteGradsWithDynamicShape(self):
+    x = tf.placeholder_with_default([1.], shape=[None])
+    self.assertAllEqual(
+        self.evaluate(tf.gradients(tf.sqrt(x), x)),
+        self.evaluate(tf.gradients(util.sqrt_with_finite_grads(x), x)))
+
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
I get an error when I use a tensor with dynamic shape as the index_points in `tfd.GaussianProcess`. This change fixed the problem.