### PR TITLE
PERT distribution and basic test for issue #209

### DIFF
--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -91,6 +91,7 @@ py_library(
         ":normal_conjugate_posteriors",
         ":onehot_categorical",
         ":pareto",
+        ":pert",
         ":plackett_luce",
         ":poisson",
         ":poisson_lognormal",
@@ -997,6 +998,20 @@ py_library(
         "//tensorflow_probability/python/internal:dtype_util",
         "//tensorflow_probability/python/internal:reparameterization",
         "//tensorflow_probability/python/internal:tensor_util",
+    ],
+)
+
+py_library(
+    name = "pert",
+    srcs = ["pert.py"],
+    deps = [
+        ":distribution",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:assert_util",
+        "//tensorflow_probability/python/internal:dtype_util",
+        "//tensorflow_probability/python/internal:tensor_util",
+        "//tensorflow_probability/python/internal:prefer_static"
     ],
 )
 
@@ -2206,6 +2221,20 @@ py_test(
     name = "pareto_test",
     size = "small",
     srcs = ["pareto_test.py"],
+    deps = [
+        # numpy dep,
+        # scipy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_case",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_test(
+    name = "pert_test",
+    size = "small",
+    srcs = ["pert_test.py"],
     deps = [
         # numpy dep,
         # scipy dep,

--- a/tensorflow_probability/python/distributions/__init__.py
+++ b/tensorflow_probability/python/distributions/__init__.py
@@ -246,6 +246,7 @@ __all__ = [
     'ExpRelaxedOneHotCategorical',
     'OneHotCategorical',
     'Pareto',
+    'PERT',
     'PlackettLuce',
     'RelaxedBernoulli',
     'RelaxedOneHotCategorical',

--- a/tensorflow_probability/python/distributions/__init__.py
+++ b/tensorflow_probability/python/distributions/__init__.py
@@ -77,6 +77,7 @@ from tensorflow_probability.python.distributions.negative_binomial import Negati
 from tensorflow_probability.python.distributions.normal import Normal
 from tensorflow_probability.python.distributions.onehot_categorical import OneHotCategorical
 from tensorflow_probability.python.distributions.pareto import Pareto
+from tensorflow_probability.python.distributions.pert import PERT
 from tensorflow_probability.python.distributions.plackett_luce import PlackettLuce
 from tensorflow_probability.python.distributions.poisson import Poisson
 from tensorflow_probability.python.distributions.poisson_lognormal import PoissonLogNormalQuadratureCompound

--- a/tensorflow_probability/python/distributions/distribution_properties_test.py
+++ b/tensorflow_probability/python/distributions/distribution_properties_test.py
@@ -87,6 +87,7 @@ TF2_FRIENDLY_DISTS = (
     'NegativeBinomial',
     'OneHotCategorical',
     'Pareto',
+    'PERT',
     'PlackettLuce',
     'Poisson',
     # 'PoissonLogNormalQuadratureCompound' TODO(b/137956955): Add support
@@ -1044,6 +1045,12 @@ def fix_triangular(d):
   high = ensure_high_gt_low(peak, d['high'])
   return dict(d, peak=peak, high=high)
 
+def fix_pert(d):
+  peak = ensure_high_gt_low(d['low'], d['peak'])
+  high = ensure_high_gt_low(peak, d['high'])
+  temperature = ensure_high_gt_low(
+    np.zeros(d['temperature'].shape,dtype=np.float32), d['temperature'])
+  return dict(d, peak=peak, high=high, temperature=temperature)
 
 def fix_wishart(d):
   df = d['df']
@@ -1133,6 +1140,8 @@ CONSTRAINTS = {
         fix_lkj,
     'Triangular':
         fix_triangular,
+    'PERT':
+        fix_pert,
     'TruncatedNormal':
         lambda d: dict(d, high=ensure_high_gt_low(d['low'], d['high'])),
     'Uniform':

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -21,7 +21,7 @@ class PERT(transformed_distribution.TransformedDistribution):
   """Modified PERT distribution for modeling expert predictions.
 
   PERT distribution is a loc-scale family of Beta distribution
-  fit onto an arbitrary real interval set between LOW and HIGH
+  fit onto an arbitrary real interval between LOW and HIGH
   values set by the user, along with PEAK to indicate the expert's
   most frequent prediction.
   [1](https://en.wikipedia.org/wiki/PERT_distribution).

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -43,6 +43,8 @@ class PERT(transformed_distribution.TransformedDistribution):
   ```
 
   PERT distribution is obtained when g = 4.
+
+  For general reference: https://en.wikipedia.org/wiki/PERT_distribution
   """
   def __init__(self,
                mini,

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -1,0 +1,162 @@
+"""The PERT distribution class"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python.distributions import Beta
+from tensorflow_probability.python.bijectors import AffineScalar
+from tensorflow_probability.python.distributions import transformed_distribution
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import prefer_static
+from tensorflow_probability.python.internal import tensor_util # pylint: disable=g-direct-tensorflow-import
+
+__all__ = [
+    'PERT',
+]
+
+class PERT(transformed_distribution.TransformedDistribution):
+  """Modified PERT distribution:
+  PERT distribution is a loc-scale family of Beta distribution intended to
+  model expert prediction on arbitrary real interval bounded by MAX and MIN
+  values set by the user, along with MODE to indicate the expert's
+  most frequent prediction.
+
+  The shift and scale factor is given by:
+
+  ```
+  shift = MIN
+  scale = MAX - MIN
+  ```
+
+  Modified PERT is a generalized version of PERT that has an additional
+  parameter, smoothness (g).
+
+  Smoothness determines the properties of Beta distribution:
+
+  ```
+  concentration1 = 1 + g * (MODE - MIN)/(MAX - MIN)
+  concentration0 = 1 + g * (MAX - MODE)/(MAX - MIN)
+  mean = (MIN + g * MODE + MAX)/(g + 2)
+  ```
+
+  PERT distribution is obtained when g = 4.
+  """
+  def __init__(self,
+               mini,
+               mode,
+               maxi,
+               smoothness=4.,
+               validate_args=False,
+               allow_nan_stats=False,
+               name="PERT"):
+    parameters = dict(locals())
+    with tf.name_scope(name) as name:
+      dtype = dtype_util.common_dtype([mini, maxi, mode], tf.float32)
+      self._min = tensor_util.convert_nonref_to_tensor(
+          mini, name='mini', dtype=dtype)
+      self._mod = tensor_util.convert_nonref_to_tensor(
+          mode, name='mode', dtype=dtype)
+      self._max = tensor_util.convert_nonref_to_tensor(
+          maxi, name='maxi', dtype=dtype)
+      self._smoothness = tensor_util.convert_nonref_to_tensor(
+          smoothness, name='smoothness', dtype=dtype)
+      self._concentration1 = 1. + self._smoothness \
+        * (self._mod - self._min) / (self._max - self._min)
+      self._concentration0 = 1. + self._smoothness \
+        * (self._max - self._mod) / (self._max - self._min)
+
+      self._scale = self._max - self._min
+
+      # Broadcasting scale on affine bijector to match batch dimension.
+      # This prevents dimension mismatch for operations like cdf.
+      super(PERT, self).__init__(
+          distribution=Beta(
+              concentration1=self._concentration1,
+              concentration0=self._concentration0,
+              allow_nan_stats=allow_nan_stats),
+          bijector=AffineScalar(
+              shift=self._min,
+              scale=tf.broadcast_to(
+                  input=self._scale,
+                  shape=self._batch_shape_tensor(
+                      concentration1=self._concentration1, 
+                      concentration0=self._concentration0))),
+          validate_args=validate_args,
+          parameters=parameters,
+          name=name)
+
+  def _batch_shape_tensor(self, concentration1=None, concentration0=None):
+    return prefer_static.broadcast_shape(
+        prefer_static.shape(
+            self.concentration1 if concentration1 is None else concentration1),
+        prefer_static.shape(
+            self.concentration0 if concentration0 is None else concentration0))
+
+  def _parameter_control_dependencies(self, is_init):
+    if not self.validate_args:
+      return []
+    assertions = []
+    if is_init != tensor_util.is_ref(self._mod):
+      if is_init != tensor_util.is_ref(self._min):
+        assertions.append(assert_util.assert_greater(
+            self._mod,
+            self._min,
+            message="Mode must be greater than minimum."
+        ))
+      if is_init != tensor_util.is_ref(self._max):
+        assertions.append(assert_util.assert_greater(
+            self._max,
+            self._mod,
+            message="Maximum must be greater than mode."
+        ))
+    if is_init != tensor_util.is_ref(self._smoothness):
+      assertions.append(assert_util.assert_positive(
+          self._smoothness,
+          message="Smoothness parameter must be positive."
+      ))
+    return assertions
+
+  def _survivial_function(self, value, **kwargs):
+    return 1. - self.cdf(value, kwargs)
+
+  def _variance(self, **kwargs):
+    mean = self.mean()
+    return (mean - self._min) * (self._max - mean) / (self._smoothness + 3.)
+
+  def _stddev(self, **kwargs):
+    return tf.sqrt(self.variance(kwargs))
+
+  def _mode(self, **kwargs):
+    return self._mod
+
+  # Distribution properties
+  @property
+  def minimum(self):
+    return self._min
+
+  @property
+  def maximum(self):
+    return self._max
+
+  @property
+  def smoothness(self):
+    return self._smoothness
+
+  @property
+  def loc(self):
+    return self._min
+
+  @property
+  def scale(self):
+    return self._scale
+
+  @property
+  def concentration0(self):
+    return self._concentration0
+
+  @property
+  def concentration1(self):
+    return self._concentration1

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -123,6 +123,10 @@ class PERT(transformed_distribution.TransformedDistribution):
           parameters=parameters,
           name=name)
 
+  @classmethod
+  def _params_event_ndims(cls):
+    return dict(low=0, high=0, peak=0, temperature=0)
+
   def _batch_shape(self):
     return tf.broadcast_static_shape(
         self.concentration1.shape, self.concentration0.shape)

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -84,7 +84,7 @@ class PERT(transformed_distribution.TransformedDistribution):
               scale=tf.broadcast_to(
                   input=self._scale,
                   shape=self._batch_shape_tensor(
-                      concentration1=self._concentration1, 
+                      concentration1=self._concentration1,
                       concentration0=self._concentration0))),
           validate_args=validate_args,
           parameters=parameters,

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -90,7 +90,6 @@ class PERT(transformed_distribution.TransformedDistribution):
       dtype = dtype_util.common_dtype([mini, maxi, mode], tf.float32)
       self._min = tensor_util.convert_nonref_to_tensor(
           mini, name='mini', dtype=dtype)
-      self._mode
       self._mod = tensor_util.convert_nonref_to_tensor(
           mode, name='mode', dtype=dtype)
       self._max = tensor_util.convert_nonref_to_tensor(

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -100,10 +100,10 @@ class PERT(transformed_distribution.TransformedDistribution):
           high, name='high', dtype=dtype)
       self._smoothness = tensor_util.convert_nonref_to_tensor(
           smoothness, name='smoothness', dtype=dtype)
-      self._concentration1 = 1. + self._smoothness \
-        * (self._peak - self._low) / (self._high - self._low)
-      self._concentration0 = 1. + self._smoothness \
-        * (self._high - self._peak) / (self._high - self._low)
+      self._concentration1 = (1. + self._smoothness
+              * (self._peak - self._low) / (self._high - self._low))
+      self._concentration0 = (1. + self._smoothness
+              * (self._high - self._peak) / (self._high - self._low))
 
       self._scale = self._high - self._low
 

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -138,14 +138,14 @@ class PERT(transformed_distribution.TransformedDistribution):
         prefer_static.shape(
             self.concentration0 if concentration0 is None else concentration0))
 
-  def _variance(self, **kwargs):
+  def _variance(self):
     mean = self.mean()
     return (mean - self._low) * (self._high - mean) / (self._temperature + 3.)
 
-  def _stddev(self, **kwargs):
-    return tf.sqrt(self.variance(kwargs))
+  def _stddev(self):
+    return tf.sqrt(self._variance())
 
-  def _mode(self, **kwargs):
+  def _mode(self):
     return self._peak
 
   # Distribution properties

--- a/tensorflow_probability/python/distributions/pert.py
+++ b/tensorflow_probability/python/distributions/pert.py
@@ -21,7 +21,7 @@ class PERT(transformed_distribution.TransformedDistribution):
   """Modified PERT distribution for modeling expert predictions.
 
   PERT distribution is a loc-scale family of Beta distribution
-  fit onto an arbitrary real interval between LOW and HIGH
+  fit onto a real interval between LOW and HIGH
   values set by the user, along with PEAK to indicate the expert's
   most frequent prediction.
   [1](https://en.wikipedia.org/wiki/PERT_distribution).

--- a/tensorflow_probability/python/distributions/pert_test.py
+++ b/tensorflow_probability/python/distributions/pert_test.py
@@ -78,16 +78,16 @@ class PERTTest(test_case.TestCase):
     self.assertEqual(1., self.evaluate(dist.cdf(11.)))
     self.assertEqual(0., self.evaluate(dist.cdf(3.)))
     self.assertEqual(
-        1., 
+        1.,
         self.evaluate(dist.cdf(3.) + dist.survival_function(3.)))
     self.assertEqual(
-        1., 
+        1.,
         self.evaluate(dist.cdf(11.) + dist.survival_function(11.)))
     self.assertEqual(
-        1., 
+        1.,
         self.evaluate(dist.cdf(3.) + dist.survival_function(3.)))
     self.assertEqual(
-        1., 
+        1.,
         self.evaluate(dist.cdf(5.) + dist.survival_function(5.)))
     self.assertEqual(-float("inf"), self.evaluate(dist.log_cdf(3.)))
     self.assertEqual(0., self.evaluate(dist.log_cdf(11.)))

--- a/tensorflow_probability/python/distributions/pert_test.py
+++ b/tensorflow_probability/python/distributions/pert_test.py
@@ -1,0 +1,208 @@
+"""Tests for PERT distribution."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+# Dependency imports
+import numpy as np
+from scipy import stats as sp_stats
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+
+from tensorflow_probability.python.internal import test_case
+from tensorflow_probability.python.internal import test_util as tfp_test_util
+from tensorflow.python.framework import test_util  # pylint: disable=g-direct-tensorflow-import
+
+tfd = tfp.distributions
+
+@test_util.run_all_in_graph_and_eager_modes
+class PERTTest(test_case.TestCase):
+  def _generate_boilerplate_param(self):
+    smoothness = np.array([1., 2., 4., 10.])
+    mini = np.array(len(smoothness)*[1.])
+    mode = np.array(len(smoothness)*[7.])
+    maxi = np.array(len(smoothness)*[10.])
+    a = 1. + smoothness * (mode - mini) / (maxi - mini)
+    b = 1. + smoothness * (maxi - mode) / (maxi - mini)
+    return smoothness, mini, mode, maxi, a, b
+
+  # Shape and broadcast testing
+  def testPertShape(self):
+    dist = tfd.PERT(mini=[3.0], mode=[10.0], maxi=[11.0], smoothness=[4.0])
+    self.assertEqual(([1]), self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([1]), dist.batch_shape)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+
+  def testBroadcastingSmoothness(self):
+    dist = tfd.PERT(
+        mini=1.,
+        mode=2.,
+        maxi=3.,
+        smoothness=[1., 4., 10.])
+    self.assertEqual([3], self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([3]), dist.batch_shape)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+
+  def testBroadcastingParam(self):
+    dist = tfd.PERT(
+        mini=1.,
+        mode=[2., 3., 4., 5., 6., 7., 8., 9.],
+        maxi=10.,
+        smoothness=4.)
+    self.assertEqual([8], self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([8]), dist.batch_shape)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+
+  def testBroadcastingHigherDimParam(self):
+    dist = tfd.PERT(
+        mini=[1., 2.],
+        mode=[[2., 3.], [4., 5.]],
+        maxi=10.,
+        smoothness=4.,
+        validate_args=True)
+    self.assertAllEqual([2, 2], self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([2, 2]), dist.batch_shape)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+
+  def testEdgeRangeOutput(self):
+    dist = tfd.PERT(mini=3.0, mode=10.0, maxi=11.0, smoothness=4.0)
+    self.assertEqual(True, self.evaluate(tf.math.is_nan(dist.prob(1.))))
+    self.assertEqual(True, self.evaluate(tf.math.is_nan(dist.log_prob(1.))))
+    self.assertEqual(1., self.evaluate(dist.cdf(11.)))
+    self.assertEqual(0., self.evaluate(dist.cdf(3.)))
+    self.assertEqual(
+        1., 
+        self.evaluate(dist.cdf(3.) + dist.survival_function(3.)))
+    self.assertEqual(
+        1., 
+        self.evaluate(dist.cdf(11.) + dist.survival_function(11.)))
+    self.assertEqual(
+        1., 
+        self.evaluate(dist.cdf(3.) + dist.survival_function(3.)))
+    self.assertEqual(
+        1., 
+        self.evaluate(dist.cdf(5.) + dist.survival_function(5.)))
+    self.assertEqual(-float("inf"), self.evaluate(dist.log_cdf(3.)))
+    self.assertEqual(0., self.evaluate(dist.log_cdf(11.)))
+
+
+  # Statistical property testing
+  def testMean(self):
+    smoothness, mini, mode, maxi, a, b = self._generate_boilerplate_param()
+    dist = tfd.PERT(mini, mode, maxi, smoothness)
+    expected_mean = sp_stats.beta.mean(a, b, mini, maxi-mini)
+    self.assertAllClose(expected_mean, self.evaluate(dist.mean()))
+
+  def testVariance(self):
+    smoothness, mini, mode, maxi, a, b = self._generate_boilerplate_param()
+    dist = tfd.PERT(mini, mode, maxi, smoothness)
+    expected_var = sp_stats.beta.var(a, b, mini, maxi-mini)
+    self.assertAllClose(expected_var, self.evaluate(dist.variance()))
+
+  # Sample testing
+  def testSampleStatistics(self):
+    n = 1 << 19
+    smoothness, mini, mode, maxi, a, b = self._generate_boilerplate_param()
+    dist = tfd.PERT(mini, mode, maxi, smoothness)\
+              .sample(n, seed=tfp_test_util.test_seed())
+    samples = self.evaluate(dist)
+    expected_mean = sp_stats.beta.mean(a, b, mini, maxi-mini)
+    expected_var = sp_stats.beta.var(a, b, mini, maxi-mini)
+    self.assertAllClose(
+        samples.mean(axis=0),
+        expected_mean,
+        rtol=0.01,
+        atol=0.01,
+        msg="Sample mean is highly off of expected.")
+    self.assertAllClose(
+        samples.var(axis=0),
+        expected_var,
+        rtol=0.01,
+        atol=0.01,
+        msg="Sample variance is highly off of expected.")
+
+  # Parameter restriction testing
+  def testSmoothnessPositive(self):
+    smoothness = tf.Variable(0.)
+    mini = [1., 2., 3.]
+    mode = [2., 3., 4.]
+    maxi = [3., 4., 5.]
+    self.evaluate(smoothness.initializer)
+    with self.assertRaisesRegex(
+        tf.errors.InvalidArgumentError,
+        "Smoothness parameter must be positive."):
+      dist = tfd.PERT(mini, mode, maxi, smoothness, validate_args=True)
+      self.evaluate(dist.sample(1))
+
+  def testSmoothnessPositiveAfterMutation(self):
+    smoothness = tf.Variable(4.)
+    mini = [1., 2., 3.]
+    mode = [2., 3., 4.]
+    maxi = [3., 4., 5.]
+    self.evaluate(smoothness.initializer)
+    dist = tfd.PERT(mini, mode, maxi, smoothness, validate_args=True)
+    with self.assertRaisesRegex(
+        tf.errors.InvalidArgumentError,
+        "Smoothness parameter must be positive."):
+      with tf.control_dependencies([smoothness.assign(-1.)]):
+        self.evaluate(dist.sample(1))
+
+  def testModeMinInequality(self):
+    mini = tf.Variable([1., 2., 3.])
+    mode = tf.Variable([1., 2., 3.])
+    maxi = [5., 5., 5.]
+    self.evaluate(mini.initializer)
+    self.evaluate(mode.initializer)
+    with self.assertRaisesRegex(
+        tf.errors.InvalidArgumentError,
+        "Mode must be greater than minimum."):
+      dist = tfd.PERT(mini, mode, maxi, validate_args=True)
+      self.evaluate(dist.sample(1))
+
+  def testModeMinInequalityAfterMutation(self):
+    mini = tf.Variable([1., 2., 3.])
+    mode = tf.Variable([2., 3., 4.])
+    maxi = [5., 5., 5.]
+    self.evaluate(mini.initializer)
+    self.evaluate(mode.initializer)
+    dist = tfd.PERT(mini, mode, maxi, validate_args=True)
+    with self.assertRaisesRegex(
+        tf.errors.InvalidArgumentError,
+        "Mode must be greater than minimum."):
+      with tf.control_dependencies([mode.assign([0., 0., 0.])]):
+        self.evaluate(dist.sample(1))
+
+  def testMaxModeInequality(self):
+    mini = [1., 2., 3.]
+    mode = tf.Variable([2., 3., 4.])
+    maxi = tf.Variable([5., 5., 4.])
+    self.evaluate(maxi.initializer)
+    self.evaluate(mode.initializer)
+    with self.assertRaisesRegex(
+        tf.errors.InvalidArgumentError,
+        "Maximum must be greater than mode."):
+      dist = tfd.PERT(mini, mode, maxi, validate_args=True)
+      self.evaluate(dist.sample(1))
+
+  def testMaxModeInequalityAfterMutation(self):
+    mini = [1., 2., 3.]
+    mode = tf.Variable([2., 3., 4.])
+    maxi = tf.Variable([5., 5., 5.])
+    self.evaluate(maxi.initializer)
+    self.evaluate(mode.initializer)
+    dist = tfd.PERT(mini, mode, maxi, validate_args=True)
+    with self.assertRaisesRegex(
+        tf.errors.InvalidArgumentError,
+        "Maximum must be greater than mode."):
+      with tf.control_dependencies([maxi.assign([0., 0., 0.])]):
+        self.evaluate(dist.sample(1))
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorflow_probability/python/distributions/pert_test.py
+++ b/tensorflow_probability/python/distributions/pert_test.py
@@ -107,8 +107,8 @@ class PERTTest(test_case.TestCase):
   def testSampleStatistics(self):
     n = 1 << 19
     temperature, low, peak, high, a, b = self._generate_boilerplate_param()
-    dist = tfd.PERT(low, peak, high, temperature)\
-              .sample(n, seed=tfp_test_util.test_seed())
+    dist = (tfd.PERT(low, peak, high, temperature)
+                  .sample(n, seed=tfp_test_util.test_seed()))
     samples = self.evaluate(dist)
     expected_mean = sp_stats.beta.mean(a, b, low, high-low)
     expected_var = sp_stats.beta.var(a, b, low, high-low)

--- a/tensorflow_probability/python/distributions/pert_test.py
+++ b/tensorflow_probability/python/distributions/pert_test.py
@@ -85,9 +85,6 @@ class PERTTest(test_case.TestCase):
         self.evaluate(dist.cdf(11.) + dist.survival_function(11.)))
     self.assertEqual(
         1.,
-        self.evaluate(dist.cdf(3.) + dist.survival_function(3.)))
-    self.assertEqual(
-        1.,
         self.evaluate(dist.cdf(5.) + dist.survival_function(5.)))
     self.assertEqual(-float("inf"), self.evaluate(dist.log_cdf(3.)))
     self.assertEqual(0., self.evaluate(dist.log_cdf(11.)))

--- a/tensorflow_probability/python/distributions/pert_test.py
+++ b/tensorflow_probability/python/distributions/pert_test.py
@@ -126,7 +126,7 @@ class PERTTest(test_case.TestCase):
         msg="Sample variance is highly off of expected.")
 
   # Parameter restriction testing
-  def testtemperaturePositive(self):
+  def testTemperaturePositive(self):
     temperature = tf.Variable(0.)
     low = [1., 2., 3.]
     peak = [2., 3., 4.]
@@ -138,7 +138,7 @@ class PERTTest(test_case.TestCase):
       dist = tfd.PERT(low, peak, high, temperature, validate_args=True)
       self.evaluate(dist.sample(1))
 
-  def testtemperaturePositiveAfterMutation(self):
+  def testTemperaturePositiveAfterMutation(self):
     temperature = tf.Variable(4.)
     low = [1., 2., 3.]
     peak = [2., 3., 4.]
@@ -151,7 +151,7 @@ class PERTTest(test_case.TestCase):
       with tf.control_dependencies([temperature.assign(-1.)]):
         self.evaluate(dist.sample(1))
 
-  def testpeaklownequality(self):
+  def testPeakLowInequality(self):
     low = tf.Variable([1., 2., 3.])
     peak = tf.Variable([1., 2., 3.])
     high = [5., 5., 5.]
@@ -163,7 +163,7 @@ class PERTTest(test_case.TestCase):
       dist = tfd.PERT(low, peak, high, validate_args=True)
       self.evaluate(dist.sample(1))
 
-  def testpeaklownequalityAfterMutation(self):
+  def testPeakLowInequalityAfterMutation(self):
     low = tf.Variable([1., 2., 3.])
     peak = tf.Variable([2., 3., 4.])
     high = [5., 5., 5.]
@@ -176,7 +176,7 @@ class PERTTest(test_case.TestCase):
       with tf.control_dependencies([peak.assign([0., 0., 0.])]):
         self.evaluate(dist.sample(1))
 
-  def testMaxpeakInequality(self):
+  def testHighPeakInequality(self):
     low = [1., 2., 3.]
     peak = tf.Variable([2., 3., 4.])
     high = tf.Variable([5., 5., 4.])
@@ -188,7 +188,7 @@ class PERTTest(test_case.TestCase):
       dist = tfd.PERT(low, peak, high, validate_args=True)
       self.evaluate(dist.sample(1))
 
-  def testMaxpeakInequalityAfterMutation(self):
+  def testHighPeakInequalityAfterMutation(self):
     low = [1., 2., 3.]
     peak = tf.Variable([2., 3., 4.])
     high = tf.Variable([5., 5., 5.])


### PR DESCRIPTION
Hello,

Issue #209 looked like a good first issue to learn about some building blocks of this project so I gave it a go. I held off on KL divergence implementation for now since I couldn't see a clean analytical solution right off the bat.

This PR implements the [modified PERT](https://en.wikipedia.org/wiki/PERT_distribution), which is a general case of standard PERT that includes an extra parameter to control the shape of the distribution. 

I used TensorFlow pylint for general style guide while referencing other implementations within this repo at my own discretion. So it might be a little off here and there - please feel free to point fingers. Whether it's about style, documentation, or implementation, I am open to any suggestions.