### PR TITLE
Fix Triangular bounds (fixes #391)

### DIFF
--- a/tensorflow_probability/python/distributions/triangular.py
+++ b/tensorflow_probability/python/distributions/triangular.py
@@ -234,7 +234,7 @@ class Triangular(distribution.Distribution):
 
     broadcast_x_to_high = _broadcast_to(x, [self.high])
     left_of_peak = tf.logical_and(
-        broadcast_x_to_high > self.low, broadcast_x_to_high <= self.peak)
+        broadcast_x_to_high >= self.low, broadcast_x_to_high <= self.peak)
 
     interval_length = self.high - self.low
     # This is the pdf function when a low <= high <= x. This looks like

--- a/tensorflow_probability/python/distributions/triangular_test.py
+++ b/tensorflow_probability/python/distributions/triangular_test.py
@@ -336,6 +336,12 @@ class _TriangularTest(object):
         rtol=.03,
         atol=0)
 
+  def testTriangularExtrema(self):
+    low = self._dtype(0.)
+    peak = self._dtype(1.)
+    high = self._dtype(4.)
+    tri = tfd.Triangular(low=low, peak=peak, high=high)
+    self.assertAllClose(self.evaluate(tri.prob([0., 1., 4.])), [0, 0.5, 0])
 
 @test_util.run_all_in_graph_and_eager_modes
 class TriangularTestStaticShape(test_case.TestCase, _TriangularTest):


### PR DESCRIPTION
Previously produced a nonzero density at the low point, since the left_of_peak condition did not include the low point.