### PR TITLE
fix broken example GaussianProcessRegressionModel

### DIFF
--- a/tensorflow_probability/g3doc/api_docs/python/tfp/distributions/GaussianProcessRegressionModel.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/distributions/GaussianProcessRegressionModel.md
@@ -305,7 +305,6 @@ num_results = 200
 
 # Now we can sample from the posterior predictive distribution at a new set
 # of index points.
-index_points = np.linspace(-1., 1., 200)[..., np.newaxis]
 gprm = tfd.GaussianProcessRegressionModel(
     # Batch of `num_results` kernels parameterized by the MCMC samples.
     kernel=psd_kernels.ExponentiatedQuadratic(amplitudes, length_scales),

--- a/tensorflow_probability/g3doc/api_docs/python/tfp/distributions/GaussianProcessRegressionModel.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/distributions/GaussianProcessRegressionModel.md
@@ -305,6 +305,7 @@ num_results = 200
 
 # Now we can sample from the posterior predictive distribution at a new set
 # of index points.
+index_points = np.linspace(-1., 1., 200)[..., np.newaxis]
 gprm = tfd.GaussianProcessRegressionModel(
     # Batch of `num_results` kernels parameterized by the MCMC samples.
     kernel=psd_kernels.ExponentiatedQuadratic(amplitudes, length_scales),

--- a/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
+++ b/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
@@ -292,7 +292,7 @@ class GaussianProcessRegressionModel(
   gprm = tfd.GaussianProcessRegressionModel(
       # Batch of `num_results` kernels parameterized by the MCMC samples.
       kernel=psd_kernels.ExponentiatedQuadratic(amplitudes, length_scales),
-      index_points=np.linspace(-2., 2., 200)[..., np.newaxis],
+      index_points=index_points,
       observation_index_points=observation_index_points,
       observations=observations,
       # We reshape this to align batch dimensions.

--- a/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
+++ b/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
@@ -288,6 +288,7 @@ class GaussianProcessRegressionModel(
 
   # Now we can sample from the posterior predictive distribution at a new set
   # of index points.
+  index_points = np.linspace(-1., 1., 200)[..., np.newaxis]
   gprm = tfd.GaussianProcessRegressionModel(
       # Batch of `num_results` kernels parameterized by the MCMC samples.
       kernel=psd_kernels.ExponentiatedQuadratic(amplitudes, length_scales),


### PR DESCRIPTION
The example in [Marginalization of model hyperparameters](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/GaussianProcessRegressionModel#marginalization_of_model_hyperparameters) section crashes, because the `index_points` variable doesn't have the correct shape. This change fixes that.

In this snippet, `index_points` is never set. However, it is set in a previous snippet, but the shape is not correct, and this example crashes when it goes to plot the results.

[Here's the working code in action](https://repl.it/@PjTrainor/tfp-gpr-text)

Per the CONTRIBUTING.md, this seemed like it was small enough for a PR without an Issue 🙂 