### PR TITLE
Fixing issue 407: DistributionLambda memory issue

### DIFF
--- a/tensorflow_probability/python/layers/internal/distribution_tensor_coercible.py
+++ b/tensorflow_probability/python/layers/internal/distribution_tensor_coercible.py
@@ -57,14 +57,13 @@ class _TensorCoercible(tfd.Distribution):
       self_class = type(distcls.__name__, (cls, distcls), {})
       _TensorCoercible.registered_class_list[distcls] = self_class
     self.__class__ = self_class
-    self._concrete_value = None  # pylint: disable=protected-access
-    self._convert_to_tensor_fn = convert_to_tensor_fn  # pylint: disable=protected-access
     return self
 
   def __init__(self,
                distribution,
                convert_to_tensor_fn=tfd.Distribution.sample):
-    pass
+    self._concrete_value = None  # pylint: disable=protected-access
+    self._convert_to_tensor_fn = convert_to_tensor_fn  # pylint: disable=protected-access
 
   @property
   def shape(self):

--- a/tensorflow_probability/python/layers/internal/distribution_tensor_coercible.py
+++ b/tensorflow_probability/python/layers/internal/distribution_tensor_coercible.py
@@ -41,6 +41,7 @@ class _DistributionAndTensorCoercibleMeta(type(tfd.Distribution),
 class _TensorCoercible(tfd.Distribution):
   """Docstring."""
 
+  registered_class_list = {}
   def __new__(cls, distribution, convert_to_tensor_fn=tfd.Distribution.sample):
     if isinstance(distribution, cls):
       return distribution
@@ -51,7 +52,10 @@ class _TensorCoercible(tfd.Distribution):
                           distribution, type(distribution)))
     self = copy.copy(distribution)
     distcls = distribution.__class__
-    self.__class__ = type(distcls.__name__, (cls, distcls), {})
+    self_class = _TensorCoercible.registered_class_list.get(distcls)
+    if not self_class:
+      self_class = _TensorCoercible.registered_class_list[distcls] = type(distcls.__name__, (cls, distcls), {})
+    self.__class__ = self_class
     self._concrete_value = None  # pylint: disable=protected-access
     self._convert_to_tensor_fn = convert_to_tensor_fn  # pylint: disable=protected-access
     return self

--- a/tensorflow_probability/python/layers/internal/distribution_tensor_coercible.py
+++ b/tensorflow_probability/python/layers/internal/distribution_tensor_coercible.py
@@ -54,7 +54,8 @@ class _TensorCoercible(tfd.Distribution):
     distcls = distribution.__class__
     self_class = _TensorCoercible.registered_class_list.get(distcls)
     if not self_class:
-      self_class = _TensorCoercible.registered_class_list[distcls] = type(distcls.__name__, (cls, distcls), {})
+      self_class = type(distcls.__name__, (cls, distcls), {})
+      _TensorCoercible.registered_class_list[distcls] = self_class
     self.__class__ = self_class
     self._concrete_value = None  # pylint: disable=protected-access
     self._convert_to_tensor_fn = convert_to_tensor_fn  # pylint: disable=protected-access


### PR DESCRIPTION
### Script to test
If we take the code sample provided in the [issue](https://github.com/tensorflow/probability/issues/407), we can see the memory usage keeps increasing.
```
import tensorflow_probability as tfp

layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
for _ in range(int(1e6)):
  dist = layer([-.23, 1.23, 1.42])
```
### Issue
For each call of the layer, a new instance of _TensorCoercible is created (distribution_layer.py line 165).
```
distribution = dtc._TensorCoercible(  # pylint: disable=protected-access
          distribution=d,
          convert_to_tensor_fn=maybe_composite_convert_to_tensor_fn)
```
In the \_\_new__ call of _TensorCoercible, a new type based of the distribution is created, and the new instance is assigned to this type (distribution_tensor_coercible.py 54):
```
self.__class__ = type(distcls.__name__, (cls, distcls), {}) 
```
Because a new class is created, the \_\_new__ function of the metaclass is called. \_TensorCoercible has two metaclasses but the one responsible for the issue is TensorMetaClass.
In the \_\_new__ function of TensorMetaClass, this line is called (deferred_tensor.py 84):
```
tf.register_tensor_conversion_function(cls, conversion_func=_tensorize) 
```
Because a new class is created at each call of the layer, the register method is called over and over for the same class.

You can modify a bit the test above to see the registry getting bigger and bigger.
```
import tensorflow_probability as tfp
from tensorflow.python.framework import tensor_conversion_registry

layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
for _ in range(int(1e6)):
  dist = layer([-.23, 1.23, 1.42])
  print (len(tensor_conversion_registry._tensor_conversion_func_registry[100]))
```
### Proposed fix
The fix I propose keeps the flexibility of DistributionLambda.
_TensorCoercible shouldn't create a new class at every constructor call. Because there's not a huge number of distribution classes, a dict can be use to check if the class has already be created without big performance issue.

__Note__: [This](https://github.com/tensorflow/probability/pull/532/commits/74d1f23423fead4ff3cb1ecc8d4831253c8383c9) commit is not really related to the issue. In my test, pylint failed even before my commit and it seems to be an issue with the linter. Somehow, the commit remove the linter error.