### PR TITLE
indicate that these arguments are not optional

### DIFF
--- a/tensorflow_probability/python/bijectors/kumaraswamy.py
+++ b/tensorflow_probability/python/bijectors/kumaraswamy.py
@@ -42,8 +42,8 @@ class Kumaraswamy(bijector.Bijector):
   """
 
   def __init__(self,
-               concentration1=None,
-               concentration0=None,
+               concentration1,
+               concentration0,
                validate_args=False,
                name="kumaraswamy"):
     """Instantiates the `Kumaraswamy` bijector.


### PR DESCRIPTION
Hi, I just noticed this during creating R bindings for bijectors... I'm imagining it would be clearer not to have defaults for these arguments?