### PR TITLE
fix formatting typos in Autoregression docs

### DIFF
--- a/tensorflow_probability/python/sts/autoregressive.py
+++ b/tensorflow_probability/python/sts/autoregressive.py
@@ -49,7 +49,7 @@ class AutoregressiveStateSpaceModel(tfd.LinearGaussianStateSpaceModel):
   ```python
   level[t+1] = (sum(coefficients * levels[t:t-order:-1]) +
                 Normal(0., level_scale))
-   ```
+  ```
 
   The process is characterized by a vector `coefficients` whose size determines
   the order of the process (how many previous values it looks at), and by
@@ -266,7 +266,7 @@ class Autoregressive(StructuralTimeSeries):
   ```python
   level[t+1] = (sum(coefficients * levels[t:t-order:-1]) +
                 Normal(0., level_scale))
-   ```
+  ```
 
   The latent state is `levels[t:t-order:-1]`. We observe a noisy realization of
   the current level: `f[t] = level[t] + Normal(0., observation_noise_scale)` at


### PR DESCRIPTION
A space before triple tick marks ` ``` ` was causing some bad rendering.

See the [docs for `AutoregressiveStateSpaceModel`](https://www.tensorflow.org/probability/api_docs/python/tfp/sts/AutoregressiveStateSpaceModel) and [`Autoregressive`](https://www.tensorflow.org/probability/api_docs/python/tfp/sts/Autoregressive). Alternatively, see the images below, and note the triple tick mark.


`AutoregressiveStateSpaceModel`

![typo in AutoregressiveStateSpaceModel docs causes bad rendering](https://user-images.githubusercontent.com/13276704/61886637-10cee000-aece-11e9-973c-ac0f70fcf668.png)

`Autoregressive`

![typo in Autoregressive docs causes bad rendering](https://user-images.githubusercontent.com/13276704/61887257-47f1c100-aecf-11e9-911f-5799a84a409d.png)
