### PR TITLE
docs: fix typos in potential_scale_reduction docstring

### DIFF
--- a/tensorflow_probability/python/mcmc/diagnostic.py
+++ b/tensorflow_probability/python/mcmc/diagnostic.py
@@ -220,24 +220,24 @@ def potential_scale_reduction(chains_states,
     Before that, R-hat > 1 (except in pathological cases, e.g. if the chain
     paths were identical).
   * The above holds for any number of chains `C > 1`.  Increasing `C` does
-    improves effectiveness of the diagnostic.
+    improve effectiveness of the diagnostic.
   * Sometimes, R-hat < 1.2 is used to indicate approximate convergence, but of
-    course this is problem dependent. See [Brooks and Gelman (1998)][2].
+    course this is problem-dependent. See [Brooks and Gelman (1998)][2].
   * R-hat only measures non-convergence of the mean. If higher moments, or
     other statistics are desired, a different diagnostic should be used. See
     [Brooks and Gelman (1998)][2].
 
   Args:
     chains_states:  `Tensor` or Python `list` of `Tensor`s representing the
-      state(s) of a Markov Chain at each result step.  The `ith` state is
+      states of a Markov Chain at each result step.  The `ith` state is
       assumed to have shape `[Ni, Ci1, Ci2,...,CiD] + A`.
       Dimension `0` indexes the `Ni > 1` result steps of the Markov Chain.
       Dimensions `1` through `D` index the `Ci1 x ... x CiD` independent
       chains to be tested for convergence to the same target.
       The remaining dimensions, `A`, can have any shape (even empty).
     independent_chain_ndims: Integer type `Tensor` with value `>= 1` giving the
-      number of giving the number of dimensions, from `dim = 1` to `dim = D`,
-      holding independent chain results to be tested for convergence.
+      number of dimensions, from `dim = 1` to `dim = D`, holding independent chain
+      results to be tested for convergence.
     name: `String` name to prepend to created tf.  Default:
       `potential_scale_reduction`.
 


### PR DESCRIPTION
I think this would be much easier to find if it was named `tfp.mcmc.r_hat`. At first, looking through the API, I thought `tfp` didn't implement R-hat. Maybe create an alias for `tfp.mcmc.r_hat`?

Also, not sure if the colon in `state.shape[1 + independent_chain_ndims:]` is intentional.