### PR TITLE
Fix examples in `tfd.autoregressive` docstring

### DIFF
--- a/tensorflow_probability/python/distributions/autoregressive.py
+++ b/tensorflow_probability/python/distributions/autoregressive.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 
 from tensorflow_probability.python.distributions import distribution
 from tensorflow_probability.python.distributions import seed_stream
+# pylint: disable=not-callable
 
 
 class Autoregressive(distribution.Distribution):
@@ -70,14 +71,15 @@ class Autoregressive(distribution.Distribution):
 
   ```python
   tfd = tfp.distributions
+  tfb = tfp.bijectors
 
-  def normal_fn(self, event_size):
-    n = event_size * (event_size + 1) / 2
+  def _normal_fn(self, event_size):
+    n = event_size * (event_size + 1) // 2
     p = tf.Variable(tfd.Normal(loc=0., scale=1.).sample(n))
-    affine = tfd.bijectors.Affine(
+    affine = tfb.Affine(
         scale_tril=tfd.fill_triangular(0.25 * p))
     def _fn(samples):
-      scale = tf.exp(affine.forward(samples)).eval()
+      scale = tf.exp(affine.forward(samples))
       return tfd.Independent(
           tfd.Normal(loc=0., scale=scale, validate_args=True),
           reinterpreted_batch_ndims=1)
@@ -85,7 +87,7 @@ class Autoregressive(distribution.Distribution):
 
   batch_and_event_shape = [3, 2, 4]
   sample0 = tf.zeros(batch_and_event_shape)
-  ar = autoregressive_lib.Autoregressive(
+  ar = tfd.Autoregressive(
       self._normal_fn(batch_and_event_shape[-1]), sample0)
   x = ar.sample([6, 5])
   # ==> x.shape = [6, 5, 3, 2, 4]


### PR DESCRIPTION
The example codes in autoregressive seems outdated. I made some changes to make it work.