### PR TITLE
Fix Tanh bijector inverse precision

### DIFF
--- a/tensorflow_probability/python/bijectors/tanh.py
+++ b/tensorflow_probability/python/bijectors/tanh.py
@@ -55,9 +55,6 @@ class Tanh(bijector.Bijector):
   def _inverse(self, y):
     return tf.atanh(y)
 
-  def _inverse_log_det_jacobian(self, y):
-    return -tf.math.log1p(-tf.square(y))
-
   def _forward_log_det_jacobian(self, x):
     #  This formula is mathematically equivalent to
     #  `tf.log1p(-tf.square(tf.tanh(x)))`, however this code is more numerically

--- a/tensorflow_probability/python/bijectors/tanh_test.py
+++ b/tensorflow_probability/python/bijectors/tanh_test.py
@@ -56,7 +56,7 @@ class TanhBijectorTest(tf.test.TestCase):
         n=int(10e4))
 
   def testBijectiveAndFinite(self):
-    x = np.linspace(-10., 10., 100).astype(np.float64)
+    x = np.linspace(-30., 30., 100).astype(np.float64)
     eps = 1e-3
     y = np.linspace(-1. + eps, 1. - eps, 100).astype(np.float64)
     bijector_test_util.assert_bijective_and_finite(


### PR DESCRIPTION
Fixes #318 by removing the `Tanh._inverse_log_det_jacobian`. Also, increases the input range for corresponding tests.

Result for the updated tests *before* tanh bijector update:
```
$ python ./tensorflow_probability/python/bijectors/tanh_test.py
Running tests under Python 3.6.5: /home/kristian/conda/envs/softlearning/bin/python
[ RUN      ] TanhBijectorTest.testBijectiveAndFinite
W0307 17:33:17.141244 140132508968384 deprecation.py:323] From /home/kristian/conda/envs/softlearning/lib/python3.6/contextlib.py:60: TensorFlowTestCase.test_session (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.
Instructions for updating:
Use `self.session()` or `self.cached_session()` instead.
2019-03-07 17:33:17.149038: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2019-03-07 17:33:17.168176: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 3696000000 Hz
2019-03-07 17:33:17.169007: I tensorflow/compiler/xla/service/service.cc:162] XLA service 0x55eecb9208e0 executing computations on platform Host. Devices:
2019-03-07 17:33:17.169034: I tensorflow/compiler/xla/service/service.cc:169]   StreamExecutor device (0): <undefined>, <undefined>
[  FAILED  ] TanhBijectorTest.testBijectiveAndFinite
[ RUN      ] TanhBijectorTest.testBijector
[       OK ] TanhBijectorTest.testBijector
[ RUN      ] TanhBijectorTest.testMatchWithAffineTransform
[       OK ] TanhBijectorTest.testMatchWithAffineTransform
[ RUN      ] TanhBijectorTest.testScalarCongruency
[       OK ] TanhBijectorTest.testScalarCongruency
[ RUN      ] TanhBijectorTest.test_session
[  SKIPPED ] TanhBijectorTest.test_session
======================================================================
FAIL: testBijectiveAndFinite (__main__.TanhBijectorTest)
testBijectiveAndFinite (__main__.TanhBijectorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kristian/conda/envs/softlearning/lib/python3.6/site-packages/tensorflow/python/framework/test_util.py", line 971, in decorated
    f(self, *args, **kwargs)
  File "./tensorflow_probability/python/bijectors/tanh_test.py", line 64, in testBijectiveAndFinite
    rtol=1e-4)
  File "/home/kristian/github/hartikainen/probability/tensorflow_probability/python/bijectors/bijector_test_util.py", line 222, in assert_bijective_and_finite
    assert_finite(ildj_f_x)
  File "/home/kristian/github/hartikainen/probability/tensorflow_probability/python/bijectors/bijector_test_util.py", line 30, in assert_finite
    raise AssertionError("array was not all finite. %s" % array[:15])
AssertionError: array was not all finite. [inf inf inf inf inf inf inf inf inf inf inf inf inf inf inf]

----------------------------------------------------------------------
Ran 5 tests in 0.304s

FAILED (failures=1, skipped=1)
```

Result for the updated tests *after* tanh bijector update:
```
(softlearning) ➜ kristian@jensen2: ~/github/hartikainen/probability on master ✗
$ python ./tensorflow_probability/python/bijectors/tanh_test.py
Running tests under Python 3.6.5: /home/kristian/conda/envs/softlearning/bin/python
[ RUN      ] TanhBijectorTest.testBijectiveAndFinite
W0307 17:33:04.416126 140276723865024 deprecation.py:323] From /home/kristian/conda/envs/softlearning/lib/python3.6/contextlib.py:60: TensorFlowTestCase.test_session (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.
Instructions for updating:
Use `self.session()` or `self.cached_session()` instead.
2019-03-07 17:33:04.423423: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2019-03-07 17:33:04.444195: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 3696000000 Hz
2019-03-07 17:33:04.445108: I tensorflow/compiler/xla/service/service.cc:162] XLA service 0x55ea85358e00 executing computations on platform Host. Devices:
2019-03-07 17:33:04.445119: I tensorflow/compiler/xla/service/service.cc:169]   StreamExecutor device (0): <undefined>, <undefined>
[       OK ] TanhBijectorTest.testBijectiveAndFinite
[ RUN      ] TanhBijectorTest.testBijector
[       OK ] TanhBijectorTest.testBijector
[ RUN      ] TanhBijectorTest.testMatchWithAffineTransform
[       OK ] TanhBijectorTest.testMatchWithAffineTransform
[ RUN      ] TanhBijectorTest.testScalarCongruency
[       OK ] TanhBijectorTest.testScalarCongruency
[ RUN      ] TanhBijectorTest.test_session
[  SKIPPED ] TanhBijectorTest.test_session
----------------------------------------------------------------------
Ran 5 tests in 0.316s

OK (skipped=1)
```