### PR TITLE
fixed typos and bugs in gaussian_process doc

### DIFF
--- a/tensorflow_probability/python/distributions/gaussian_process.py
+++ b/tensorflow_probability/python/distributions/gaussian_process.py
@@ -148,7 +148,7 @@ class GaussianProcess(mvn_linear_operator.MultivariateNormalLinearOperator):
       kernel=kernel,
       index_points=index_points,
       observation_noise_variance=.05)
-  noisy_samples = noise_gp.sample(10)
+  noisy_samples = noisy_gp.sample(10)
   # ==> 10 independently drawn, noisy joint samples at `index_points`
   ```
 
@@ -166,8 +166,8 @@ class GaussianProcess(mvn_linear_operator.MultivariateNormalLinearOperator):
 
   # Define a kernel with trainable parameters.
   kernel = psd_kernels.ExponentiatedQuadratic(
-      amplitude=tf.get_variable('amplitude', np.float32),
-      length_scale=tf.get_variable('length_scale', np.float32))
+      amplitude=tf.get_variable('amplitude', shape=(), dtype=np.float64),
+      length_scale=tf.get_variable('length_scale', shape=(), dtype=np.float64))
 
   gp = tfd.GaussianProcess(kernel, observed_index_points)
   neg_log_likelihood = -gp.log_prob(observed_values)


### PR DESCRIPTION
This PR fixes a typo and some bugs in the `GaussianProcess` class.

The typo was simple, but I'm not sure about the bugs 🐛. This is what happens:

```py
# TypeError: int() argument must be a string, a bytes-like object or a number, not 'type'
tf.get_variable('amplitude', np.float32)

# this works, but crashes on a dtype conflict with another variable
tf.get_variable('amplitude', shape=(), dtype=np.float32)

# this works!
tf.get_variable('amplitude', shape=(), dtype=np.float64)
```

See a [running repl.it](https://repl.it/@PjTrainor/tfp-gpr-example) for more details. **Note**: sometimes this crashes with `Input matrix is not invertible.`

The repl is running on tensorflow-1.13.1, so maybe there's an issue with that 🤷‍♂️