### PR TITLE
Fix a typo in API doc tfp.distributions.HiddenMarkovModel

### DIFF
--- a/tensorflow_probability/g3doc/api_docs/python/tfp/distributions/HiddenMarkovModel.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/distributions/HiddenMarkovModel.md
@@ -115,7 +115,7 @@ model.mean()  # shape [7], elements approach 9.0
 
 # The log pdf of a week of temperature 0 is:
 
-model.log_prob(tfp.zeros(shape=[7]))
+model.log_prob(tf.zeros(shape=[7]))
 ```
 
 #### References

--- a/tensorflow_probability/python/distributions/hidden_markov_model.py
+++ b/tensorflow_probability/python/distributions/hidden_markov_model.py
@@ -102,7 +102,7 @@ class HiddenMarkovModel(distribution.Distribution):
 
   # The log pdf of a week of temperature 0 is:
 
-  model.log_prob(tfp.zeros(shape=[7]))
+  model.log_prob(tf.zeros(shape=[7]))
   ```
 
   #### References


### PR DESCRIPTION
https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/HiddenMarkovModel
I believe `tfp.zeros()` should be `tf.zeros()`.
I didn't open issue for this since this is just a small document/comment fix.