### PR TITLE
Correction to GP formula in GP regression documentation

### DIFF
--- a/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
+++ b/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
@@ -172,7 +172,7 @@ class GaussianProcessRegressionModel(gaussian_process.GaussianProcess):
 
     where
 
-    loc = k(t, x) @ inv(k(x, x) + v * I) @ (y - loc)
+    loc = k(t, x) @ inv(k(x, x) + v * I) @ f(x)
     cov = k(t, t) - k(t, x) @ inv(k(x, x) + v * I) @ k(x, t)
   ```
 

--- a/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
+++ b/tensorflow_probability/python/distributions/gaussian_process_regression_model.py
@@ -168,11 +168,11 @@ class GaussianProcessRegressionModel(gaussian_process.GaussianProcess):
   at a new set of points `t`, conditional on those observed data.
 
   ```none
-    (f(t) | t, x, f(x)) ~ MVN(loc, cov)
+    (f(t) | t, x, y) ~ MVN(loc, cov)
 
     where
 
-    loc = k(t, x) @ inv(k(x, x) + v * I) @ f(x)
+    loc = m(t) + k(t, x) @ inv(k(x, x) + v * I) @ (y - m(x))
     cov = k(t, t) - k(t, x) @ inv(k(x, x) + v * I) @ k(x, t)
   ```
 


### PR DESCRIPTION
The line here is wrong:   `loc = k(t, x) @ inv(k(x, x) + v * I) @ (y - loc)` - `loc` is on both the right and left-hand side, and `y` is not defined in the context of the comment block.

I believe this term should be `f(x)` looking at formula 2.23 of Rasmussen and Williams, but worth reviewing.