### PR TITLE
fix doc rendering for LocalLevelStateSpaceModel

### DIFF
--- a/tensorflow_probability/python/sts/local_level.py
+++ b/tensorflow_probability/python/sts/local_level.py
@@ -48,7 +48,7 @@ class LocalLevelStateSpaceModel(tfd.LinearGaussianStateSpaceModel):
 
   ```python
   level[t] = level[t-1] + Normal(0., level_scale)
-   ```
+  ```
 
   The latent state is `[level]` and `[level]` is observed (with noise) at each
   timestep.


### PR DESCRIPTION
An additional whitespace was making it so that the code blocks in the docs weren't rendering properly. See [here](https://www.tensorflow.org/probability/api_docs/python/tfp/sts/LocalLevelStateSpaceModel)

Same issue as #507, which was merged into master, although the rendering is still bad on those pages. See [here](https://www.tensorflow.org/probability/api_docs/python/tfp/sts/Autoregressive)