### PR TITLE
Fixing wrong entropy of the Kumaraswamy distribution

### DIFF
--- a/tensorflow_probability/python/distributions/kumaraswamy.py
+++ b/tensorflow_probability/python/distributions/kumaraswamy.py
@@ -185,8 +185,8 @@ class Kumaraswamy(transformed_distribution.TransformedDistribution):
   def _entropy(self):
     a = self.concentration1
     b = self.concentration0
-    return (1 - 1. / a) + (1 - 1. / b) * _harmonic_number(b) + tf.math.log(
-        a) + tf.math.log(b)
+    return (1 - 1. / b) + (1 - 1. / a) * _harmonic_number(b) - tf.math.log(
+        a) - tf.math.log(b)
 
   def _moment(self, n):
     """Compute the n'th (uncentered) moment."""


### PR DESCRIPTION
Hi,

it seems that the entropy of the Kumaraswamy distribution is implemented wrong. The implementation follows the entropy stated in Wikipedia (https://en.wikipedia.org/w/index.php?title=Kumaraswamy_distribution&oldid=885024421) which is also wrong. I put the link to the version at the time of writing because I am about to change Wikipedia as well. The correct entropy as stated in [1](pag. 100) is
![Imgur](https://i.imgur.com/WcprIZv.png)
which is not what is implemented.

There is the need of chaining:
`return (1 - 1. / a) + (1 - 1. / b) * _harmonic_number(b) + tf.math.log(a) + tf.math.log(b)`
to
`return (1 - 1. / b) + (1 - 1. / a) * _harmonic_number(b) - tf.math.log(a) - tf.math.log(b)`

As an empirical proof that it is wrong, a Monte Carlo estimate of the entropy doesn't match the output of the entropy function. Where the correctly implemented entropy does as you see in the snipet:

```
>>> import tensorflow as tf
>>> import tensorflow_probability as tfp
>>> dist = tfp.distributions.Kumaraswamy(2, 3)
>>> samples = dist.sample(10000)
>>> mc = -tf.reduce_mean(dist.log_prob(samples))
>>> session = tf.Session()
>>> session.run(mc)
-0.2085925
>>> session.run(dist.entropy())
3.5139818
>>> a = tf.constant(2.)
>>> b = tf.constant(3.)
>>> session.run((1 - 1. / b) + (1 - 1. / a) * tfp.distributions.kumaraswamy._harmonic_number(b) - tf.math.log(a) - tf.math.log(b))
-0.208426
```

[1] Michalowicz, Joseph Victor, Jonathan M. Nichols, and Frank Bucholtz. Handbook of differential entropy. Chapman and Hall/CRC, 2013.