### PR TITLE
Fix numpy_test on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ jobs:
 # of python versions x SHARD will be expanded and run in parallel.
 python:
   - "2.7"
-  - "3.6"
+  - "3.4"
+virtualenv:
+  system_site_packages: true
 env:
   global:
     - NUM_SHARDS=3


### PR DESCRIPTION
This fixes it by switching the python interpreter version on Travis to
be the one provided by the Ubuntu repositories. Concretely, that version
of the interpreter has the 'random' module built in, so it doesn't get
overridden by a local copy of it in the numpy backend directory.