### PR TITLE
484 update psd kernel docs

### DIFF
--- a/tensorflow_probability/python/positive_semidefinite_kernels/exponentiated_quadratic.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/exponentiated_quadratic.py
@@ -60,13 +60,13 @@ class ExponentiatedQuadratic(psd_kernel.PositiveSemidefiniteKernel):
     Args:
       amplitude: floating point `Tensor` that controls the maximum value
         of the kernel. Must be broadcastable with `length_scale` and inputs to
-        `apply` and `matrix` methods. Must be greater than zero. A value of 
+        `apply` and `matrix` methods. Must be greater than zero. A value of
         `None` is treated like 1.
       length_scale: floating point `Tensor` that controls how sharp or wide the
         kernel shape is. This provides a characteristic "unit" of length against
         which `||x - y||` can be compared for scale. Must be broadcastable with
-        `amplitude` and inputs to `apply` and `matrix` methods. A value of `None` 
-        is treated like 1.
+        `amplitude` and inputs to `apply` and `matrix` methods. A value of
+        `None` is treated like 1.
       feature_ndims: Python `int` number of rightmost dims to include in the
         squared difference norm in the exponential.
       validate_args: If `True`, parameters are checked for validity despite

--- a/tensorflow_probability/python/positive_semidefinite_kernels/exponentiated_quadratic.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/exponentiated_quadratic.py
@@ -60,11 +60,11 @@ class ExponentiatedQuadratic(psd_kernel.PositiveSemidefiniteKernel):
     Args:
       amplitude: floating point `Tensor` that controls the maximum value
         of the kernel. Must be broadcastable with `length_scale` and inputs to
-        `apply` and `matrix` methods. Must be greater than zero.
+        `apply` and `matrix` methods. Must be greater than zero. A value of None is treated like 1.
       length_scale: floating point `Tensor` that controls how sharp or wide the
         kernel shape is. This provides a characteristic "unit" of length against
         which `||x - y||` can be compared for scale. Must be broadcastable with
-        `amplitude` and inputs to `apply` and `matrix` methods.
+        `amplitude` and inputs to `apply` and `matrix` methods. A value of None is treated like 1.
       feature_ndims: Python `int` number of rightmost dims to include in the
         squared difference norm in the exponential.
       validate_args: If `True`, parameters are checked for validity despite

--- a/tensorflow_probability/python/positive_semidefinite_kernels/exponentiated_quadratic.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/exponentiated_quadratic.py
@@ -60,11 +60,13 @@ class ExponentiatedQuadratic(psd_kernel.PositiveSemidefiniteKernel):
     Args:
       amplitude: floating point `Tensor` that controls the maximum value
         of the kernel. Must be broadcastable with `length_scale` and inputs to
-        `apply` and `matrix` methods. Must be greater than zero. A value of None is treated like 1.
+        `apply` and `matrix` methods. Must be greater than zero. A value of 
+        `None` is treated like 1.
       length_scale: floating point `Tensor` that controls how sharp or wide the
         kernel shape is. This provides a characteristic "unit" of length against
         which `||x - y||` can be compared for scale. Must be broadcastable with
-        `amplitude` and inputs to `apply` and `matrix` methods. A value of None is treated like 1.
+        `amplitude` and inputs to `apply` and `matrix` methods. A value of `None` 
+        is treated like 1.
       feature_ndims: Python `int` number of rightmost dims to include in the
         squared difference norm in the exponential.
       validate_args: If `True`, parameters are checked for validity despite

--- a/tensorflow_probability/python/positive_semidefinite_kernels/rational_quadratic.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/rational_quadratic.py
@@ -93,7 +93,7 @@ class RationalQuadratic(psd_kernel.PositiveSemidefiniteKernel):
     Args:
       amplitude: Positive floating point `Tensor` that controls the maximum
         value of the kernel. Must be broadcastable with `length_scale` and
-        `scale_mixture_rate` and inputs to `apply` and `matrix` methods. A 
+        `scale_mixture_rate` and inputs to `apply` and `matrix` methods. A
         value of `None` is treated like 1.
       length_scale: Positive floating point `Tensor` that controls how sharp or
         wide the kernel shape is. This provides a characteristic "unit" of
@@ -102,8 +102,8 @@ class RationalQuadratic(psd_kernel.PositiveSemidefiniteKernel):
         `apply` and `matrix` methods. A value of `None` is treated like 1.
       scale_mixture_rate: Positive floating point `Tensor` that controls how the
         ExponentiatedQuadratic kernels are mixed.  Must be broadcastable with
-        `amplitude`, `length_scale` and inputs to `apply` and `matrix` methods. A 
-        value of `None` is treated like 1.
+        `amplitude`, `length_scale` and inputs to `apply` and `matrix` methods.
+        A value of `None` is treated like 1.
       feature_ndims: Python `int` number of rightmost dims to include in the
         squared difference norm in the exponential.
       validate_args: If `True`, parameters are checked for validity despite

--- a/tensorflow_probability/python/positive_semidefinite_kernels/rational_quadratic.py
+++ b/tensorflow_probability/python/positive_semidefinite_kernels/rational_quadratic.py
@@ -93,15 +93,17 @@ class RationalQuadratic(psd_kernel.PositiveSemidefiniteKernel):
     Args:
       amplitude: Positive floating point `Tensor` that controls the maximum
         value of the kernel. Must be broadcastable with `length_scale` and
-        `scale_mixture_rate` and inputs to `apply` and `matrix` methods.
+        `scale_mixture_rate` and inputs to `apply` and `matrix` methods. A 
+        value of `None` is treated like 1.
       length_scale: Positive floating point `Tensor` that controls how sharp or
         wide the kernel shape is. This provides a characteristic "unit" of
         length against which `||x - y||` can be compared for scale. Must be
         broadcastable with `amplitude`, `scale_mixture_rate`  and inputs to
-        `apply` and `matrix` methods.
+        `apply` and `matrix` methods. A value of `None` is treated like 1.
       scale_mixture_rate: Positive floating point `Tensor` that controls how the
         ExponentiatedQuadratic kernels are mixed.  Must be broadcastable with
-        `amplitude`, `length_scale` and inputs to `apply` and `matrix` methods.
+        `amplitude`, `length_scale` and inputs to `apply` and `matrix` methods. A 
+        value of `None` is treated like 1.
       feature_ndims: Python `int` number of rightmost dims to include in the
         squared difference norm in the exponential.
       validate_args: If `True`, parameters are checked for validity despite


### PR DESCRIPTION
Addresses #484 

The docs for [ExponentiatedQuadratic](https://www.tensorflow.org/probability/api_docs/python/tfp/positive_semidefinite_kernels/ExponentiatedQuadratic) and [RationalQuadratic](https://www.tensorflow.org/probability/api_docs/python/tfp/positive_semidefinite_kernels/RationalQuadratic) don't specify what happens when kernels are called with their default parameters.

The I've added the following sentence in the appropriate places:

> "A value of `None` is treated like 1."  

This is consistent with the documentation for the other kernels.