### PR TITLE
Issue 553: Updated the datatype for poisson distribution, default is now int32.

### DIFF
--- a/tensorflow_probability/python/distributions/poisson.py
+++ b/tensorflow_probability/python/distributions/poisson.py
@@ -55,6 +55,7 @@ class Poisson(distribution.Distribution):
                rate=None,
                log_rate=None,
                interpolate_nondiscrete=True,
+               dtype=tf.int32,
                validate_args=False,
                allow_nan_stats=True,
                name='Poisson'):
@@ -72,6 +73,7 @@ class Poisson(distribution.Distribution):
         at integer arguments `k` (note that this function is not itself
         a normalized probability log-density).
         Default value: `True`.
+      dtype: The type of the event samples. Default: `int32`.
       validate_args: Python `bool`. When `True` distribution
         parameters are checked for validity despite possibly degrading runtime
         performance. When `False` invalid inputs may silently render incorrect


### PR DESCRIPTION
One file changed: `tensorflow_probability/python/distributions/poisson.py`

Updated the datatype for poisson distribution, default is now `int32`.  Updated documentation to include `dtype` option with description.  Description is copied from the `dtype` description for the Bernoulli distribution. There does not appear to be any other dependency on Poisson `dtype`.