### PR TITLE
Dual averaging step size

### DIFF
--- a/tensorflow_probability/python/mcmc/BUILD
+++ b/tensorflow_probability/python/mcmc/BUILD
@@ -33,6 +33,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":diagnostic",
+        ":dual_averaging_step_size_adaptation",
         ":hmc",
         ":kernel",
         ":langevin",
@@ -67,6 +68,29 @@ py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+    ],
+)
+
+py_library(
+    name = "dual_averaging_step_size_adaptation",
+    srcs = ["dual_averaging_step_size_adaptation.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":kernel",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/mcmc/internal",
+    ],
+)
+
+py_test(
+    name = "dual_averaging_step_size_adaptation_test",
+    srcs = ["dual_averaging_step_size_adaptation_test.py"],
+    deps = [
+        # absl/testing:parameterized dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
     ],
 )
 

--- a/tensorflow_probability/python/mcmc/__init__.py
+++ b/tensorflow_probability/python/mcmc/__init__.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 from tensorflow_probability.python.mcmc.diagnostic import effective_sample_size
 from tensorflow_probability.python.mcmc.diagnostic import potential_scale_reduction
+from tensorflow_probability.python.mcmc.dual_averaging_step_size_adaptation import DualAveragingStepSizeAdaptation
 from tensorflow_probability.python.mcmc.hmc import HamiltonianMonteCarlo
 from tensorflow_probability.python.mcmc.hmc import make_simple_step_size_update_policy
 from tensorflow_probability.python.mcmc.hmc import UncalibratedHamiltonianMonteCarlo
@@ -44,6 +45,7 @@ from tensorflow_probability.python.mcmc.transformed_kernel import TransformedTra
 
 __all__ = [
     'CheckpointableStatesAndTrace',
+    'DualAveragingStepSizeAdaptation',
     'HamiltonianMonteCarlo',
     'MetropolisAdjustedLangevinAlgorithm',
     'MetropolisHastings',

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -465,8 +465,8 @@ def _maybe_validate_target_accept_prob(target_accept_prob, validate_args):
   if not validate_args:
     return target_accept_prob
   with tf.control_dependencies([
-      tf.assert_positive(
-          target_accept_prob, message='`target_accept_prob` must be > 0.'
+      tf.assert_greater(
+          target_accept_prob, 0., message='`target_accept_prob` must be > 0.'
       ),
       tf.assert_less(
           target_accept_prob,

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -298,10 +298,10 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
   def _one_step_part(
       self,
       *parts,
-      log_accept_prob_rank,
-      log_accept_prob,
-      target_accept_prob,
-      previous_kernel_results):
+      log_accept_prob_rank=None,
+      log_accept_prob=None,
+      target_accept_prob=None,
+      previous_kernel_results=None):
     """Compute new step sizes for each step size part.
 
     If step size part has smaller rank than the corresponding state part, then

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import collections
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 
 from tensorflow_probability.python.internal import dtype_util
 from tensorflow_probability.python.mcmc import kernel as kernel_base
@@ -78,9 +78,8 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
   ):
     inner_kernel = mcmc_util.enable_store_parameters_in_results(inner_kernel)
 
-    with tf.compat.v1.name_scope(
-        mcmc_util.make_name(name, 'simple_step_size_adaptation', '__init__'),
-        values=[target_accept_prob, gamma, t0, kappa, num_adaptation_steps],
+    with tf.name_scope(
+        mcmc_util.make_name(name, 'simple_step_size_adaptation', '__init__')
     ) as name:
       dtype = dtype_util.common_dtype([target_accept_prob, gamma, t0, kappa],
                                       tf.float32)
@@ -138,13 +137,9 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
     return self._parameters
 
   def one_step(self, current_state, previous_kernel_results):
-    with tf.compat.v1.name_scope(
-        name=mcmc_util.make_name(
-            self.name, 'simple_step_size_adaptation', 'one_step'
-        ),
-        values=[current_state, previous_kernel_results],
-    ):
-
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'simple_step_size_adaptation',
+                            'one_step')):
       # Set the step_size.
       inner_results = self.step_size_setter_fn(
           previous_kernel_results.inner_results,
@@ -251,11 +246,9 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
           new_step_size=new_step_size)
 
   def bootstrap_results(self, init_state):
-    with tf.compat.v1.name_scope(
-        name=mcmc_util.make_name(self.name, 'simple_step_size_adaptation',
-                                 'bootstrap_results'),
-        values=[init_state]):
-
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'simple_step_size_adaptation',
+                            'bootstrap_results')):
       inner_results = self.inner_kernel.bootstrap_results(init_state)
       step_size = self.step_size_getter_fn(inner_results)
 
@@ -281,10 +274,10 @@ def _maybe_validate_target_accept_prob(target_accept_prob, validate_args):
   if not validate_args:
     return target_accept_prob
   with tf.control_dependencies([
-      tf.compat.v1.assert_positive(
+      tf.assert_positive(
           target_accept_prob, message='`target_accept_prob` must be > 0.'
       ),
-      tf.compat.v1.assert_less(
+      tf.assert_less(
           target_accept_prob,
           tf.ones_like(target_accept_prob),
           message='`target_accept_prob` must be < 1.'),

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -1,0 +1,299 @@
+"""DualAveragingStepSizeAdaptation TransitionKernel."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+import numpy as np
+import tensorflow as tf
+
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.mcmc import kernel as kernel_base
+from tensorflow_probability.python.mcmc.internal import util as mcmc_util
+
+
+@mcmc_util.make_innermost_setter
+def _hmc_like_step_size_setter_fn(kernel_results, new_step_size):
+  return kernel_results._replace(
+    accepted_results=kernel_results.accepted_results._replace(
+      step_size=new_step_size
+    )
+  )
+
+
+@mcmc_util.make_innermost_getter
+def _hmc_like_step_size_getter_fn(kernel_results):
+  return kernel_results.accepted_results.step_size
+
+
+@mcmc_util.make_innermost_getter
+def _hmc_like_log_accept_prob_getter_fn(kernel_results):
+  log_accept_ratio = kernel_results.log_accept_ratio
+  return tf.minimum(tf.constant(0.0, log_accept_ratio.dtype), log_accept_ratio)
+
+
+def _reduce_logmeanexp(value, dims, keepdims=False):
+  # This is intentionally numerically imprecise for simplicity. For the purposes
+  # of computing the mean acceptance probability this is more than sufficient.
+  return tf.math.log(
+    tf.reduce_mean(input_tensor=tf.exp(value), axis=dims, keepdims=keepdims)
+  )
+
+
+def _get_differing_dims(a, b):
+  # Get the indices of dimensions where shapes of `a` and `b` differ.
+  # `a` is allowed to have fewer dimensions than `b`.
+  if a.shape.is_fully_defined() and b.shape.is_fully_defined():
+    a_shape = np.array(a.shape.as_list())
+    b_shape = np.array(b.shape.as_list())
+    return np.where(a_shape != b_shape[: len(a_shape)])[0]
+  else:
+    return tf.where(
+      tf.not_equal(tf.shape(input=a), tf.shape(input=b)[: tf.rank(a)])
+    )[:, 0]
+
+
+class DualAveragingStepSizeAdaptationResults(
+  collections.namedtuple(
+    "DualAveragingStepSizeAdaptationResults",
+    "inner_results, target_accept_prob, mu, gamma, t0, kappa, error_sum, log_averaging_step, step, new_step_size",
+  )
+):
+  __slots__ = ()
+
+
+class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
+  def __init__(
+    self,
+    inner_kernel,
+    num_adaptation_steps,
+    target_accept_prob=0.75,
+    gamma=0.05,
+    t0=10.0,
+    kappa=0.75,
+    step_size_setter_fn=_hmc_like_step_size_setter_fn,
+    step_size_getter_fn=_hmc_like_step_size_getter_fn,
+    log_accept_prob_getter_fn=_hmc_like_log_accept_prob_getter_fn,
+    validate_args=False,
+    name=None,
+  ):
+    inner_kernel = mcmc_util.enable_store_parameters_in_results(inner_kernel)
+
+    with tf.compat.v1.name_scope(
+      mcmc_util.make_name(name, "simple_step_size_adaptation", "__init__"),
+      values=[target_accept_prob, gamma, t0, kappa, num_adaptation_steps],
+    ) as name:
+        dtype = dtype_util.common_dtype(
+          [target_accept_prob, gamma, t0, kappa], tf.float32
+        )
+        target_accept_prob = tf.convert_to_tensor(
+          value=target_accept_prob, dtype=dtype, name="target_accept_prob"
+        )
+        gamma = tf.convert_to_tensor(
+          value=gamma, dtype=dtype, name="gamma"
+        )
+        t0 = tf.convert_to_tensor(
+          value=t0, dtype=dtype, name="t0"
+        )
+        kappa = tf.convert_to_tensor(
+          value=kappa, dtype=dtype, name="kappa"
+        )
+        num_adaptation_steps = tf.convert_to_tensor(
+          value=num_adaptation_steps, dtype=tf.int32, name="num_adaptation_steps"
+        )
+
+        target_accept_prob = _maybe_validate_target_accept_prob(
+          target_accept_prob, validate_args
+        )
+
+    self._parameters = dict(
+      inner_kernel=inner_kernel,
+      num_adaptation_steps=num_adaptation_steps,
+      target_accept_prob=target_accept_prob,
+      gamma=gamma,
+      t0=t0,
+      kappa=kappa,
+      step_size_setter_fn=step_size_setter_fn,
+      step_size_getter_fn=step_size_getter_fn,
+      log_accept_prob_getter_fn=log_accept_prob_getter_fn,
+      name=name,
+    )
+
+  @property
+  def inner_kernel(self):
+    return self._parameters["inner_kernel"]
+
+  @property
+  def name(self):
+    return self._parameters["name"]
+
+  @property
+  def num_adaptation_steps(self):
+    return self._parameters["num_adaptation_steps"]
+
+  def step_size_setter_fn(self, kernel_results, new_step_size):
+    return self._parameters["step_size_setter_fn"](kernel_results, new_step_size)
+
+  def step_size_getter_fn(self, kernel_results):
+    return self._parameters["step_size_getter_fn"](kernel_results)
+
+  def log_accept_prob_getter_fn(self, kernel_results):
+    return self._parameters["log_accept_prob_getter_fn"](kernel_results)
+
+  @property
+  def parameters(self):
+    """Return `dict` of ``__init__`` arguments and their values."""
+    return self._parameters
+
+  def one_step(self, current_state, previous_kernel_results):
+    with tf.compat.v1.name_scope(
+      name=mcmc_util.make_name(
+        self.name, "simple_step_size_adaptation", "one_step"
+      ),
+      values=[current_state, previous_kernel_results],
+    ):
+
+      # Set the step_size.
+      inner_results = self.step_size_setter_fn(
+        previous_kernel_results.inner_results,
+        previous_kernel_results.new_step_size,
+      )
+
+      # Step the inner kernel.
+      new_state, new_inner_results = self.inner_kernel.one_step(
+        current_state, inner_results)
+
+      # Get the new step size.
+      log_accept_prob = self.log_accept_prob_getter_fn(new_inner_results)
+      target_accept_prob = previous_kernel_results.target_accept_prob
+
+      state_parts = tf.nest.flatten(current_state)
+      step_size = self.step_size_getter_fn(new_inner_results)
+      step_size_parts = tf.nest.flatten(step_size)
+      log_accept_prob_rank = tf.rank(log_accept_prob)
+
+      new_step_size_parts = []
+      for step_size_part, state_part in zip(step_size_parts, state_parts):
+        # Compute new step sizes for each step size part. If step size part has
+        # smaller rank than the corresponding state part, then the difference is
+        # averaged away in the log accept prob.
+        #
+        # Example:
+        #
+        # state_part has shape      [2, 3, 4, 5]
+        # step_size_part has shape     [1, 4, 1]
+        # log_accept_prob has shape [2, 3, 4]
+        #
+        # Since step size has 1 rank fewer than the state, we reduce away the
+        # leading dimension of log_accept_prob to get a Tensor with shape [3,
+        # 4]. Next, since log_accept_prob must broadcast into step_size_part on
+        # the left, we reduce the dimensions where their shapes differ, to get a
+        # Tensor with shape [1, 4], which now is compatible with the leading
+        # dimensions of step_size_part.
+        #
+        # There is a subtlety here in that step_size_parts might be a length-1
+        # list, which means that we'll be "structure-broadcasting" it for all
+        # the state parts (see logic in, e.g., hmc.py). In this case we must
+        # assume that that the lone step size provided broadcasts with the event
+        # dims of each state part. This means that either step size has no
+        # dimensions corresponding to chain dimensions, or all states are of the
+        # same shape. For the former, we want to reduce over all chain
+        # dimensions. For the later, we want to use the same logic as in the
+        # non-structure-broadcasted case.
+        #
+        # It turns out we can compute the reduction dimensions for both cases
+        # uniformly by taking the rank of any state part. This obviously works
+        # in the second case (where all state ranks are the same). In the first
+        # case, all state parts have the rank L + D_i + B, where L is the rank
+        # of log_accept_prob, D_i is the non-shared dimensions amongst all
+        # states, and B are the shared dimensions of all the states, which are
+        # equal to the step size. When we subtract B, we will always get a
+        # number >= L, which means we'll get the full reduction we want.
+        num_reduce_dims = tf.minimum(
+          log_accept_prob_rank, tf.rank(state_part) - tf.rank(step_size_part)
+        )
+        reduced_log_accept_prob = _reduce_logmeanexp(
+          log_accept_prob, tf.range(num_reduce_dims)
+        )
+        # reduced_log_accept_prob must broadcast into step_size_part on the
+        # left, so we do an additional reduction over dimensions where their
+        # shapes differ.
+        reduce_indices = _get_differing_dims(
+          reduced_log_accept_prob, step_size_part
+        )
+        reduced_log_accept_prob = _reduce_logmeanexp(
+          reduced_log_accept_prob, reduce_indices, keepdims=True
+        )
+
+        t = previous_kernel_results.t0 + tf.cast(previous_kernel_results.step, previous_kernel_results.t0.dtype)
+        new_error_sum = previous_kernel_results.error_sum + target_accept_prob - tf.math.exp(reduced_log_accept_prob)
+        log_step = previous_kernel_results.mu - new_error_sum / (tf.math.sqrt(t) * previous_kernel_results.gamma)
+        eta = tf.math.pow(t, -previous_kernel_results.kappa)
+        new_log_averaging_step = eta * log_step + (1 - eta) * previous_kernel_results.log_averaging_step
+
+        # - If still adapting, return an exploring step size,
+        # - If just finished, return the averaging step size
+        # - Otherwise, do not update
+        new_step_size_parts.append(
+          tf.where(
+            previous_kernel_results.step < self.num_adaptation_steps,
+            tf.math.exp(log_step),
+            tf.where(
+              previous_kernel_results.step > self.num_adaptation_steps,
+              step_size_part,
+              tf.math.exp(new_log_averaging_step)
+            )
+          )
+        )
+      new_step_size = tf.nest.pack_sequence_as(step_size, new_step_size_parts)
+
+      return new_state, previous_kernel_results._replace(
+          inner_results=new_inner_results,
+          error_sum=new_error_sum,
+          step=previous_kernel_results.step + 1,
+          log_averaging_step=new_log_averaging_step,
+          new_step_size=new_step_size)
+
+  def bootstrap_results(self, init_state):
+    with tf.compat.v1.name_scope(
+        name=mcmc_util.make_name(self.name, "simple_step_size_adaptation",
+                                 "bootstrap_results"),
+        values=[init_state]):
+
+      inner_results = self.inner_kernel.bootstrap_results(init_state)
+      step_size = self.step_size_getter_fn(inner_results)
+
+      return DualAveragingStepSizeAdaptationResults(
+          inner_results=inner_results,
+          step=tf.constant(0, dtype=tf.int32),
+          target_accept_prob=self.parameters["target_accept_prob"],
+          mu=tf.math.log(10 * step_size),
+          gamma=self.parameters["gamma"],
+          t0=self.parameters["t0"],
+          kappa=self.parameters["kappa"],
+          error_sum=tf.constant(0., dtype=tf.float32),
+          log_averaging_step=tf.constant(0., dtype=tf.float32),
+          new_step_size=step_size,
+      )
+
+  def is_calibrated(self):
+    return self.inner_kernel.is_calibrated()
+
+
+def _maybe_validate_target_accept_prob(target_accept_prob, validate_args):
+  """Validates that target_accept_prob is in (0, 1)."""
+  if not validate_args:
+    return target_accept_prob
+  with tf.control_dependencies([
+      tf.compat.v1.assert_positive(
+          target_accept_prob, message="`target_accept_prob` must be > 0."
+      ),
+      tf.compat.v1.assert_less(
+          target_accept_prob,
+          tf.ones_like(target_accept_prob),
+          message="`target_accept_prob` must be < 1."),
+  ]):
+    return tf.identity(target_accept_prob)
+

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -17,10 +17,8 @@ from tensorflow_probability.python.mcmc.internal import util as mcmc_util
 @mcmc_util.make_innermost_setter
 def _hmc_like_step_size_setter_fn(kernel_results, new_step_size):
   return kernel_results._replace(
-    accepted_results=kernel_results.accepted_results._replace(
-      step_size=new_step_size
-    )
-  )
+      accepted_results=kernel_results.accepted_results._replace(
+          step_size=new_step_size))
 
 
 @mcmc_util.make_innermost_getter
@@ -38,7 +36,7 @@ def _reduce_logmeanexp(value, dims, keepdims=False):
   # This is intentionally numerically imprecise for simplicity. For the purposes
   # of computing the mean acceptance probability this is more than sufficient.
   return tf.math.log(
-    tf.reduce_mean(input_tensor=tf.exp(value), axis=dims, keepdims=keepdims)
+      tf.reduce_mean(input_tensor=tf.exp(value), axis=dims, keepdims=keepdims)
   )
 
 
@@ -51,96 +49,88 @@ def _get_differing_dims(a, b):
     return np.where(a_shape != b_shape[: len(a_shape)])[0]
   else:
     return tf.where(
-      tf.not_equal(tf.shape(input=a), tf.shape(input=b)[: tf.rank(a)])
-    )[:, 0]
+        tf.not_equal(tf.shape(input=a),
+                     tf.shape(input=b)[: tf.rank(a)]))[:, 0]
 
 
 class DualAveragingStepSizeAdaptationResults(
-  collections.namedtuple(
-    "DualAveragingStepSizeAdaptationResults",
-    "inner_results, target_accept_prob, mu, gamma, t0, kappa, error_sum, log_averaging_step, step, new_step_size",
-  )
-):
+    collections.namedtuple(
+        'DualAveragingStepSizeAdaptationResults',
+        'inner_results, target_accept_prob, mu, gamma, t0, kappa, error_sum, '
+        'log_averaging_step, step, new_step_size')):
   __slots__ = ()
 
 
 class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
   def __init__(
-    self,
-    inner_kernel,
-    num_adaptation_steps,
-    target_accept_prob=0.75,
-    gamma=0.05,
-    t0=10.0,
-    kappa=0.75,
-    step_size_setter_fn=_hmc_like_step_size_setter_fn,
-    step_size_getter_fn=_hmc_like_step_size_getter_fn,
-    log_accept_prob_getter_fn=_hmc_like_log_accept_prob_getter_fn,
-    validate_args=False,
-    name=None,
+      self,
+      inner_kernel,
+      num_adaptation_steps,
+      target_accept_prob=0.75,
+      gamma=0.05,
+      t0=10.0,
+      kappa=0.75,
+      step_size_setter_fn=_hmc_like_step_size_setter_fn,
+      step_size_getter_fn=_hmc_like_step_size_getter_fn,
+      log_accept_prob_getter_fn=_hmc_like_log_accept_prob_getter_fn,
+      validate_args=False,
+      name=None,
   ):
     inner_kernel = mcmc_util.enable_store_parameters_in_results(inner_kernel)
 
     with tf.compat.v1.name_scope(
-      mcmc_util.make_name(name, "simple_step_size_adaptation", "__init__"),
-      values=[target_accept_prob, gamma, t0, kappa, num_adaptation_steps],
+        mcmc_util.make_name(name, 'simple_step_size_adaptation', '__init__'),
+        values=[target_accept_prob, gamma, t0, kappa, num_adaptation_steps],
     ) as name:
-        dtype = dtype_util.common_dtype(
-          [target_accept_prob, gamma, t0, kappa], tf.float32
-        )
-        target_accept_prob = tf.convert_to_tensor(
-          value=target_accept_prob, dtype=dtype, name="target_accept_prob"
-        )
-        gamma = tf.convert_to_tensor(
-          value=gamma, dtype=dtype, name="gamma"
-        )
-        t0 = tf.convert_to_tensor(
-          value=t0, dtype=dtype, name="t0"
-        )
-        kappa = tf.convert_to_tensor(
-          value=kappa, dtype=dtype, name="kappa"
-        )
-        num_adaptation_steps = tf.convert_to_tensor(
-          value=num_adaptation_steps, dtype=tf.int32, name="num_adaptation_steps"
-        )
+      dtype = dtype_util.common_dtype([target_accept_prob, gamma, t0, kappa],
+                                      tf.float32)
+      target_accept_prob = tf.convert_to_tensor(
+          value=target_accept_prob, dtype=dtype, name='target_accept_prob')
+      gamma = tf.convert_to_tensor(value=gamma, dtype=dtype, name='gamma')
+      t0 = tf.convert_to_tensor(value=t0, dtype=dtype, name='t0')
+      kappa = tf.convert_to_tensor(value=kappa, dtype=dtype, name='kappa')
+      num_adaptation_steps = tf.convert_to_tensor(
+          value=num_adaptation_steps,
+          dtype=tf.int32,
+          name='num_adaptation_steps')
 
-        target_accept_prob = _maybe_validate_target_accept_prob(
-          target_accept_prob, validate_args
-        )
+      target_accept_prob = _maybe_validate_target_accept_prob(
+          target_accept_prob, validate_args)
 
     self._parameters = dict(
-      inner_kernel=inner_kernel,
-      num_adaptation_steps=num_adaptation_steps,
-      target_accept_prob=target_accept_prob,
-      gamma=gamma,
-      t0=t0,
-      kappa=kappa,
-      step_size_setter_fn=step_size_setter_fn,
-      step_size_getter_fn=step_size_getter_fn,
-      log_accept_prob_getter_fn=log_accept_prob_getter_fn,
-      name=name,
+        inner_kernel=inner_kernel,
+        num_adaptation_steps=num_adaptation_steps,
+        target_accept_prob=target_accept_prob,
+        gamma=gamma,
+        t0=t0,
+        kappa=kappa,
+        step_size_setter_fn=step_size_setter_fn,
+        step_size_getter_fn=step_size_getter_fn,
+        log_accept_prob_getter_fn=log_accept_prob_getter_fn,
+        name=name
     )
 
   @property
   def inner_kernel(self):
-    return self._parameters["inner_kernel"]
+    return self._parameters['inner_kernel']
 
   @property
   def name(self):
-    return self._parameters["name"]
+    return self._parameters['name']
 
   @property
   def num_adaptation_steps(self):
-    return self._parameters["num_adaptation_steps"]
+    return self._parameters['num_adaptation_steps']
 
   def step_size_setter_fn(self, kernel_results, new_step_size):
-    return self._parameters["step_size_setter_fn"](kernel_results, new_step_size)
+    return self._parameters['step_size_setter_fn'](kernel_results,
+                                                   new_step_size)
 
   def step_size_getter_fn(self, kernel_results):
-    return self._parameters["step_size_getter_fn"](kernel_results)
+    return self._parameters['step_size_getter_fn'](kernel_results)
 
   def log_accept_prob_getter_fn(self, kernel_results):
-    return self._parameters["log_accept_prob_getter_fn"](kernel_results)
+    return self._parameters['log_accept_prob_getter_fn'](kernel_results)
 
   @property
   def parameters(self):
@@ -149,21 +139,21 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
 
   def one_step(self, current_state, previous_kernel_results):
     with tf.compat.v1.name_scope(
-      name=mcmc_util.make_name(
-        self.name, "simple_step_size_adaptation", "one_step"
-      ),
-      values=[current_state, previous_kernel_results],
+        name=mcmc_util.make_name(
+            self.name, 'simple_step_size_adaptation', 'one_step'
+        ),
+        values=[current_state, previous_kernel_results],
     ):
 
       # Set the step_size.
       inner_results = self.step_size_setter_fn(
-        previous_kernel_results.inner_results,
-        previous_kernel_results.new_step_size,
+          previous_kernel_results.inner_results,
+          previous_kernel_results.new_step_size,
       )
 
       # Step the inner kernel.
       new_state, new_inner_results = self.inner_kernel.one_step(
-        current_state, inner_results)
+          current_state, inner_results)
 
       # Get the new step size.
       log_accept_prob = self.log_accept_prob_getter_fn(new_inner_results)
@@ -212,40 +202,44 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
         # equal to the step size. When we subtract B, we will always get a
         # number >= L, which means we'll get the full reduction we want.
         num_reduce_dims = tf.minimum(
-          log_accept_prob_rank, tf.rank(state_part) - tf.rank(step_size_part)
-        )
-        reduced_log_accept_prob = _reduce_logmeanexp(
-          log_accept_prob, tf.range(num_reduce_dims)
-        )
+            log_accept_prob_rank,
+            tf.rank(state_part) - tf.rank(step_size_part))
+        reduced_log_accept_prob = _reduce_logmeanexp(log_accept_prob,
+                                                     tf.range(num_reduce_dims))
         # reduced_log_accept_prob must broadcast into step_size_part on the
         # left, so we do an additional reduction over dimensions where their
         # shapes differ.
-        reduce_indices = _get_differing_dims(
-          reduced_log_accept_prob, step_size_part
-        )
+        reduce_indices = _get_differing_dims(reduced_log_accept_prob,
+                                             step_size_part)
         reduced_log_accept_prob = _reduce_logmeanexp(
-          reduced_log_accept_prob, reduce_indices, keepdims=True
-        )
+            reduced_log_accept_prob, reduce_indices, keepdims=True)
 
-        t = previous_kernel_results.t0 + tf.cast(previous_kernel_results.step, previous_kernel_results.t0.dtype)
-        new_error_sum = previous_kernel_results.error_sum + target_accept_prob - tf.math.exp(reduced_log_accept_prob)
-        log_step = previous_kernel_results.mu - new_error_sum / (tf.math.sqrt(t) * previous_kernel_results.gamma)
+        t0 = previous_kernel_results.t0
+        t = t0 + tf.cast(previous_kernel_results.step, t0.dtype)
+        new_error_sum = (previous_kernel_results.error_sum +
+                         target_accept_prob -
+                         tf.math.exp(reduced_log_accept_prob))
+        log_step = (
+            previous_kernel_results.mu -
+            new_error_sum / (tf.math.sqrt(t) * previous_kernel_results.gamma))
         eta = tf.math.pow(t, -previous_kernel_results.kappa)
-        new_log_averaging_step = eta * log_step + (1 - eta) * previous_kernel_results.log_averaging_step
+        new_log_averaging_step = (
+            eta * log_step +
+            (1 - eta) * previous_kernel_results.log_averaging_step)
 
         # - If still adapting, return an exploring step size,
         # - If just finished, return the averaging step size
         # - Otherwise, do not update
         new_step_size_parts.append(
-          tf.where(
-            previous_kernel_results.step < self.num_adaptation_steps,
-            tf.math.exp(log_step),
             tf.where(
-              previous_kernel_results.step > self.num_adaptation_steps,
-              step_size_part,
-              tf.math.exp(new_log_averaging_step)
+                previous_kernel_results.step < self.num_adaptation_steps,
+                tf.math.exp(log_step),
+                tf.where(
+                    previous_kernel_results.step > self.num_adaptation_steps,
+                    step_size_part,
+                    tf.math.exp(new_log_averaging_step)
+                )
             )
-          )
         )
       new_step_size = tf.nest.pack_sequence_as(step_size, new_step_size_parts)
 
@@ -258,8 +252,8 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
 
   def bootstrap_results(self, init_state):
     with tf.compat.v1.name_scope(
-        name=mcmc_util.make_name(self.name, "simple_step_size_adaptation",
-                                 "bootstrap_results"),
+        name=mcmc_util.make_name(self.name, 'simple_step_size_adaptation',
+                                 'bootstrap_results'),
         values=[init_state]):
 
       inner_results = self.inner_kernel.bootstrap_results(init_state)
@@ -268,11 +262,11 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
       return DualAveragingStepSizeAdaptationResults(
           inner_results=inner_results,
           step=tf.constant(0, dtype=tf.int32),
-          target_accept_prob=self.parameters["target_accept_prob"],
+          target_accept_prob=self.parameters['target_accept_prob'],
           mu=tf.math.log(10 * step_size),
-          gamma=self.parameters["gamma"],
-          t0=self.parameters["t0"],
-          kappa=self.parameters["kappa"],
+          gamma=self.parameters['gamma'],
+          t0=self.parameters['t0'],
+          kappa=self.parameters['kappa'],
           error_sum=tf.constant(0., dtype=tf.float32),
           log_averaging_step=tf.constant(0., dtype=tf.float32),
           new_step_size=step_size,
@@ -288,12 +282,12 @@ def _maybe_validate_target_accept_prob(target_accept_prob, validate_args):
     return target_accept_prob
   with tf.control_dependencies([
       tf.compat.v1.assert_positive(
-          target_accept_prob, message="`target_accept_prob` must be > 0."
+          target_accept_prob, message='`target_accept_prob` must be > 0.'
       ),
       tf.compat.v1.assert_less(
           target_accept_prob,
           tf.ones_like(target_accept_prob),
-          message="`target_accept_prob` must be < 1."),
+          message='`target_accept_prob` must be < 1.'),
   ]):
     return tf.identity(target_accept_prob)
 

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -297,11 +297,16 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
 
   def _one_step_part(
       self,
-      *parts,
+      step_size,
+      state,
+      error_sum,
+      log_averaging_step,
+      shrinkage_target,
       log_accept_prob_rank=None,
       log_accept_prob=None,
       target_accept_prob=None,
-      previous_kernel_results=None):
+      previous_kernel_results=None,
+      ):
     """Compute new step sizes for each step size part.
 
     If step size part has smaller rank than the corresponding state part, then
@@ -338,7 +343,6 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
     size. When we subtract B, we will always get a number >= L, which means
     we'll get the full reduction we want.
     """
-    step_size, state, error_sum, log_averaging_step, shrinkage_target = parts
     num_reduce_dims = tf.minimum(
         log_accept_prob_rank,
         tf.rank(state) - tf.rank(step_size))

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation_test.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation_test.py
@@ -129,7 +129,8 @@ class FakeWrapperKernel(tfp.mcmc.TransitionKernel):
 
 
 @test_util.run_all_in_graph_and_eager_modes
-class DualAveragingStepSizeAdaptationTest(tf.test.TestCase, parameterized.TestCase):
+class DualAveragingStepSizeAdaptationTest(tf.test.TestCase,
+                                          parameterized.TestCase):
 
   def testTurnOnStoreParametersInKernelResults(self):
     kernel = FakeWrapperKernel(FakeSteppedKernel(step_size=0.5))
@@ -163,7 +164,8 @@ class DualAveragingStepSizeAdaptationTest(tf.test.TestCase, parameterized.TestCa
 
     expected = tf.math.exp(
         tf.math.log(10. * tf.constant([0.1, 0.2, 0.3])) -
-        tf.constant([0.01, -0.01, -0.01]) / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+        tf.constant([0.01, -0.01, -0.01]) / (
+            (_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
     self.assertAllClose(expected, step_size)
 
   def testWrapped(self):
@@ -211,7 +213,8 @@ class DualAveragingStepSizeAdaptationTest(tf.test.TestCase, parameterized.TestCa
 
     expected = tf.math.exp(
         tf.math.log(10. * init_step) -
-        tf.constant([0.01, -0.01]) / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+        tf.constant([0.01, -0.01]) / (
+            (_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
     self.assertAllClose(expected, step_size)
 
   def testChainLogProbChainTarget(self):
@@ -237,7 +240,8 @@ class DualAveragingStepSizeAdaptationTest(tf.test.TestCase, parameterized.TestCa
 
     expected = tf.math.exp(
         tf.math.log(10. * init_step) -
-        tf.constant([-0.04, 0.04]) / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+        tf.constant([-0.04, 0.04]) / (
+            (_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
     self.assertAllClose(expected, step_size)
 
   @parameterized.parameters((-1., '`target_accept_prob` must be > 0.'),
@@ -292,32 +296,33 @@ class DualAveragingStepSizeAdaptationTest(tf.test.TestCase, parameterized.TestCa
 
 
 @test_util.run_all_in_graph_and_eager_modes
-class DualAveragingStepSizeAdaptationStaticBroadcastingTest(tf.test.TestCase,
-                                                     parameterized.TestCase):
+class DualAveragingStepSizeAdaptationStaticBroadcastingTest(
+    tf.test.TestCase,
+    parameterized.TestCase):
   use_static_shape = True
 
   @parameterized.parameters(
-      (np.float64(1.), np.float64(9.96974283748709)),
+      (np.float64(1.), 9.96974283748709),
       ([np.float64(1.), np.ones([3, 1])], [
           9.96974283748709,
           np.array([[10.],
                     [10.27648032],
-                    [ 9.64289579]])
+                    [9.64289579]])
       ]),
       ([np.float64(1.), np.ones([2, 3, 1])], [
           9.96974283748709,
-          np.array([[[ 9.64289579], [10.18348113], [ 9.64289579]],
-                    [[10.3703288 ], [10.3703288 ], [ 9.64289579]]])
+          np.array([[[9.64289579], [10.18348113], [9.64289579]],
+                    [[10.3703288], [10.3703288], [9.64289579]]])
       ]),
       ([np.float64(1.), np.ones([2, 1, 1])], [
           9.96974283748709,
-          np.array([[[ 9.81982474]], [[10.12194972]]])
+          np.array([[[9.81982474]], [[10.12194972]]])
       ]),
       ([np.float64(1.), np.ones([1, 3, 1])], [
           9.96974283748709,
           np.array([[[10.],
-                    [10.27648032],
-                    [ 9.64289579]]])
+                     [10.27648032],
+                     [9.64289579]]])
       ]),
       ([np.float64(1.), np.ones([1, 1, 1])], [
           9.96974283748709,

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation_test.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation_test.py
@@ -1,0 +1,369 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for DualAveragingStepSizeAdaptation kernel."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+
+from absl.testing import parameterized
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from tensorflow_probability.python.internal import test_util as tfp_test_util
+
+from tensorflow.python.framework import test_util  # pylint: disable=g-direct-tensorflow-import
+
+tfd = tfp.distributions
+
+_INITIAL_T = 10.0
+_EXPLORATION_SHRINKAGE = 0.05
+
+def _set_seed(seed):
+  """Helper which uses graph seed if using eager."""
+  # TODO(b/68017812): Deprecate once eager correctly supports seed.
+  if tf.executing_eagerly():
+    return None
+  return seed
+
+
+FakeMHKernelResults = collections.namedtuple(
+    'FakeMHKernelResults', 'accepted_results, log_accept_ratio')
+
+
+class FakeMHKernel(tfp.mcmc.TransitionKernel):
+
+  def __init__(self,
+               inner_kernel,
+               log_accept_ratio,
+               store_parameters_in_results=False):
+    self.parameters = dict(
+        inner_kernel=inner_kernel,
+        log_accept_ratio=log_accept_ratio,
+        store_parameters_in_results=store_parameters_in_results,
+    )
+
+  def one_step(self, current_state, previous_kernel_results):
+    new_state, new_accepted_results = self.parameters['inner_kernel'].one_step(
+        current_state, previous_kernel_results.accepted_results)
+    return new_state, previous_kernel_results._replace(
+        accepted_results=new_accepted_results)
+
+  def bootstrap_results(self, current_state):
+    return FakeMHKernelResults(
+        accepted_results=self.parameters['inner_kernel'].bootstrap_results(
+            current_state),
+        log_accept_ratio=tf.convert_to_tensor(
+            value=self.parameters['log_accept_ratio']),
+    )
+
+  def is_calibrated(self):
+    return True
+
+
+FakeSteppedKernelResults = collections.namedtuple('FakeSteppedKernelResults',
+                                                  'step_size')
+
+
+class FakeSteppedKernel(tfp.mcmc.TransitionKernel):
+
+  def __init__(self, step_size, store_parameters_in_results=False):
+    self.parameters = dict(
+        step_size=step_size,
+        store_parameters_in_results=store_parameters_in_results)
+
+  def one_step(self, current_state, previous_kernel_results):
+    return current_state, previous_kernel_results
+
+  def bootstrap_results(self, current_state):
+    return FakeSteppedKernelResults(
+        step_size=tf.nest.map_structure(tf.convert_to_tensor,
+                                        self.parameters['step_size']))
+
+  def is_calibrated(self):
+    return False
+
+
+FakeWrapperKernelResults = collections.namedtuple('FakeWrapperKernelResults',
+                                                  'inner_results')
+
+
+class FakeWrapperKernel(tfp.mcmc.TransitionKernel):
+
+  def __init__(self, inner_kernel):
+    self.parameters = dict(inner_kernel=inner_kernel)
+
+  @property
+  def inner_kernel(self):
+    return self.parameters['inner_kernel']
+
+  def one_step(self, current_state, previous_kernel_results):
+    new_state, new_inner_results = self.inner_kernel.one_step(
+        current_state, previous_kernel_results.inner_results)
+    return new_state, previous_kernel_results._replace(
+        inner_results=new_inner_results)
+
+  def bootstrap_results(self, current_state):
+    return FakeWrapperKernelResults(
+        inner_results=self.inner_kernel.bootstrap_results(current_state))
+
+  def is_calibrated(self):
+    return self.inner_kernel.is_calibrated()
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class DualAveragingStepSizeAdaptationTest(tf.test.TestCase, parameterized.TestCase):
+
+  def testTurnOnStoreParametersInKernelResults(self):
+    kernel = FakeWrapperKernel(FakeSteppedKernel(step_size=0.5))
+    self.assertFalse(
+        kernel.inner_kernel.parameters['store_parameters_in_results'])
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        kernel,
+        num_adaptation_steps=1,
+        validate_args=True)
+    self.assertTrue(kernel.inner_kernel.inner_kernel
+                    .parameters['store_parameters_in_results'])
+
+  def testListStep(self):
+    kernel = FakeMHKernel(
+        FakeSteppedKernel(step_size=tf.constant([0.1, 0.2, 0.3])),
+        log_accept_ratio=tf.stack(
+            [tf.math.log(0.74),
+             tf.math.log(0.76),
+             tf.math.log(0.76)]))
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        kernel,
+        num_adaptation_steps=1,
+        validate_args=True)
+
+    kernel_results = kernel.bootstrap_results(tf.zeros(3))
+    for _ in range(2):
+      _, kernel_results = kernel.one_step(tf.zeros(3), kernel_results)
+
+    step_size = self.evaluate(
+        kernel_results.inner_results.accepted_results.step_size,)
+
+    expected = tf.math.exp(
+        tf.math.log(10. * tf.constant([0.1, 0.2, 0.3])) -
+        tf.constant([0.01, -0.01, -0.01]) / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+    self.assertAllClose(expected, step_size)
+
+  def testWrapped(self):
+    kernel = FakeMHKernel(
+        FakeSteppedKernel(step_size=0.1),
+        # Just over the target_accept_prob.
+        log_accept_ratio=tf.stack(tf.math.log(0.76)))
+    kernel = FakeWrapperKernel(kernel)
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        kernel,
+        num_adaptation_steps=1,
+        validate_args=True)
+
+    kernel_results = kernel.bootstrap_results(0.)
+    for _ in range(2):
+      _, kernel_results = kernel.one_step(0., kernel_results)
+
+    step_size = self.evaluate(
+        kernel_results.inner_results.inner_results.accepted_results.step_size)
+
+    expected = tf.math.exp(
+        tf.math.log(10. * 0.1) -
+        -0.01 / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+    self.assertAllClose(expected, step_size)
+
+  def testChainLogProbScalarTarget(self):
+    init_step = tf.constant([0.1, 0.2])
+    kernel = FakeMHKernel(
+        FakeSteppedKernel(step_size=init_step),
+        log_accept_ratio=tf.stack([tf.math.log(0.74),
+                                   tf.math.log(0.76)]))
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        kernel,
+        num_adaptation_steps=1,
+        log_accept_prob_getter_fn=(
+            lambda pkr: tf.minimum(0., pkr.log_accept_ratio)),
+        validate_args=True)
+
+    kernel_results = kernel.bootstrap_results(tf.zeros(2))
+    for _ in range(2):
+      _, kernel_results = kernel.one_step(tf.zeros(2), kernel_results)
+
+    step_size = self.evaluate(
+        kernel_results.inner_results.accepted_results.step_size,)
+
+    expected = tf.math.exp(
+        tf.math.log(10. * init_step) -
+        tf.constant([0.01, -0.01]) / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+    self.assertAllClose(expected, step_size)
+
+  def testChainLogProbChainTarget(self):
+    init_step = tf.constant([0.1, 0.2])
+    kernel = FakeMHKernel(
+        FakeSteppedKernel(step_size=init_step),
+        log_accept_ratio=tf.stack([tf.math.log(0.74),
+                                   tf.math.log(0.76)]))
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        kernel,
+        num_adaptation_steps=1,
+        log_accept_prob_getter_fn=(
+            lambda pkr: tf.minimum(0., pkr.log_accept_ratio)),
+        validate_args=True,
+        target_accept_prob=tf.stack([0.7, 0.8]))
+
+    kernel_results = kernel.bootstrap_results(tf.zeros(2))
+    for _ in range(2):
+      _, kernel_results = kernel.one_step(tf.zeros(2), kernel_results)
+
+    step_size = self.evaluate(
+        kernel_results.inner_results.accepted_results.step_size,)
+
+    expected = tf.math.exp(
+        tf.math.log(10. * init_step) -
+        tf.constant([-0.04, 0.04]) / ((_INITIAL_T + 1.) * _EXPLORATION_SHRINKAGE))
+    self.assertAllClose(expected, step_size)
+
+  @parameterized.parameters((-1., '`target_accept_prob` must be > 0.'),
+                            (0., '`target_accept_prob` must be > 0.'),
+                            (0.999, None),
+                            (1., '`target_accept_prob` must be < 1.'))
+  def testTargetAcceptanceProbChecks(self, target_accept_prob, message):
+
+    def _impl():
+      kernel = FakeMHKernel(
+          FakeSteppedKernel(step_size=1.), log_accept_ratio=0.)
+      kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+          kernel,
+          num_adaptation_steps=1,
+          target_accept_prob=target_accept_prob,
+          validate_args=True)
+      self.evaluate(kernel.bootstrap_results(tf.zeros(2)))
+
+    if message:
+      with self.assertRaisesRegexp(tf.errors.InvalidArgumentError, message):
+        _impl()
+    else:
+      _impl()
+
+  def testExample(self):
+    tf.compat.v1.random.set_random_seed(tfp_test_util.test_seed())
+    target_log_prob_fn = tfd.Normal(loc=0., scale=1.).log_prob
+    num_burnin_steps = 500
+    num_results = 500
+    num_chains = 64
+    step_size = 0.1
+
+    kernel = tfp.mcmc.HamiltonianMonteCarlo(
+        target_log_prob_fn=target_log_prob_fn,
+        num_leapfrog_steps=2,
+        step_size=step_size,
+        seed=_set_seed(tfp_test_util.test_seed()))
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        inner_kernel=kernel, num_adaptation_steps=int(num_burnin_steps * 0.8))
+
+    _, log_accept_ratio = tfp.mcmc.sample_chain(
+        num_results=num_results,
+        num_burnin_steps=num_burnin_steps,
+        current_state=tf.zeros(num_chains),
+        kernel=kernel,
+        trace_fn=lambda _, pkr: pkr.inner_results.log_accept_ratio)
+
+    p_accept = tf.reduce_mean(
+        input_tensor=tf.exp(tf.minimum(log_accept_ratio, 0.)))
+
+    self.assertAllClose(0.75, self.evaluate(p_accept), atol=0.15)
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class DualAveragingStepSizeAdaptationStaticBroadcastingTest(tf.test.TestCase,
+                                                     parameterized.TestCase):
+  use_static_shape = True
+
+  @parameterized.parameters(
+      (np.float64(1.), np.float64(1.)),
+      ([np.float64(1.), np.ones([3, 1])], [
+          np.float64(1.),
+          np.array([[1.], [1.], [1.]])
+      ]),
+      ([np.float64(1.), np.ones([2, 3, 1])], [
+          np.float64(1.),
+          np.array([[[1.], [1.], [1.]],
+                    [[1.], [1.], [1.]]])
+      ]),
+      ([np.float64(1.), np.ones([2, 1, 1])], [
+          np.float64(1.),
+          np.array([[[1.]], [[1.]]])
+      ]),
+      ([np.float64(1.), np.ones([1, 3, 1])], [
+          np.float64(1.),
+          np.array([[[1.], [1.], [1.]]])
+      ]),
+      ([np.float64(1.), np.ones([1, 1, 1])], [
+          np.float64(1.),
+          np.array([[[1.]]])
+      ]),
+      ([np.float64(1.), np.ones([1, 1])], [
+          np.float64(1.),
+          np.array([[1.]])
+      ]),
+      ([np.float64(1.), np.ones([1])], [
+          np.float64(1.),
+          np.array([1.])
+      ]),
+  )
+  def testBroadcasting(self, old_step_size, new_step_size):
+    log_accept_ratio = tf.constant(
+        [[np.log(0.73), np.log(0.76), np.log(0.73)],
+         [np.log(0.77), np.log(0.77), np.log(0.73)]],
+        dtype=tf.float64)
+    log_accept_ratio = tf.compat.v1.placeholder_with_default(
+        input=log_accept_ratio,
+        shape=log_accept_ratio.shape if self.use_static_shape else None)
+    state = [
+        tf.zeros([2, 3], dtype=tf.float64),
+        tf.zeros([2, 3, 4], dtype=tf.float64)
+    ]
+
+    kernel = FakeMHKernel(
+        FakeSteppedKernel(step_size=old_step_size),
+        log_accept_ratio=log_accept_ratio)
+    kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+        kernel,
+        num_adaptation_steps=1,
+        validate_args=True)
+
+    kernel_results = kernel.bootstrap_results(state)
+    for _ in range(2):
+      _, kernel_results = kernel.one_step(state, kernel_results)
+
+    step_size = self.evaluate(
+        kernel_results.inner_results.accepted_results.step_size,)
+
+    self.assertAllClose(new_step_size, step_size)
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class DualAveragingStepSizeAdaptationDynamicBroadcastingTest(
+    DualAveragingStepSizeAdaptationStaticBroadcastingTest):
+  use_static_shape = False
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation_test.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation_test.py
@@ -297,35 +297,39 @@ class DualAveragingStepSizeAdaptationStaticBroadcastingTest(tf.test.TestCase,
   use_static_shape = True
 
   @parameterized.parameters(
-      (np.float64(1.), np.float64(1.)),
+      (np.float64(1.), np.float64(9.96974283748709)),
       ([np.float64(1.), np.ones([3, 1])], [
-          np.float64(1.),
-          np.array([[1.], [1.], [1.]])
+          9.96974283748709,
+          np.array([[10.],
+                    [10.27648032],
+                    [ 9.64289579]])
       ]),
       ([np.float64(1.), np.ones([2, 3, 1])], [
-          np.float64(1.),
-          np.array([[[1.], [1.], [1.]],
-                    [[1.], [1.], [1.]]])
+          9.96974283748709,
+          np.array([[[ 9.64289579], [10.18348113], [ 9.64289579]],
+                    [[10.3703288 ], [10.3703288 ], [ 9.64289579]]])
       ]),
       ([np.float64(1.), np.ones([2, 1, 1])], [
-          np.float64(1.),
-          np.array([[[1.]], [[1.]]])
+          9.96974283748709,
+          np.array([[[ 9.81982474]], [[10.12194972]]])
       ]),
       ([np.float64(1.), np.ones([1, 3, 1])], [
-          np.float64(1.),
-          np.array([[[1.], [1.], [1.]]])
+          9.96974283748709,
+          np.array([[[10.],
+                    [10.27648032],
+                    [ 9.64289579]]])
       ]),
       ([np.float64(1.), np.ones([1, 1, 1])], [
-          np.float64(1.),
-          np.array([[[1.]]])
+          9.96974283748709,
+          np.array([[[9.96974284]]])
       ]),
       ([np.float64(1.), np.ones([1, 1])], [
-          np.float64(1.),
-          np.array([[1.]])
+          9.96974283748709,
+          np.array([[9.96974284]])
       ]),
       ([np.float64(1.), np.ones([1])], [
-          np.float64(1.),
-          np.array([1.])
+          9.96974283748709,
+          np.array([9.96974284])
       ]),
   )
   def testBroadcasting(self, old_step_size, new_step_size):
@@ -340,7 +344,6 @@ class DualAveragingStepSizeAdaptationStaticBroadcastingTest(tf.test.TestCase,
         tf.zeros([2, 3], dtype=tf.float64),
         tf.zeros([2, 3, 4], dtype=tf.float64)
     ]
-
     kernel = FakeMHKernel(
         FakeSteppedKernel(step_size=old_step_size),
         log_accept_ratio=log_accept_ratio)


### PR DESCRIPTION
Wanted to push this early -- I am pattern matching a lot from the nicely documented `SimpleStepSizeAdaptation` class, and may ask questions here.

This implements dual averaging step size. The reference is Section 3.2 in "The No-U-Turn Sampler: Adaptively Setting Path Lengths in Hamiltonian Monte Carlo.", and a reference implementation using `autograd` is [here](https://colindcarroll.com/2019/04/21/step-size-adaptation-in-hamiltonian-monte-carlo/).

Here are two experiments comparing warmup with this and the `SimpleStepSizeAdaptation`:

![image](https://user-images.githubusercontent.com/2295568/56582281-e440ba80-65a4-11e9-8802-079e6e97b81a.png)
![image](https://user-images.githubusercontent.com/2295568/56582292-ec005f00-65a4-11e9-9934-efb52542e810.png)


TODO:
[ ] Clean up reused code
[ ] Add tests
[ ] Update variable names (descriptive are preferred to the names from the paper?)
[ ] Update documentation
[ ] Update style

Code for the experiments above. I can add the plotting code if desired:

```python
import tensorflow as tf
import tensorflow_probability as tfp
tfd = tfp.distributions

print(tfp.__version__)  # 0.7.0-dev
print(tf.__version__)  # 2.0.0-dev20190422

target_log_prob_fn = tfd.Normal(loc=0., scale=1.1).log_prob
num_results = 1000
num_chains = 64
step_size = 0.01

inner_kernel = tfp.mcmc.HamiltonianMonteCarlo(target_log_prob_fn=target_log_prob_fn, num_leapfrog_steps=8, step_size=step_size)

simple_kernel = tfp.mcmc.SimpleStepSizeAdaptation(inner_kernel=inner_kernel, num_adaptation_steps=num_results)
averaging_kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(inner_kernel=inner_kernel, num_adaptation_steps=num_results)

def simple_trace_fn(x, pkr):
    return [pkr.inner_results.accepted_results.step_size, pkr.inner_results.log_accept_ratio]

def averaging_trace_fn(x, pkr):
    return [pkr.inner_results.accepted_results.step_size, pkr.inner_results.log_accept_ratio, pkr.log_averaging_step]


_, [simple_step_size, simple_log_accept_ratio] = tfp.mcmc.sample_chain(
    num_results=num_results,
    num_burnin_steps=0,
    current_state=tf.zeros(num_chains),
    kernel=simple_kernel,
    trace_fn=simple_trace_fn)

_, [averaging_step_size, averaging_log_accept_ratio, log_averaging_step] = tfp.mcmc.sample_chain(
    num_results=num_results,
    num_burnin_steps=0,
    current_state=tf.zeros(num_chains),
    kernel=averaging_kernel,
    trace_fn=averaging_trace_fn)
```

@junpenglao may be interested in this.