### PR TITLE
check for use_exact_kl == True instead of None

### DIFF
--- a/tensorflow_probability/python/layers/dense_variational_v2.py
+++ b/tensorflow_probability/python/layers/dense_variational_v2.py
@@ -152,7 +152,7 @@ def _make_kl_divergence_penalty(
     weight=None):
   """Creates a callable computing `KL[a,b]` from `a`, a `tfd.Distribution`."""
 
-  if use_exact_kl is None:
+  if use_exact_kl:
     kl_divergence_fn = kullback_leibler.kl_divergence
   else:
     def kl_divergence_fn(distribution_a, distribution_b):


### PR DESCRIPTION
I'm not completely sure why the existing code checks for  `use_exact_kl is None`, but wouldn't the user expect that if she passes `True` here she gets the exact KL?
Perhaps I'm missing sth but I don't see what...