### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/tensorflow_probability/python/internal/distribution_util.py
+++ b/tensorflow_probability/python/internal/distribution_util.py
@@ -958,7 +958,7 @@ def embed_check_categorical_event_shape(
     max_event_size = (
         _largest_integer_by_dtype(x_dtype)
         if dtype_util.is_floating(x_dtype) else 0)
-    if max_event_size is 0:
+    if max_event_size == 0:
       raise TypeError("Unable to validate size of unrecognized dtype "
                       "({}).".format(dtype_util.name(x_dtype)))
     try:


### PR DESCRIPTION
Identity is not the same thing as equality in Python.  We want the latter in this instance.

Use ==/!= to compare str, bytes, and int literals.

$ __python__
```python
>>> id = "i"
>>> id += 'd'
>>> id
'id'
>>> id == 'id'
True
>>> id is 'id'
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```