### PR TITLE
Continuous bernoulli branch

### DIFF
--- a/tensorflow_probability/python/distributions/__init__.py
+++ b/tensorflow_probability/python/distributions/__init__.py
@@ -31,6 +31,7 @@ from tensorflow_probability.python.distributions.cauchy import Cauchy
 from tensorflow_probability.python.distributions.chi import Chi
 from tensorflow_probability.python.distributions.chi2 import Chi2
 from tensorflow_probability.python.distributions.cholesky_lkj import CholeskyLKJ
+from tensorflow_probability.python.distributions.continuous_bernoulli import ContinuousBernoulli
 from tensorflow_probability.python.distributions.deterministic import Deterministic
 from tensorflow_probability.python.distributions.deterministic import VectorDeterministic
 from tensorflow_probability.python.distributions.dirichlet import Dirichlet

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -38,6 +38,8 @@ class ContinuousBernoulli(distribution.Distribution):
     for more details, see:
     The continuous Bernoulli: fixing a pervasive error in variational autoencoders, Loaiza-Ganem and Cunningham,
     NeurIPS 2019, https://arxiv.org/abs/1907.06845
+    NOTE: Unlike the Bernoulli, numerical instabilities can happen for lams very close to 0 or 1.
+    Current implementation allows any value in (0,1), but this could be changed to (1e-6, 1-1e-6) to avoid these issues.
 
     """
 

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -1,0 +1,315 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""The continuous Bernoulli distribution class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.distributions import distribution
+from tensorflow_probability.python.distributions import kullback_leibler
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import reparameterization
+from tensorflow_probability.python.internal import tensor_util
+
+
+class ContinuousBernoulli(distribution.Distribution):
+    """Continuous Bernoulli distribution.
+
+    The continuous Bernoulli distribution with `lam` in (0, 1) parameter, supported in [0, 1], the pdf is given by:
+    pdf(x|lam) = lam^x * (1 - lam)^(1 - x) * C(lam)
+    where C(lam) = 2 * atanh(1 - 2 * lam) / (1 - 2* lam) if lam != 0.5 and 2 otherwise
+    for more details, see:
+    The continuous Bernoulli: fixing a pervasive error in variational autoencoders, Loaiza-Ganem and Cunningham,
+    NeurIPS 2019, https://arxiv.org/abs/1907.06845
+
+    """
+
+    def __init__(self,
+                 logits=None,
+                 lams=None,
+                 lims=[0.499, 0.501],
+                 dtype=tf.float32,
+                 validate_args=False,
+                 allow_nan_stats=True,
+                 name='ContinuousBernoulli'):
+        """Construct Bernoulli distributions.
+
+        Args:
+          logits: An N-D `Tensor`. Each entry in the `Tensor` parameterizes an independent continuous Bernoulli
+            distribution with parameter sigmoid(logits). Only one of `logits` or `lams` should be passed in.
+            Note that this does not correspond to the log-odds as in the Bernoulli case.
+          lams: An N-D `Tensor` representing the parameter of a continuous Bernoulli.
+            Each entry in the `Tensor` parameterizes an independent continuous
+            Bernoulli distribution. Only one of `logits` or `lams` should be passed
+            in.
+          lims: A list with two floats containing the lower and upper limits used to approximate the continuous
+            Bernoulli around 0.5 for numerical stability purposes.
+          dtype: The type of the event samples. Default: `float32`.
+          validate_args: Python `bool`, default `False`. When `True` distribution
+            parameters are checked for validity despite possibly degrading runtime
+            performance. When `False` invalid inputs may silently render incorrect
+            outputs.
+          allow_nan_stats: Python `bool`, default `True`. When `True`,
+            statistics (e.g., mean, mode, variance) use the value "`NaN`" to
+            indicate the result is undefined. When `False`, an exception is raised
+            if one or more of the statistic's batch members are undefined.
+          name: Python `str` name prefixed to Ops created by this class.
+
+        Raises:
+          ValueError: If p and logits are passed, or if neither are passed.
+        """
+        parameters = dict(locals())
+        if (lams is None) == (logits is None):
+            raise ValueError('Must pass lams or logits, but not both.')
+        self._lims = lims
+        with tf.name_scope(name) as name:
+            self._lams = tensor_util.convert_nonref_to_tensor(
+                lams, dtype_hint=tf.float32, name='lams')
+            self._logits = tensor_util.convert_nonref_to_tensor(
+                logits, dtype_hint=tf.float32, name='logits')
+        super(ContinuousBernoulli, self).__init__(
+            dtype=dtype,
+            reparameterization_type=reparameterization.FULLY_REPARAMETERIZED,
+            validate_args=validate_args,
+            allow_nan_stats=allow_nan_stats,
+            parameters=parameters,
+            name=name)
+
+    @staticmethod
+    def _param_shapes(sample_shape):
+        return {'logits': tf.convert_to_tensor(sample_shape, dtype=tf.int32)}
+
+    @classmethod
+    def _params_event_ndims(cls):
+        return dict(logits=0, lams=0)
+
+    @property
+    def logits(self):
+        """Input argument `logits`."""
+        return self._logits
+
+    @property
+    def lams(self):
+        """Input argument `lams`."""
+        return self._lams
+
+    def _batch_shape_tensor(self):
+        x = self._lams if self._logits is None else self._logits
+        return tf.shape(x)
+
+    def _batch_shape(self):
+        x = self._lams if self._logits is None else self._logits
+        return x.shape
+
+    def _event_shape_tensor(self):
+        return tf.constant([], dtype=tf.int32)
+
+    def _event_shape(self):
+        return tf.TensorShape([])
+
+    def _sample_n(self, n, seed=None):
+        lams = self._lams_parameter_no_checks()
+        cut_lams = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                            lams, self._lims[0] * tf.ones_like(lams))
+        new_shape = tf.concat([[n], tf.shape(lams)], 0)
+        uniform = tf.random.uniform(new_shape, seed=seed, dtype=lams.dtype)
+        sample = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                          (tf.math.log(uniform * (2.0 * cut_lams - 1.0) + 1.0 - cut_lams)
+                           - tf.math.log(1.0 - cut_lams)) / (tf.log(cut_lams) - tf.math.log(1.0 - cut_lams)),
+                          uniform)
+        return tf.cast(sample, self.dtype)
+
+    def _cont_bern_log_norm(self):
+        lams = self._lams_parameter_no_checks()
+        cut_lams = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                            lams, self._lims[0] * tf.ones_like(lams))
+        log_norm = tf.math.log(tf.math.abs(2.0 * tf.math.atanh(1 - 2.0 * cut_lams)))\
+                   - tf.math.log(tf.math.abs(1 - 2.0 * cut_lams))
+        taylor = tf.math.log(2.0) + 4.0 / 3.0 * tf.math.pow(lams - 0.5, 2) + 104.0 / 45.0 * tf.math.pow(lams - 0.5, 4)
+        return tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])), log_norm, taylor)
+
+    def _log_prob(self, event):
+        log_lams0, log_lams1 = self._outcome_log_lams()
+        event = tf.cast(event, log_lams0.dtype)
+        return (tf.math.multiply_no_nan(log_lams0, 1 - event) +
+                tf.math.multiply_no_nan(log_lams1, event) +
+                self._cont_bern_log_norm())
+
+    def _log_cdf(self, x):
+        return tf.math.log(self._cdf(x))
+
+    def _cdf(self, x):
+        lams = self._lams_parameter_no_checks()
+        cut_lams = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                            lams, self._lims[0] * tf.ones_like(lams))
+        cdfs = (tf.math.pow(cut_lams, x) * tf.math.pow(1.0 - cut_lams, 1.0 - x) + cut_lams - 1.0) /\
+               (2.0 * cut_lams - 1.0)
+        unbounded_cdfs = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])), cdfs, x)
+        indicators0 = tf.where(tf.logical_or(tf.less(x, 0.0), tf.greater(x, 1.0)), tf.zeros_like(x), tf.ones_like(x))
+        indicators1 = tf.where(tf.greater(x, 1.0), tf.ones_like(x), tf.zeros_like(x))
+        return unbounded_cdfs * indicators0 + indicators1
+
+    def _log_survival_function(self, x):
+        return tf.math.log(self._survival_function(x))
+
+    def _survival_function(self, x):
+        return 1.0 - self._cdf(x)
+
+    def _outcome_log_lams(self):
+        if self._logits is None:
+            lam = tf.convert_to_tensor(self._lams)
+            return tf.math.log1p(-lam), tf.math.log(lam)
+        s = tf.convert_to_tensor(self._logits)
+        # softplus(s) = -Log[1 - p]
+        # -softplus(-s) = Log[p]
+        # softplus(+inf) = +inf, softplus(-inf) = 0, so...
+        #  logits = -inf ==> log_probs0 = 0, log_probs1 = -inf (as desired)
+        #  logits = +inf ==> log_probs0 = -inf, log_probs1 = 0 (as desired)
+        return -tf.math.softplus(s), -tf.math.softplus(-s)
+
+    def _entropy(self):
+        log_lams0, log_lams1 = self._outcome_log_lams()
+        return self._mean() * (log_lams1 - log_lams0) - self._cont_bern_log_norm() - log_lams1
+
+    def _mean(self):
+        lams = self._lams_parameter_no_checks()
+        cut_lams = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                            lams, self._lims[0] * tf.ones_like(lams))
+        mus = cut_lams / (2.0 * cut_lams - 1.0) + 1.0 / (2.0 * tf.math.atanh(1.0 - 2.0 * cut_lams))
+        taylor = 0.5 + (lams - 0.5) / 3.0 + 16.0 / 45.0 * tf.math.pow(lams - 0.5, 3)
+        return tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])), mus, taylor)
+
+    def _variance(self):
+        lams = self._lams_parameter_no_checks()
+        cut_lams = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                            lams, self._lims[0] * tf.ones_like(lams))
+        vars = cut_lams * (cut_lams - 1.0) / tf.math.pow(1.0 - 2.0 * cut_lams, 2) +\
+               1.0 / tf.math.pow(2.0 * tf.math.atanh(1.0 - 2.0 * cut_lams), 2)
+        taylor = 1.0 / 12.0 - tf.math.pow(lams - 0.5, 2) / 15.0 - 128.0 / 945.0 * tf.math.pow(lams - 0.5, 4)
+        return tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])), vars, taylor)
+
+    def _quantile(self, p):
+        lams = self._lams_parameter_no_checks()
+        cut_lams = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                            lams, self._lims[0] * tf.ones_like(lams))
+        return tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
+                        (tf.math.log(p * (2.0 * cut_lams - 1.0) + 1.0 - cut_lams)
+                         - tf.math.log(1.0 - cut_lams)) / (tf.log(cut_lams) - tf.math.log(1.0 - cut_lams)),
+                        p)
+
+    def _stddev(self):
+        return tf.math.sqrt(self._variance)
+
+    def _mode(self):
+        """Returns `1` if `prob > 0.5` and `0` otherwise."""
+        return tf.cast(self._probs_parameter_no_checks() > 0.5, self.dtype)
+
+    def logits_parameter(self, name=None):
+        """Logits computed from non-`None` input arg (`lams` or `logits`)."""
+        with self._name_and_control_scope(name or 'logits_parameter'):
+            return self._logits_parameter_no_checks()
+
+    def _logits_parameter_no_checks(self):
+        if self._logits is None:
+            lams = tf.convert_to_tensor(self._lamss)
+            return tf.math.log(lams) - tf.math.log1p(-lams)
+        return tf.identity(self._logits)
+
+    def lams_parameter(self, name=None):
+        """Lams computed from non-`None` input arg (`lams` or `logits`)."""
+        with self._name_and_control_scope(name or 'lams_parameter'):
+            return self._lams_parameter_no_checks()
+
+    def _lams_parameter_no_checks(self):
+        if self._logits is None:
+            return tf.identity(self._lams)
+        return tf.math.sigmoid(self._logits)
+
+    def _default_event_space_bijector(self):
+        return
+
+    def _parameter_control_dependencies(self, is_init):
+        return maybe_assert_continuous_bernoulli_param_correctness(
+            is_init, self.validate_args, self._lams, self._logits)
+
+    def _sample_control_dependencies(self, x):
+        assertions = []
+        if not self.validate_args:
+            return assertions
+        assertions.append(assert_util.assert_non_negative(
+            x, message='Sample must be non-negative.'))
+        assertions.append(
+            assert_util.assert_less_equal(
+                x, tf.ones([], dtype=x.dtype),
+                message='Sample must be less than or equal to `1`.'))
+        return assertions
+
+
+def maybe_assert_continuous_bernoulli_param_correctness(
+        is_init, validate_args, lams, logits):
+    """Return assertions for `Bernoulli`-type distributions."""
+    if is_init:
+        x, name = (lams, 'lams') if logits is None else (logits, 'logits')
+        if not dtype_util.is_floating(x.dtype):
+            raise TypeError(
+                'Argument `{}` must having floating type.'.format(name))
+
+    if not validate_args:
+        return []
+
+    assertions = []
+
+    if lams is not None:
+        if is_init != tensor_util.is_ref(lams):
+            lams = tf.convert_to_tensor(lams)
+            one = tf.constant(1., lams.dtype)
+            assertions += [
+                assert_util.assert_non_negative(
+                    lams, message='lams has components less than 0.'),
+                assert_util.assert_less_equal(
+                    lams, one, message='lams has components greater than 1.')
+            ]
+
+    return assertions
+
+
+@kullback_leibler.RegisterKL(ContinuousBernoulli, ContinuousBernoulli)
+def _kl_bernoulli_bernoulli(a, b, name=None):
+    """Calculate the batched KL divergence KL(a || b) with a and b continuous Bernoulli.
+
+    Args:
+      a: instance of a continuous Bernoulli distribution object.
+      b: instance of a continuous Bernoulli distribution object.
+      name: Python `str` name to use for created operations.
+        Default value: `None` (i.e., `'kl_continuous_bernoulli_continuous_bernoulli'`).
+
+    Returns:
+      Batchwise KL(a || b)
+    """
+    with tf.name_scope(name or 'kl_continuous_bernoulli_continuous_bernoulli'):
+        a_log_lams0, a_log_lams1 = a._outcome_log_lams()  # pylint:disable=protected-access
+        b_log_lams0, b_log_lams1 = b._outcome_log_lams()  # pylint:disable=protected-access
+        a_mean = a._mean() # pylint:disable=protected-access
+        a_log_norm = a._cont_bern_log_norm() # pylint:disable=protected-access
+        b_log_norm = b._cont_bern_log_norm() # pylint:disable=protected-access
+
+        return (
+                a_mean * (a_log_lams0 + b_log_lams1 - a_log_lams1 - b_log_lams0) + a_log_norm - b_log_norm +
+                a_log_lams1 - b_log_lams1
+        )

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -54,7 +54,7 @@ class ContinuousBernoulli(distribution.Distribution):
         dtype=tf.float32,
         validate_args=False,
         allow_nan_stats=True,
-        name="ContinuousBernoulli",
+        name="ContinuousBernoulli"
     ):
         """Construct Bernoulli distributions.
 
@@ -103,7 +103,7 @@ class ContinuousBernoulli(distribution.Distribution):
             validate_args=validate_args,
             allow_nan_stats=allow_nan_stats,
             parameters=parameters,
-            name=name,
+            name=name
         )
 
     @staticmethod
@@ -161,7 +161,7 @@ class ContinuousBernoulli(distribution.Distribution):
                 - tf.math.log1p(-cut_lams)
             )
             / (tf.math.log(cut_lams) - tf.math.log1p(-cut_lams)),
-            uniform,
+            uniform
         )
         return tf.cast(sample, self.dtype)
 
@@ -176,11 +176,7 @@ class ContinuousBernoulli(distribution.Distribution):
             + 4.0 / 3.0 * tf.math.pow(lams - 0.5, 2)
             + 104.0 / 45.0 * tf.math.pow(lams - 0.5, 4)
         )
-        return tf.where(
-            self._outside_unstable_region(),
-            log_norm,
-            taylor,
-        )
+        return tf.where(self._outside_unstable_region(), log_norm, taylor)
 
     def _log_prob(self, event):
         log_lams0, log_lams1 = self._outcome_log_lams()
@@ -193,7 +189,7 @@ class ContinuousBernoulli(distribution.Distribution):
         return tf.where(
             event < 0 | event > 1,
             -float("Inf") * tf.ones_like(tentative_log_pdf),
-            tentative_log_pdf,
+            tentative_log_pdf
         )
 
     def _cdf(self, x):
@@ -203,11 +199,7 @@ class ContinuousBernoulli(distribution.Distribution):
             + cut_lams
             - 1.0
         ) / (2.0 * cut_lams - 1.0)
-        unbounded_cdfs = tf.where(
-            self._outside_unstable_region(),
-            cdfs,
-            x,
-        )
+        unbounded_cdfs = tf.where(self._outside_unstable_region(), cdfs, x)
         return tf.where(
             x < 0.0,
             tf.zeros_like(x),
@@ -243,29 +235,22 @@ class ContinuousBernoulli(distribution.Distribution):
         taylor = (
             0.5 + (lams - 0.5) / 3.0 + 16.0 / 45.0 * tf.math.pow(lams - 0.5, 3)
         )
-        return tf.where(
-            self._outside_unstable_region(),
-            mus,
-            taylor,
-        )
+        return tf.where(self._outside_unstable_region(), mus, taylor)
 
     def _variance(self):
         lams = self._lams_parameter_no_checks()
         cut_lams = self._cut_lams()
         vars = cut_lams * (cut_lams - 1.0) / tf.math.pow(
             1.0 - 2.0 * cut_lams, 2
-        ) + 1.0 / tf.math.pow(tf.math.log1p(-cut_lams) - tf.math.log(cut_lams),
-                              2)
+        ) + 1.0 / tf.math.pow(
+            tf.math.log1p(-cut_lams) - tf.math.log(cut_lams), 2
+        )
         taylor = (
             1.0 / 12.0
             - tf.math.pow(lams - 0.5, 2) / 15.0
             - 128.0 / 945.0 * tf.math.pow(lams - 0.5, 4)
         )
-        return tf.where(
-            self._outside_unstable_region(),
-            vars,
-            taylor,
-        )
+        return tf.where(self._outside_unstable_region(), vars, taylor)
 
     def _quantile(self, p):
         cut_lams = self._cut_lams()
@@ -276,7 +261,7 @@ class ContinuousBernoulli(distribution.Distribution):
                 - tf.math.log1p(-cut_lams)
             )
             / (tf.math.log(cut_lams) - tf.math.log1p(-cut_lams)),
-            p,
+            p
         )
 
     def _mode(self):
@@ -323,7 +308,7 @@ class ContinuousBernoulli(distribution.Distribution):
             assert_util.assert_less(
                 x,
                 tf.ones([], dtype=x.dtype),
-                message="Sample must be less than `1`.",
+                message="Sample must be less than `1`."
             )
         )
         return assertions
@@ -356,8 +341,8 @@ def maybe_assert_continuous_bernoulli_param_correctness(
                 assert_util.assert_less(
                     lams,
                     one,
-                    message="lams has components greater than or equal to 1.",
-                ),
+                    message="lams has components greater than or equal to 1."
+                )
             ]
 
     return assertions
@@ -381,11 +366,11 @@ def _kl_bernoulli_bernoulli(a, b, name=None):
     with tf.name_scope(name or "kl_continuous_bernoulli_continuous_bernoulli"):
         (
             a_log_lams0,
-            a_log_lams1,
+            a_log_lams1
         ) = a._outcome_log_lams()  # pylint:disable=protected-access
         (
             b_log_lams0,
-            b_log_lams1,
+            b_log_lams1
         ) = b._outcome_log_lams()  # pylint:disable=protected-access
         a_mean = a._mean()  # pylint:disable=protected-access
         a_log_norm = a._cont_bern_log_norm()  # pylint:disable=protected-access

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -167,12 +167,7 @@ class ContinuousBernoulli(distribution.Distribution):
         cut_probs = self._cut_probs()
         new_shape = tf.concat([[n], tf.shape(cut_probs)], axis=0)
         uniform = tf.random.uniform(new_shape, seed=seed, dtype=cut_probs.dtype)
-        sample = tf.where(
-            self._outside_unstable_region(),
-            (tf.math.log1p(-cut_probs + uniform * (2.0 * cut_probs - 1.0))
-             - tf.math.log1p(-cut_probs))
-            / (tf.math.log(cut_probs) - tf.math.log1p(-cut_probs)),
-            uniform)
+        sample = self._quantile(uniform)
         return tf.cast(sample, self.dtype)
 
     def _cont_bern_log_norm(self):

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -131,7 +131,7 @@ class ContinuousBernoulli(distribution.Distribution):
         uniform = tf.random.uniform(new_shape, seed=seed, dtype=lams.dtype)
         sample = tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
                           (tf.math.log(uniform * (2.0 * cut_lams - 1.0) + 1.0 - cut_lams)
-                           - tf.math.log(1.0 - cut_lams)) / (tf.log(cut_lams) - tf.math.log(1.0 - cut_lams)),
+                           - tf.math.log(1.0 - cut_lams)) / (tf.math.log(cut_lams) - tf.math.log(1.0 - cut_lams)),
                           uniform)
         return tf.cast(sample, self.dtype)
 
@@ -185,7 +185,7 @@ class ContinuousBernoulli(distribution.Distribution):
 
     def _entropy(self):
         log_lams0, log_lams1 = self._outcome_log_lams()
-        return self._mean() * (log_lams1 - log_lams0) - self._cont_bern_log_norm() - log_lams1
+        return self._mean() * (log_lams0 - log_lams1) - self._cont_bern_log_norm() - log_lams0
 
     def _mean(self):
         lams = self._lams_parameter_no_checks()
@@ -210,7 +210,7 @@ class ContinuousBernoulli(distribution.Distribution):
                             lams, self._lims[0] * tf.ones_like(lams))
         return tf.where(tf.logical_or(tf.less(lams, self._lims[0]), tf.greater(lams, self._lims[1])),
                         (tf.math.log(p * (2.0 * cut_lams - 1.0) + 1.0 - cut_lams)
-                         - tf.math.log(1.0 - cut_lams)) / (tf.log(cut_lams) - tf.math.log(1.0 - cut_lams)),
+                         - tf.math.log(1.0 - cut_lams)) / (tf.math.log(cut_lams) - tf.math.log(1.0 - cut_lams)),
                         p)
 
     def _stddev(self):
@@ -310,6 +310,6 @@ def _kl_bernoulli_bernoulli(a, b, name=None):
         b_log_norm = b._cont_bern_log_norm() # pylint:disable=protected-access
 
         return (
-                a_mean * (a_log_lams0 + b_log_lams1 - a_log_lams1 - b_log_lams0) + a_log_norm - b_log_norm +
-                a_log_lams1 - b_log_lams1
+                a_mean * (a_log_lams1 + b_log_lams0 - a_log_lams0 - b_log_lams1) + a_log_norm - b_log_norm +
+                a_log_lams0 - b_log_lams0
         )

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -252,12 +252,12 @@ class ContinuousBernoulli(distribution.Distribution):
         assertions = []
         if not self.validate_args:
             return assertions
-        assertions.append(assert_util.assert_non_negative(
-            x, message='Sample must be non-negative.'))
+        assertions.append(assert_util.assert_positive(
+            x, message='Sample must be positive.'))
         assertions.append(
-            assert_util.assert_less_equal(
+            assert_util.assert_less(
                 x, tf.ones([], dtype=x.dtype),
-                message='Sample must be less than or equal to `1`.'))
+                message='Sample must be less than `1`.'))
         return assertions
 
 
@@ -280,10 +280,10 @@ def maybe_assert_continuous_bernoulli_param_correctness(
             lams = tf.convert_to_tensor(lams)
             one = tf.constant(1., lams.dtype)
             assertions += [
-                assert_util.assert_non_negative(
-                    lams, message='lams has components less than 0.'),
-                assert_util.assert_less_equal(
-                    lams, one, message='lams has components greater than 1.')
+                assert_util.assert_positive(
+                    lams, message='lams has components less than or equal to 0.'),
+                assert_util.assert_less(
+                    lams, one, message='lams has components greater than or equal to 1.')
             ]
 
     return assertions

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Probability Authors.
+# Copyright 2020 The TensorFlow Probability Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -94,7 +94,7 @@ def quantile(p, lams):
     ) / (np.log(lams) - np.log(1.0 - lams))
 
 
-@test_util.test_all_tf_execution_regimes
+#@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliTest(test_util.TestCase):
     def testLam(self):
         lam = [0.2, 0.4]
@@ -459,14 +459,14 @@ class ContinuousBernoulliTest(test_util.TestCase):
             mean(a_p)
             * (
                 np.log(a_p)
-                + np.log(1.0 - b_p)
+                + np.log1p(-b_p)
                 - np.log(b_p)
-                - np.log(1.0 - a_p)
+                - np.log1p(-a_p)
             )
             + log_norm_const(a_p)
             - log_norm_const(b_p)
-            + np.log(1.0 - a_p)
-            - np.log(1.0 - b_p)
+            + np.log1p(-a_p)
+            - np.log1p(-b_p)
         )
 
         self.assertEqual(kl.shape, (batch_size,))
@@ -481,7 +481,7 @@ class _MakeSlicer(object):
 make_slicer = _MakeSlicer()
 
 
-@test_util.test_all_tf_execution_regimes
+#@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliSlicingTest(test_util.TestCase):
     def testScalarSlice(self):
         logits = self.evaluate(tf.random.normal([], seed=test_util.test_seed()))
@@ -638,7 +638,7 @@ class ContinuousBernoulliSlicingTest(test_util.TestCase):
         self.assertAllEqual((3, 1, 5, 2, 4), cb2.batch_shape)
 
 
-@test_util.test_all_tf_execution_regimes
+#@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliFromVariableTest(test_util.TestCase):
     @test_util.tf_tape_safety_test
     def testGradientLogits(self):

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -68,8 +68,7 @@ def quantile(p, lams):
     return (np.log(p * (2.0 * lams - 1.0) + 1.0 - lams) - np.log(1.0 - lams)) / (np.log(lams) - np.log(1.0 - lams))
 
 
-# @test_util.test_all_tf_execution_regimes
-@test_util.test_graph_mode_only
+@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliTest(test_util.TestCase):
 
     def testLam(self):
@@ -360,8 +359,7 @@ class _MakeSlicer(object):
 make_slicer = _MakeSlicer()
 
 
-# @test_util.test_all_tf_execution_regimes
-@test_util.test_graph_mode_only
+@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliSlicingTest(test_util.TestCase):
 
     def testScalarSlice(self):
@@ -490,8 +488,7 @@ class ContinuousBernoulliSlicingTest(test_util.TestCase):
         self.assertAllEqual((3, 1, 5, 2, 4), cb2.batch_shape)
 
 
-# @test_util.test_all_tf_execution_regimes
-@test_util.test_graph_mode_only
+@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliFromVariableTest(test_util.TestCase):
 
     @test_util.tf_tape_safety_test

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -35,91 +35,126 @@ def make_continuous_bernoulli(batch_shape, dtype=tf.float32):
     lam = tf.constant(lam, dtype=tf.float32)
     return tfd.ContinuousBernoulli(lams=lam, dtype=dtype, validate_args=True)
 
+
 def log_norm_const(lams):
     # do not evaluate close to 0.5
-    return np.log(np.absolute(2.0 * np.arctanh(1.0 - 2.0 * lams))) - np.log(np.absolute(1.0 - 2.0 * lams))
+    return np.log(np.absolute(2.0 * np.arctanh(1.0 - 2.0 * lams))) - np.log(
+        np.absolute(1.0 - 2.0 * lams)
+    )
+
 
 def pdf(x, lams):
     # do not evaluate close to 0.5
     x = np.array(x, dtype=np.float32)
     lams = np.array(lams, dtype=np.float32)
-    return np.power(lams, x) * np.power(1.0 - lams, 1.0 - x) * np.exp(log_norm_const(lams))
+    return (
+        np.power(lams, x)
+        * np.power(1.0 - lams, 1.0 - x)
+        * np.exp(log_norm_const(lams))
+    )
+
 
 def mean(lams):
     # do not evaluate close to 0.5
-    return lams / (2.0 * lams - 1.0) + 1.0 / (2.0 * np.arctanh(1.0 - 2.0 * lams))
+    return lams / (2.0 * lams - 1.0) + 1.0 / (
+        2.0 * np.arctanh(1.0 - 2.0 * lams)
+    )
+
 
 def var(lams):
     # do not evaluate close to 0.5
-    return lams * (lams - 1.0) / (1.0 - 2.0 * lams)**2 + 1.0 / (2.0 * np.arctanh(1.0 - 2.0 * lams))**2
+    return (
+        lams * (lams - 1.0) / (1.0 - 2.0 * lams) ** 2
+        + 1.0 / (2.0 * np.arctanh(1.0 - 2.0 * lams)) ** 2
+    )
+
 
 def entropy(lams):
     # do not evaluate close to 0.5
-    return mean(lams) * (np.log(1.0 - lams) - np.log(lams)) - log_norm_const(lams) - np.log(1.0 - lams)
+    return (
+        mean(lams) * (np.log(1.0 - lams) - np.log(lams))
+        - log_norm_const(lams)
+        - np.log(1.0 - lams)
+    )
+
 
 def cdf(x, lams):
     # do not evaluate close to 0.5
-    tentative_cdf = (lams**x * (1.0 - lams)**(1.0 - x) + lams - 1.0) / (2.0 * lams - 1.0)
+    tentative_cdf = (lams ** x * (1.0 - lams) ** (1.0 - x) + lams - 1.0) / (
+        2.0 * lams - 1.0
+    )
     correct_above = np.where(x > 1.0, 1.0, tentative_cdf)
     return np.where(x < 0, 0.0, correct_above)
 
+
 def quantile(p, lams):
     # do not evaluate close to 0.5
-    return (np.log(p * (2.0 * lams - 1.0) + 1.0 - lams) - np.log(1.0 - lams)) / (np.log(lams) - np.log(1.0 - lams))
+    return (
+        np.log(p * (2.0 * lams - 1.0) + 1.0 - lams) - np.log(1.0 - lams)
+    ) / (np.log(lams) - np.log(1.0 - lams))
 
 
 @test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliTest(test_util.TestCase):
-
     def testLam(self):
         lam = [0.2, 0.4]
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
         self.assertAllClose(lam, self.evaluate(dist.lams))
 
     def testLogits(self):
-        logits = [-42., 42.]
+        logits = [-42.0, 42.0]
         dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
         self.assertAllClose(logits, self.evaluate(dist.logits))
-        self.assertAllClose(sp_special.expit(logits),
-                            self.evaluate(dist.lams_parameter()))
+        self.assertAllClose(
+            sp_special.expit(logits), self.evaluate(dist.lams_parameter())
+        )
 
         lam = [0.01, 0.99, 0.42]
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
-        self.assertAllClose(sp_special.logit(lam),
-                            self.evaluate(dist.logits_parameter()))
+        self.assertAllClose(
+            sp_special.logit(lam), self.evaluate(dist.logits_parameter())
+        )
 
     def testInvalidLam(self):
-        invalid_lams = [1.01, 2., 1.0]
+        invalid_lams = [1.01, 2.0, 1.0]
         for lam in invalid_lams:
-            with self.assertRaisesOpError('lams has components greater than or equal to 1'):
+            with self.assertRaisesOpError(
+                "lams has components greater than or equal to 1"
+            ):
                 dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
                 self.evaluate(dist.lams_parameter())
 
-        invalid_lams = [-0.01, 0.0, -3.]
+        invalid_lams = [-0.01, 0.0, -3.0]
         for lam in invalid_lams:
-            with self.assertRaisesOpError('x > 0 did not hold'):
+            with self.assertRaisesOpError("x > 0 did not hold"):
                 dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
                 self.evaluate(dist.lams_parameter())
 
         valid_lams = [0.1, 0.5, 0.9]
         for lam in valid_lams:
             dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
-            self.assertEqual(np.float32(lam), self.evaluate(dist.lams))  # Should not fail
+            self.assertEqual(
+                np.float32(lam), self.evaluate(dist.lams)
+            )  # Should not fail
 
     def testShapes(self):
         for batch_shape in ([], [1], [2, 3, 4]):
             dist = make_continuous_bernoulli(batch_shape)
-            self.assertAllEqual(batch_shape,
-                                tensorshape_util.as_list(dist.batch_shape))
-            self.assertAllEqual(batch_shape, self.evaluate(dist.batch_shape_tensor()))
+            self.assertAllEqual(
+                batch_shape, tensorshape_util.as_list(dist.batch_shape)
+            )
+            self.assertAllEqual(
+                batch_shape, self.evaluate(dist.batch_shape_tensor())
+            )
             self.assertAllEqual([], tensorshape_util.as_list(dist.event_shape))
             self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
 
     def testDtype(self):
         dist = make_continuous_bernoulli([])
         self.assertEqual(dist.dtype, tf.float32)
-        self.assertEqual(dist.dtype, dist.sample(
-            5, seed=test_util.test_seed()).dtype)
+        self.assertEqual(
+            dist.dtype, dist.sample(5, seed=test_util.test_seed()).dtype
+        )
         self.assertEqual(dist.dtype, dist.mode().dtype)
         self.assertEqual(dist.lams.dtype, dist.mean().dtype)
         self.assertEqual(dist.lams.dtype, dist.variance().dtype)
@@ -142,12 +177,15 @@ class ContinuousBernoulliTest(test_util.TestCase):
 
         dist64 = make_continuous_bernoulli([], tf.float64)
         self.assertEqual(dist64.dtype, tf.float64)
-        self.assertEqual(dist64.dtype, dist64.sample(
-            5, seed=test_util.test_seed()).dtype)
+        self.assertEqual(
+            dist64.dtype, dist64.sample(5, seed=test_util.test_seed()).dtype
+        )
         self.assertEqual(dist64.dtype, dist64.mode().dtype)
 
     def testFloatMode(self):
-        dist = tfd.ContinuousBernoulli(lams=.6, dtype=tf.float32, validate_args=True)
+        dist = tfd.ContinuousBernoulli(
+            lams=0.6, dtype=tf.float32, validate_args=True
+        )
         self.assertEqual(np.float32(1), self.evaluate(dist.mode()))
 
     def _testPdf(self, **kwargs):
@@ -171,7 +209,9 @@ class ContinuousBernoulliTest(test_util.TestCase):
 
         for x, expected_pmf in zip(xs, expected_pmfs):
             self.assertAllClose(self.evaluate(dist.prob(x)), expected_pmf)
-            self.assertAllClose(self.evaluate(dist.log_prob(x)), np.log(expected_pmf))
+            self.assertAllClose(
+                self.evaluate(dist.log_prob(x)), np.log(expected_pmf)
+            )
 
     def testPdfCorrectBroadcastDynamicShape(self):
         lam = tf1.placeholder_with_default([0.2, 0.3, 0.4], shape=None)
@@ -179,9 +219,13 @@ class ContinuousBernoulliTest(test_util.TestCase):
         event1 = [0.9, 0.1, 1.0]
         event2 = [[0.9, 0.1, 1.0]]
         self.assertAllClose(
-            [pdf(0.9, 0.2), pdf(0.1, 0.3), pdf(1.0, 0.4)], self.evaluate(dist.prob(event1)))
+            [pdf(0.9, 0.2), pdf(0.1, 0.3), pdf(1.0, 0.4)],
+            self.evaluate(dist.prob(event1)),
+        )
         self.assertAllClose(
-            [[pdf(0.9, 0.2), pdf(0.1, 0.3), pdf(1.0, 0.4)]], self.evaluate(dist.prob(event2)))
+            [[pdf(0.9, 0.2), pdf(0.1, 0.3), pdf(1.0, 0.4)]],
+            self.evaluate(dist.prob(event2)),
+        )
 
     def testPdfWithLam(self):
         lam = [[0.2, 0.4], [0.3, 0.6]]
@@ -194,25 +238,40 @@ class ContinuousBernoulliTest(test_util.TestCase):
         self.assertAllClose(
             np.log(pdf(samps, lam)),
             self.evaluate(
-                tfd.ContinuousBernoulli(lams=lam, validate_args=False).log_prob(samps)))
+                tfd.ContinuousBernoulli(lams=lam, validate_args=False).log_prob(
+                    samps
+                )
+            ),
+        )
 
     def testBroadcasting(self):
         lams = lambda lam: tf1.placeholder_with_default(lam, shape=None)
-        dist = lambda lam: tfd.ContinuousBernoulli(lams=lams(lam), validate_args=True)
+        dist = lambda lam: tfd.ContinuousBernoulli(
+            lams=lams(lam), validate_args=True
+        )
         self.assertAllClose(0.0, self.evaluate(dist(0.5).log_prob(0.9)))
         self.assertAllClose(
-            np.log([1.0, 1.0, 1.0]), self.evaluate(dist(0.5).log_prob([0.9, 0.9, 0.9])))
-        self.assertAllClose(np.log([1.0, 1.0, 1.0]),
-                            self.evaluate(dist([0.5, 0.5, 0.5]).log_prob(0.9)))
+            np.log([1.0, 1.0, 1.0]),
+            self.evaluate(dist(0.5).log_prob([0.9, 0.9, 0.9])),
+        )
+        self.assertAllClose(
+            np.log([1.0, 1.0, 1.0]),
+            self.evaluate(dist([0.5, 0.5, 0.5]).log_prob(0.9)),
+        )
 
     def testPdfShapes(self):
         lams = lambda lam: tf1.placeholder_with_default(lam, shape=None)
-        dist = lambda lam: tfd.ContinuousBernoulli(lams=lams(lam), validate_args=True)
+        dist = lambda lam: tfd.ContinuousBernoulli(
+            lams=lams(lam), validate_args=True
+        )
         self.assertEqual(
-            2, len(self.evaluate(dist([[0.5], [0.5]]).log_prob(0.9)).shape))
+            2, len(self.evaluate(dist([[0.5], [0.5]]).log_prob(0.9)).shape)
+        )
 
         dist = tfd.ContinuousBernoulli(lams=0.5, validate_args=True)
-        self.assertEqual(2, len(self.evaluate(dist.log_prob([[0.9], [0.9]])).shape))
+        self.assertEqual(
+            2, len(self.evaluate(dist.log_prob([[0.9], [0.9]])).shape)
+        )
 
         dist = tfd.ContinuousBernoulli(lams=0.5, validate_args=True)
         self.assertAllEqual([], dist.log_prob(0.9).shape)
@@ -232,8 +291,8 @@ class ContinuousBernoulliTest(test_util.TestCase):
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=False)
         self.assertAllClose(
             self.evaluate(dist.entropy()),
-            [[entropy(0.1), entropy(0.7)], [entropy(0.2),
-                                            entropy(0.6)]])
+            [[entropy(0.1), entropy(0.7)], [entropy(0.2), entropy(0.6)]],
+        )
 
     def testSampleN(self):
         lam = [0.2, 0.6]
@@ -245,36 +304,46 @@ class ContinuousBernoulliTest(test_util.TestCase):
         sample_values = self.evaluate(samples)
         self.assertTrue(np.all(sample_values > 0))
         self.assertTrue(np.all(sample_values < 1))
-        # Note that the standard error for the sample mean is ~ sqrt(p * (1 - p) /
-        # n). This means that the tolerance is very sensitive to the value of p
-        # as well as n.
-        self.assertAllClose(mean(np.array(lam, dtype=np.float32)), np.mean(sample_values, axis=0), atol=1e-2)
+        # This  tolerance is very sensitive to the value of lam as well as n.
+        self.assertAllClose(
+            mean(np.array(lam, dtype=np.float32)),
+            np.mean(sample_values, axis=0),
+            atol=1e-2,
+        )
         # In this test we're just interested in verifying there isn't a crash
         # owing to mismatched types. b/30940152
-        dist = tfd.ContinuousBernoulli(np.log([.2, .4]), validate_args=True)
+        dist = tfd.ContinuousBernoulli(np.log([0.2, 0.4]), validate_args=True)
         x = dist.sample(1, seed=test_util.test_seed())
         self.assertAllEqual((1, 2), tensorshape_util.as_list(x.shape))
 
     def testReparameterized(self):
         lam = tf.constant([0.2, 0.6])
         _, grad_lam = tfp.math.value_and_gradient(
-            lambda x: tfd.ContinuousBernoulli(lams=x, validate_args=True).sample(  # pylint: disable=g-long-lambda
-                100, seed=test_util.test_seed()), lam)
+            lambda x: tfd.ContinuousBernoulli(
+                lams=x, validate_args=True
+            ).sample(  # pylint: disable=g-long-lambda
+                100, seed=test_util.test_seed()
+            ),
+            lam,
+        )
         self.assertIsNotNone(grad_lam)
 
     def testSampleDeterministicScalarVsVector(self):
         lam = [0.2, 0.6]
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
         n = 1000
+
         def _seed(seed=None):
             seed = test_util.test_seed() if seed is None else seed
             if tf.executing_eagerly():
                 tf1.set_random_seed(seed)
             return seed
+
         seed = _seed()
         self.assertAllEqual(
             self.evaluate(dist.sample(n, _seed(seed=seed))),
-            self.evaluate(dist.sample([n], _seed(seed=seed))))
+            self.evaluate(dist.sample([n], _seed(seed=seed))),
+        )
         n = tf1.placeholder_with_default(np.int32(1000), shape=None)
         seed = _seed()
         sample1 = dist.sample(n, _seed(seed=seed))
@@ -292,46 +361,88 @@ class ContinuousBernoulliTest(test_util.TestCase):
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
         self.assertAllClose(
             self.evaluate(dist.variance()),
-            np.array([[var(0.2), var(0.7)], [var(0.8), var(0.4)]],
-                     dtype=np.float32))
+            np.array(
+                [[var(0.2), var(0.7)], [var(0.8), var(0.4)]], dtype=np.float32
+            ),
+        )
         self.assertAllClose(
             self.evaluate(dist.stddev()),
-            np.array([[np.sqrt(var(0.2)), np.sqrt(var(0.7))],
-                      [np.sqrt(var(0.8)), np.sqrt(var(0.4))]],
-                     dtype=np.float32))
+            np.array(
+                [
+                    [np.sqrt(var(0.2)), np.sqrt(var(0.7))],
+                    [np.sqrt(var(0.8)), np.sqrt(var(0.4))],
+                ],
+                dtype=np.float32,
+            ),
+        )
 
     def testCdfAndLogCdf(self):
         lam = 0.2
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
         self.assertAllClose(
-            self.evaluate(dist.cdf(np.array([-2.0, 0.3, 1.1], dtype=np.float32))),
-            np.array([cdf(-2.0, 0.2), cdf(0.3, 0.2), cdf(1.1, 0.2)],
-                     dtype=np.float32))
+            self.evaluate(
+                dist.cdf(np.array([-2.0, 0.3, 1.1], dtype=np.float32))
+            ),
+            np.array(
+                [cdf(-2.0, 0.2), cdf(0.3, 0.2), cdf(1.1, 0.2)], dtype=np.float32
+            ),
+        )
         self.assertAllClose(
-            self.evaluate(dist.log_cdf(np.array([-2.0, 0.3, 1.1], dtype=np.float32))),
-                          np.array([np.log(cdf(-2.0, 0.2)), np.log(cdf(0.3, 0.2)), np.log(cdf(1.1, 0.2))],
-                                   dtype=np.float32))
+            self.evaluate(
+                dist.log_cdf(np.array([-2.0, 0.3, 1.1], dtype=np.float32))
+            ),
+            np.array(
+                [
+                    np.log(cdf(-2.0, 0.2)),
+                    np.log(cdf(0.3, 0.2)),
+                    np.log(cdf(1.1, 0.2)),
+                ],
+                dtype=np.float32,
+            ),
+        )
 
     def testSurvivalAndLogSurvival(self):
         lam = 0.2
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
         self.assertAllClose(
-            self.evaluate(dist.survival_function(np.array([-2.0, 0.3, 1.1], dtype=np.float32))),
-                          1.0 - np.array([cdf(-2.0, 0.2), cdf(0.3, 0.2), cdf(1.1, 0.2)],
-                                         dtype=np.float32))
+            self.evaluate(
+                dist.survival_function(
+                    np.array([-2.0, 0.3, 1.1], dtype=np.float32)
+                )
+            ),
+            1.0
+            - np.array(
+                [cdf(-2.0, 0.2), cdf(0.3, 0.2), cdf(1.1, 0.2)], dtype=np.float32
+            ),
+        )
         self.assertAllClose(
-            self.evaluate(dist.log_survival_function(np.array([-2.0, 0.3, 1.1], dtype=np.float32))),
-                          np.array([np.log(1.0 - cdf(-2.0, 0.2)), np.log(1.0 - cdf(0.3, 0.2)),
-                                    np.log(1.0 - cdf(1.1, 0.2))],
-                                   dtype=np.float32))
+            self.evaluate(
+                dist.log_survival_function(
+                    np.array([-2.0, 0.3, 1.1], dtype=np.float32)
+                )
+            ),
+            np.array(
+                [
+                    np.log(1.0 - cdf(-2.0, 0.2)),
+                    np.log(1.0 - cdf(0.3, 0.2)),
+                    np.log(1.0 - cdf(1.1, 0.2)),
+                ],
+                dtype=np.float32,
+            ),
+        )
 
     def testQuantile(self):
         lam = 0.2
         dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
         self.assertAllClose(
-            self.evaluate(dist.quantile(np.array([0.1, 0.3, 0.9], dtype=np.float32))),
-                          np.array([quantile(0.1, 0.2), quantile(0.3, 0.2), quantile(0.9, 0.2)],
-                                         dtype=np.float32))
+            self.evaluate(
+                dist.quantile(np.array([0.1, 0.3, 0.9], dtype=np.float32))
+            ),
+            np.array(
+                [quantile(0.1, 0.2), quantile(0.3, 0.2), quantile(0.9, 0.2)],
+                dtype=np.float32,
+            ),
+        )
 
     def testContinuousBernoulliContinuousBernoulliKL(self):
         batch_size = 6
@@ -344,40 +455,54 @@ class ContinuousBernoulliTest(test_util.TestCase):
         kl = tfd.kl_divergence(a, b)
         kl_val = self.evaluate(kl)
 
-        kl_expected = mean(a_p) * (np.log(a_p) + np.log(1.0 - b_p) - np.log(b_p) - np.log(1.0 - a_p)) +\
-                      log_norm_const(a_p) - log_norm_const(b_p) + np.log(1.0 - a_p) - np.log(1.0 - b_p)
+        kl_expected = (
+            mean(a_p)
+            * (
+                np.log(a_p)
+                + np.log(1.0 - b_p)
+                - np.log(b_p)
+                - np.log(1.0 - a_p)
+            )
+            + log_norm_const(a_p)
+            - log_norm_const(b_p)
+            + np.log(1.0 - a_p)
+            - np.log(1.0 - b_p)
+        )
 
         self.assertEqual(kl.shape, (batch_size,))
         self.assertAllClose(kl_val, kl_expected)
 
 
 class _MakeSlicer(object):
-
     def __getitem__(self, slices):
         return lambda x: x[slices]
+
 
 make_slicer = _MakeSlicer()
 
 
 @test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliSlicingTest(test_util.TestCase):
-
     def testScalarSlice(self):
         logits = self.evaluate(tf.random.normal([], seed=test_util.test_seed()))
         dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
         self.assertAllEqual([], dist.batch_shape)
         self.assertAllEqual([1], dist[tf.newaxis].batch_shape)
         self.assertAllEqual([], dist[...].batch_shape)
-        self.assertAllEqual([1, 1], dist[tf.newaxis, ..., tf.newaxis].batch_shape)
+        self.assertAllEqual(
+            [1, 1], dist[tf.newaxis, ..., tf.newaxis].batch_shape
+        )
 
     def testSlice(self):
-        logits = self.evaluate(tf.random.normal(
-            [20, 3, 1, 5], seed=test_util.test_seed()))
+        logits = self.evaluate(
+            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed())
+        )
         dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
         batch_shape = tensorshape_util.as_list(dist.batch_shape)
         dist_noshape = tfd.ContinuousBernoulli(
             logits=tf1.placeholder_with_default(logits, shape=None),
-            validate_args=True)
+            validate_args=True,
+        )
 
         def check(*slicers):
             for ds, assert_static_shape in (dist, True), (dist_noshape, False):
@@ -391,7 +516,9 @@ class ContinuousBernoulliSlicingTest(test_util.TestCase):
                         self.assertAllEqual(bs, ds.batch_shape)
                     else:
                         self.assertIsNone(tensorshape_util.rank(ds.batch_shape))
-                    self.assertAllEqual(bs, self.evaluate(ds.batch_shape_tensor()))
+                    self.assertAllEqual(
+                        bs, self.evaluate(ds.batch_shape_tensor())
+                    )
                     self.assertAllClose(prob, self.evaluate(ds.prob(0)))
 
         check(make_slicer[3])
@@ -403,86 +530,109 @@ class ContinuousBernoulliSlicingTest(test_util.TestCase):
         check(make_slicer[..., tf.newaxis, 3:, tf.newaxis])
         check(make_slicer[..., tf.newaxis, -3:, tf.newaxis])
         check(make_slicer[tf.newaxis, :-3, tf.newaxis, ...])
+
         def halfway(x):
             if isinstance(x, tfd.ContinuousBernoulli):
                 return x.batch_shape_tensor()[0] // 2
             return x.shape[0] // 2
+
         check(lambda x: x[halfway(x)])
-        check(lambda x: x[:halfway(x)])
-        check(lambda x: x[halfway(x):])
-        check(make_slicer[:-3, tf.newaxis], make_slicer[..., 0, :2],
-              make_slicer[::2])
-        if tf.executing_eagerly(): return
-        with self.assertRaisesRegexp((ValueError, tf.errors.InvalidArgumentError),
-                                     'Index out of range.*input has only 4 dims'):
+        check(lambda x: x[: halfway(x)])
+        check(lambda x: x[halfway(x) :])
+        check(
+            make_slicer[:-3, tf.newaxis],
+            make_slicer[..., 0, :2],
+            make_slicer[::2],
+        )
+        if tf.executing_eagerly():
+            return
+        with self.assertRaisesRegexp(
+            (ValueError, tf.errors.InvalidArgumentError),
+            "Index out of range.*input has only 4 dims",
+        ):
             check(make_slicer[19, tf.newaxis, 2, ..., :, 0, 4])
-        with self.assertRaisesRegexp((ValueError, tf.errors.InvalidArgumentError),
-                                     'slice index.*out of bounds'):
+        with self.assertRaisesRegexp(
+            (ValueError, tf.errors.InvalidArgumentError),
+            "slice index.*out of bounds",
+        ):
             check(make_slicer[..., 2, :])  # ...,1,5 -> 2 is oob.
 
     def testSliceSequencePreservesOrigVarGradLinkage(self):
-        logits = tf.Variable(tf.random.normal(
-            [20, 3, 1, 5], seed=test_util.test_seed()))
+        logits = tf.Variable(
+            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed())
+        )
         self.evaluate(logits.initializer)
         dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
-        for slicer in [make_slicer[:5], make_slicer[..., -1], make_slicer[:, 1::2]]:
+        for slicer in [
+            make_slicer[:5],
+            make_slicer[..., -1],
+            make_slicer[:, 1::2],
+        ]:
             with tf.GradientTape() as tape:
                 dist = slicer(dist)
                 lp = dist.log_prob(0.1)
             dlpdlogits = tape.gradient(lp, logits)
             self.assertIsNotNone(dlpdlogits)
             self.assertGreater(
-                self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
+                self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0
+            )
 
     def testSliceThenCopyPreservesOrigVarGradLinkage(self):
         logits = tf.Variable(
-            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed()))
+            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed())
+        )
         self.evaluate(logits.initializer)
         dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
         dist = dist[:5]
         with tf.GradientTape() as tape:
-            dist = dist.copy(name='contbern2')
+            dist = dist.copy(name="contbern2")
             lp = dist.log_prob(0.1)
         dlpdlogits = tape.gradient(lp, logits)
-        self.assertIn('contbern2', dist.name)
+        self.assertIn("contbern2", dist.name)
         self.assertIsNotNone(dlpdlogits)
-        self.assertGreater(
-            self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
+        self.assertGreater(self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
         with tf.GradientTape() as tape:
             dist = dist[:3]
             lp = dist.log_prob(0)
         dlpdlogits = tape.gradient(lp, logits)
-        self.assertIn('contbern2', dist.name)
+        self.assertIn("contbern2", dist.name)
         self.assertIsNotNone(dlpdlogits)
-        self.assertGreater(
-            self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
+        self.assertGreater(self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
 
     def testCopyUnknownRank(self):
         logits = tf1.placeholder_with_default(
-            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed()), shape=None)
-        dist = tfd.ContinuousBernoulli(logits=logits, name='cb1', validate_args=True)
-        self.assertIn('cb1', dist.name)
-        dist = dist.copy(name='cb2')
-        self.assertIn('cb2', dist.name)
+            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed()),
+            shape=None,
+        )
+        dist = tfd.ContinuousBernoulli(
+            logits=logits, name="cb1", validate_args=True
+        )
+        self.assertIn("cb1", dist.name)
+        dist = dist.copy(name="cb2")
+        self.assertIn("cb2", dist.name)
 
     def testSliceCopyOverrideNameSliceAgainCopyOverrideLogitsSliceAgain(self):
-        seed_stream = test_util.test_seed_stream('slice_continuous_bernoulli')
+        seed_stream = test_util.test_seed_stream("slice_continuous_bernoulli")
         logits = tf.random.normal([20, 3, 2, 5], seed=seed_stream())
-        dist = tfd.ContinuousBernoulli(logits=logits, name='cb1', validate_args=True)
-        self.assertIn('cb1', dist.name)
-        dist = dist[:10].copy(name='cb2')
+        dist = tfd.ContinuousBernoulli(
+            logits=logits, name="cb1", validate_args=True
+        )
+        self.assertIn("cb1", dist.name)
+        dist = dist[:10].copy(name="cb2")
         self.assertAllEqual((10, 3, 2, 5), dist.batch_shape)
-        self.assertIn('cb2', dist.name)
-        dist = dist.copy(name='cb3')[..., 1]
+        self.assertIn("cb2", dist.name)
+        dist = dist.copy(name="cb3")[..., 1]
         self.assertAllEqual((10, 3, 2), dist.batch_shape)
-        self.assertIn('cb3', dist.name)
+        self.assertIn("cb3", dist.name)
         dist = dist.copy(logits=tf.random.normal([2], seed=seed_stream()))
         self.assertAllEqual((2,), dist.batch_shape)
-        self.assertIn('cb3', dist.name)
+        self.assertIn("cb3", dist.name)
 
     def testDocstrSliceExample(self):
         # batch shape [3, 5, 7, 9]
-        cb = tfd.ContinuousBernoulli(logits=tf.zeros([3, 5, 7, 9]), validate_args=True)
+        cb = tfd.ContinuousBernoulli(
+            logits=tf.zeros([3, 5, 7, 9]), validate_args=True
+        )
         self.assertAllEqual((3, 5, 7, 9), cb.batch_shape)
         cb2 = cb[:, tf.newaxis, ..., -2:, 1::2]  # batch shape [3, 1, 5, 2, 4]
         self.assertAllEqual((3, 1, 5, 2, 4), cb2.batch_shape)
@@ -490,10 +640,9 @@ class ContinuousBernoulliSlicingTest(test_util.TestCase):
 
 @test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliFromVariableTest(test_util.TestCase):
-
     @test_util.tf_tape_safety_test
     def testGradientLogits(self):
-        x = tf.Variable([-1., 1])
+        x = tf.Variable([-1.0, 1])
         self.evaluate(x.initializer)
         d = tfd.ContinuousBernoulli(logits=x, validate_args=True)
         with tf.GradientTape() as tape:
@@ -514,5 +663,5 @@ class ContinuousBernoulliFromVariableTest(test_util.TestCase):
         self.assertAllNotNone(g)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -24,7 +24,6 @@ import numpy as np
 from scipy import special as sp_special
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
-import tensorflow_probability as tfp
 from tensorflow_probability.python import distributions as tfd
 from tensorflow_probability.python.internal import tensorshape_util
 from tensorflow_probability.python.internal import test_util

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -1,0 +1,602 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for the continuous Bernoulli distribution."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+
+import numpy as np
+from scipy import special as sp_special
+import tensorflow.compat.v1 as tf1
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python import distributions as tfd
+from tensorflow_probability.python.internal import tensorshape_util
+from tensorflow_probability.python.internal import test_util
+
+
+def make_continuous_bernoulli(batch_shape, dtype=tf.float32):
+    p = np.random.uniform(size=list(batch_shape))
+    p = tf.constant(p, dtype=tf.float32)
+    return tfd.ContinuousBernoulli(probs=p, dtype=dtype, validate_args=True)
+
+
+def entropy(p): # TODO: CHANGE
+    q = 1. - p
+    return -q * np.log(q) - p * np.log(p)
+
+
+@test_util.test_all_tf_execution_regimes
+class ContinuousBernoulliTest(test_util.TestCase):
+
+    def testLam(self):
+        lam = [0.2, 0.4]
+        dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+        self.assertAllClose(lam, self.evaluate(dist.lams))
+
+    def testLogits(self):
+        logits = [-42., 42.]
+        dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
+        self.assertAllClose(logits, self.evaluate(dist.logits))
+        self.assertAllClose(sp_special.expit(logits),
+                            self.evaluate(dist.probs_parameter()))
+
+        lam = [0.01, 0.99, 0.42]
+        dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+        self.assertAllClose(sp_special.logit(lam),
+                            self.evaluate(dist.logits_parameter()))
+
+    def testInvalidLam(self):
+        invalid_lams = [1.01, 2., 1.0]
+        for lam in invalid_lams:
+            with self.assertRaisesOpError('lams has components greater than or equal to 1'):
+                dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+                self.evaluate(dist.lams_parameter())
+
+        invalid_lams = [-0.01, 0.0, -3.]
+        for lam in invalid_lams:
+            with self.assertRaisesOpError('x > 0 did not hold'):
+                dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+                self.evaluate(dist.probs_parameter())
+
+        valid_lams = [0.1, 0.5, 0.9]
+        for lam in valid_lams:
+            dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+            self.assertEqual(lam, self.evaluate(dist.lams))  # Should not fail
+
+    def testShapes(self):
+        for batch_shape in ([], [1], [2, 3, 4]):
+            dist = make_continuous_bernoulli(batch_shape)
+            self.assertAllEqual(batch_shape,
+                                tensorshape_util.as_list(dist.batch_shape))
+            self.assertAllEqual(batch_shape, self.evaluate(dist.batch_shape_tensor()))
+            self.assertAllEqual([], tensorshape_util.as_list(dist.event_shape))
+            self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+
+    def testDtype(self):
+        dist = make_continuous_bernoulli([])
+        self.assertEqual(dist.dtype, tf.float32)
+        self.assertEqual(dist.dtype, dist.sample(
+            5, seed=test_util.test_seed()).dtype)
+        self.assertEqual(dist.dtype, dist.mode().dtype)
+        self.assertEqual(dist.lams.dtype, dist.mean().dtype)
+        self.assertEqual(dist.lams.dtype, dist.variance().dtype)
+        self.assertEqual(dist.lams.dtype, dist.stddev().dtype)
+        self.assertEqual(dist.lams.dtype, dist.entropy().dtype)
+        self.assertEqual(dist.lams.dtype, dist.prob(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.prob(0.9).dtype)
+        self.assertEqual(dist.lams.dtype, dist.log_prob(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.log_prob(0.9).dtype)
+        self.assertEqual(dist.lams.dtype, dist.cdf(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.cdf(0.9).dtype)
+        self.assertEqual(dist.lams.dtype, dist.log_cdf(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.log_cdf(0.9).dtype)
+        self.assertEqual(dist.lams.dtype, dist.survival_function(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.survival_function(0.9).dtype)
+        self.assertEqual(dist.lams.dtype, dist.log_survival_function(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.log_survival_function(0.9).dtype)
+        self.assertEqual(dist.lams.dtype, dist.quantile(0.1).dtype)
+        self.assertEqual(dist.lams.dtype, dist.quantile(0.9).dtype)
+
+        dist64 = make_continuous_bernoulli([], tf.float64)
+        self.assertEqual(dist64.dtype, tf.float64)
+        self.assertEqual(dist64.dtype, dist64.sample(
+            5, seed=test_util.test_seed()).dtype)
+        self.assertEqual(dist64.dtype, dist64.mode().dtype)
+
+    def testFloatMode(self):
+        dist = tfd.ContinuousBernoulli(lams=.6, dtype=tf.float32, validate_args=True)
+        self.assertEqual(np.float32(1), self.evaluate(dist.mode()))
+
+    # TODO: implement test requiring expected matches
+    # def _testPdf(self, **kwargs):
+    #     dist = tfd.ContinuousBernoulli(validate_args=True, **kwargs)
+    #     # pylint: disable=bad-continuation
+    #     xs = [
+    #         0,
+    #         [1],
+    #         [1, 0],
+    #         [[1, 0]],
+    #         [[1, 0], [1, 1]],
+    #     ]
+    #     expected_pmfs = [
+    #         [[0.8, 0.6], [0.7, 0.4]],
+    #         [[0.2, 0.4], [0.3, 0.6]],
+    #         [[0.2, 0.6], [0.3, 0.4]],
+    #         [[0.2, 0.6], [0.3, 0.4]],
+    #         [[0.2, 0.6], [0.3, 0.6]],
+    #     ]
+    #     # pylint: enable=bad-continuation
+    #
+    #     for x, expected_pmf in zip(xs, expected_pmfs):
+    #         self.assertAllClose(self.evaluate(dist.prob(x)), expected_pmf)
+    #         self.assertAllClose(self.evaluate(dist.log_prob(x)), np.log(expected_pmf))
+
+    def testPdfCorrectBroadcastDynamicShape(self):
+        lam = tf1.placeholder_with_default([0.2, 0.3, 0.4], shape=None)
+        dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+        event1 = [0.9, 0.1, 1.0]
+        event2 = [[0.9, 0.1, 1.0]]
+        self.assertAllClose(
+            [0.2, 0.7, 0.4], self.evaluate(dist.prob(event1)))
+        self.assertAllClose(
+            [[0.2, 0.7, 0.4]], self.evaluate(dist.prob(event2)))
+
+    def testPdfInvalid(self):
+        lam = [0.1, 0.2, 0.7]
+        dist = tfd.ContinuousBernoulli(lams=lam, validate_args=True)
+        with self.assertRaisesOpError('must be positive.'):
+            self.evaluate(dist.prob([1, 0.9, -1]))
+        with self.assertRaisesOpError('must be less than `1`'):
+            self.evaluate(dist.prob([2, 0.1, 1]))
+
+    # def testPdfWithLam(self):
+    #     lam = [[0.2, 0.4], [0.3, 0.6]]
+    #     self._testPdf(lams=lam)
+    #     self._testPdf(logits=sp_special.logit(lam))
+
+    # def testPmfWithFloatArgReturnsXEntropy(self):
+    #     p = [[0.2], [0.4], [0.3], [0.6]]
+    #     samps = [0, 0.1, 0.8]
+    #     self.assertAllClose(
+    #         np.float32(samps) * np.log(np.float32(p)) +
+    #         (1 - np.float32(samps)) * np.log(1 - np.float32(p)),
+    #         self.evaluate(
+    #             tfd.Bernoulli(probs=p, validate_args=False).log_prob(samps)))
+
+    def testBroadcasting(self):
+        lams = lambda lam: tf1.placeholder_with_default(lam, shape=None)
+        dist = lambda lam: tfd.ContinuousBernoulli(lams=lams(lam), validate_args=True)
+        self.assertAllClose(0.0, self.evaluate(dist(0.5).log_prob(0.9)))
+        self.assertAllClose(
+            np.log([1.0, 1.0, 1.0]), self.evaluate(dist(0.5).log_prob([0.9, 0.9, 0.9])))
+        self.assertAllClose(np.log([1.0, 1.0, 1.0]),
+                            self.evaluate(dist([0.5, 0.5, 0.5]).log_prob(0.9)))
+
+    def testPdfShapes(self):
+        lams = lambda lam: tf1.placeholder_with_default(lam, shape=None)
+        dist = lambda lam: tfd.ContinuousBernoulli(lams=lams(lam), validate_args=True)
+        self.assertEqual(
+            2, len(self.evaluate(dist([[0.5], [0.5]]).log_prob(0.9)).shape))
+
+        dist = tfd.ContinuousBernoulli(lams=0.5, validate_args=True)
+        self.assertEqual(2, len(self.evaluate(dist.log_prob([[0.9], [0.9]])).shape))
+
+        dist = tfd.ContinuousBernoulli(lams=0.5, validate_args=True)
+        self.assertAllEqual([], dist.log_prob(0.9).shape)
+        self.assertAllEqual([1], dist.log_prob([0.9]).shape)
+        self.assertAllEqual([2, 1], dist.log_prob([[0.9], [0.9]]).shape)
+
+        dist = tfd.ContinuousBernoulli(lams=[[0.5], [0.5]], validate_args=True)
+        self.assertAllEqual([2, 1], dist.log_prob(0.9).shape)
+
+    # def testEntropyNoBatch(self):
+    #     p = 0.2
+    #     dist = tfd.Bernoulli(probs=p, validate_args=True)
+    #     self.assertAllClose(self.evaluate(dist.entropy()), entropy(p))
+
+    # def testEntropyWithBatch(self):
+    #     p = [[0.1, 0.7], [0.2, 0.6]]
+    #     dist = tfd.Bernoulli(probs=p, validate_args=False)
+    #     self.assertAllClose(
+    #         self.evaluate(dist.entropy()),
+    #         [[entropy(0.1), entropy(0.7)], [entropy(0.2),
+    #                                         entropy(0.6)]])
+
+    # def testSampleN(self):
+    #     p = [0.2, 0.6]
+    #     dist = tfd.Bernoulli(probs=p, validate_args=True)
+    #     n = 100000
+    #     samples = dist.sample(n, seed=test_util.test_seed())
+    #     tensorshape_util.set_shape(samples, [n, 2])
+    #     self.assertEqual(samples.dtype, tf.int32)
+    #     sample_values = self.evaluate(samples)
+    #     self.assertTrue(np.all(sample_values >= 0))
+    #     self.assertTrue(np.all(sample_values <= 1))
+    #     # Note that the standard error for the sample mean is ~ sqrt(p * (1 - p) /
+    #     # n). This means that the tolerance is very sensitive to the value of p
+    #     # as well as n.
+    #     self.assertAllClose(p, np.mean(sample_values, axis=0), atol=1e-2)
+    #     self.assertEqual(set([0, 1]), set(sample_values.flatten()))
+    #     # In this test we're just interested in verifying there isn't a crash
+    #     # owing to mismatched types. b/30940152
+    #     dist = tfd.Bernoulli(np.log([.2, .4]), validate_args=True)
+    #     x = dist.sample(1, seed=test_util.test_seed())
+    #     self.assertAllEqual((1, 2), tensorshape_util.as_list(x.shape))
+
+    # def testNotReparameterized(self):
+    #     p = tf.constant([0.2, 0.6])
+    #     _, grad_p = tfp.math.value_and_gradient(
+    #         lambda x: tfd.Bernoulli(probs=x, validate_args=True).sample(  # pylint: disable=g-long-lambda
+    #             100, seed=test_util.test_seed()), p)
+    #     self.assertIsNone(grad_p)
+
+    # def testSampleDeterministicScalarVsVector(self):
+    #     p = [0.2, 0.6]
+    #     dist = tfd.Bernoulli(probs=p, validate_args=True)
+    #     n = 1000
+    #     def _seed(seed=None):
+    #         seed = test_util.test_seed() if seed is None else seed
+    #         if tf.executing_eagerly():
+    #             tf1.set_random_seed(seed)
+    #         return seed
+    #     seed = _seed()
+    #     self.assertAllEqual(
+    #         self.evaluate(dist.sample(n, _seed(seed=seed))),
+    #         self.evaluate(dist.sample([n], _seed(seed=seed))))
+    #     n = tf1.placeholder_with_default(np.int32(1000), shape=None)
+    #     seed = _seed()
+    #     sample1 = dist.sample(n, _seed(seed=seed))
+    #     sample2 = dist.sample([n], _seed(seed=seed))
+    #     sample1, sample2 = self.evaluate([sample1, sample2])
+    #     self.assertAllEqual(sample1, sample2)
+
+    # def testMean(self):
+    #     p = np.array([[0.2, 0.7], [0.5, 0.4]], dtype=np.float32)
+    #     dist = tfd.Bernoulli(probs=p, validate_args=True)
+    #     self.assertAllEqual(self.evaluate(dist.mean()), p)
+
+    # def testVarianceAndStd(self):
+    #     var = lambda p: p * (1. - p)
+    #     p = [[0.2, 0.7], [0.5, 0.4]]
+    #     dist = tfd.Bernoulli(probs=p, validate_args=True)
+    #     self.assertAllClose(
+    #         self.evaluate(dist.variance()),
+    #         np.array([[var(0.2), var(0.7)], [var(0.5), var(0.4)]],
+    #                  dtype=np.float32))
+    #     self.assertAllClose(
+    #         self.evaluate(dist.stddev()),
+    #         np.array([[np.sqrt(var(0.2)), np.sqrt(var(0.7))],
+    #                   [np.sqrt(var(0.5)), np.sqrt(var(0.4))]],
+    #                  dtype=np.float32))
+
+    # def testVarianceWhenProbCloseToOne(self):
+    #     # Prob is very close to 1.0, so the naive 1 - p will be (numerically) 0,
+    #     # which would make variance zero.  Main point of this test is to verify that
+    #     # the variance is > 0 ... we also verify that variance is correct.
+    #
+    #     # tf.sigmoid(logits) is < float eps away from 1.0, which means the naive
+    #     # 1 - tf.sigmoid(logits) will result in 0.0, which is a loss of precision.
+    #     one_minus_prob_64 = np.float64(np.finfo(np.float32).eps) / 2
+    #     logits_32 = np.float32(np.log((1. - one_minus_prob_64) / one_minus_prob_64))
+    #
+    #     # Verify that this value of logits results in loss of precision for a naive
+    #     # implementation (justifying our "fancy" implementation of sigmoid(-logits))
+    #     self.assertAllEqual(0., 1 - tf.sigmoid(logits_32))
+    #
+    #     # See! This one weird trick fixes everything.  Asserts below check that we
+    #     # used the trick correctly in our code.
+    #     self.assertGreater(self.evaluate(tf.sigmoid(-logits_32)), 0.)
+    #
+    #     dist = tfd.Bernoulli(logits=logits_32)
+    #
+    #     expected_variance = np.float32(one_minus_prob_64 * (1 - one_minus_prob_64))
+    #
+    #     self.assertGreater(expected_variance, 0.)
+    #
+    #     self.assertAllClose(
+    #         dist.variance(),
+    #         expected_variance,
+    #         # Equivalent to atol=0, rtol=1e-6, but less likely to confuse which
+    #         # element is being used for the "r" in rtol.
+    #         # Note this also ensures dist.variance() > 0, which the naive
+    #         # implementation would not be able to do.
+    #         atol=expected_variance * 1e-6,
+    #         rtol=0,
+    #     )
+
+    # def testBernoulliBernoulliKL(self):
+    #     batch_size = 6
+    #     a_p = np.array([0.6] * batch_size, dtype=np.float32)
+    #     b_p = np.array([0.4] * batch_size, dtype=np.float32)
+    #
+    #     a = tfd.Bernoulli(probs=a_p, validate_args=True)
+    #     b = tfd.Bernoulli(probs=b_p, validate_args=True)
+    #
+    #     kl = tfd.kl_divergence(a, b)
+    #     kl_val = self.evaluate(kl)
+    #
+    #     kl_expected = (a_p * np.log(a_p / b_p) + (1. - a_p) * np.log(
+    #         (1. - a_p) / (1. - b_p)))
+    #
+    #     self.assertEqual(kl.shape, (batch_size,))
+    #     self.assertAllClose(kl_val, kl_expected)
+
+    # def testBernoulliBernoulliKLWhenProbOneIsOne(self):
+    #     # KL[a || b] = Pa * Log[Pa / Pb] + (1 - Pa) * Log[(1 - Pa) / (1 - Pb)]
+    #     # This is defined iff (Pb = 0 ==> Pa = 0) AND (Pb = 1 ==> Pa = 1).
+    #     a = tfd.Bernoulli(probs=[1., 1., 1.])
+    #     b = tfd.Bernoulli(probs=[0.5, 1., 0.])
+    #     kl_expected = [
+    #         # The (1 - Pa) term kills the entire second term.
+    #         1 * np.log(1 / 0.5) + 0,
+    #         # P[b = 0] = 0, and P[a = 0] = 0, so absolute continuity holds.
+    #         1 * np.log(1 / 1) + 0,
+    #         # P[b = 1] = 0, but P[a = 1] != 0, so not absolutely continuous.
+    #         # Some would argue that NaN would be more correct...
+    #         np.inf
+    #     ]
+    #     self.assertAllClose(self.evaluate(tfd.kl_divergence(a, b)), kl_expected)
+
+    # def testBernoulliBernoulliKLWhenProbOneIsZero(self):
+    #     # KL[a || b] = Pa * Log[Pa / Pb] + (1 - Pa) * Log[(1 - Pa) / (1 - Pb)]
+    #     # This is defined iff (Pb = 0 ==> Pa = 0) AND (Pb = 1 ==> Pa = 1).
+    #     a = tfd.Bernoulli(probs=[0., 0., 0.])
+    #     b = tfd.Bernoulli(probs=[0.5, 1., 0.])
+    #     kl_expected = [
+    #         # The Pa term kills the entire first term.
+    #         0 + 1 * np.log(1 / 0.5),
+    #         # P[b = 0] = 0, but P[a = 0] != 0, so not absolutely continuous.
+    #         # Some would argue that NaN would be more correct...
+    #         np.inf,
+    #         # P[b = 1] = 0, and P[a = 1] = 0, so absolute continuity holds.
+    #         0 + 1 * np.log(1 / 1)
+    #     ]
+    #     self.assertAllClose(self.evaluate(tfd.kl_divergence(a, b)), kl_expected)
+
+    # def testParamTensorFromLogits(self):
+    #     x = tf.constant([-1., 0.5, 1.])
+    #     d = tfd.ContinuousBernoulli(logits=x, validate_args=True)
+    #     logit = lambda x: tf.math.log(x) - tf.math.log1p(-x)
+    #     self.assertAllClose(
+    #         *self.evaluate([logit(d.prob(1.)), d.logits_parameter()]),
+    #         atol=0, rtol=1e-4)
+    #     self.assertAllClose(
+    #         *self.evaluate([d.prob(1.), d.probs_parameter()]),
+    #         atol=0, rtol=1e-4)
+
+    # def testParamTensorFromProbs(self):
+    #     x = tf.constant([0.1, 0.5, 0.4])
+    #     d = tfd.ContinuousBernoulli(lams=x, validate_args=True)
+    #     logit = lambda x: tf.math.log(x) - tf.math.log1p(-x)
+    #     self.assertAllClose(
+    #         *self.evaluate([logit(d.prob(1.)), d.logits_parameter()]),
+    #         atol=0, rtol=1e-4)
+    #     self.assertAllClose(
+    #         *self.evaluate([d.prob(1.), d.probs_parameter()]),
+    #         atol=0, rtol=1e-4)
+
+    # def testLogProbWithInfiniteLogits(self):
+    #     logits = [np.inf, -np.inf]  # probs = [1, 0].
+    #     dist = tfd.Bernoulli(logits=logits)
+    #     self.assertAllEqual([0., -np.inf], dist.log_prob([1., 1.]))
+    #     self.assertAllEqual([-np.inf, 0.], dist.log_prob([0., 0.]))
+    #     self.assertAllEqual([np.nan, np.nan], dist.log_prob([np.nan, np.nan]))
+
+    # def testLogProbWithZeroOrOneProbs(self):
+    #     probs = [1., 0.]  # logits = [np.inf, -np.inf]
+    #     dist = tfd.Bernoulli(probs=probs)
+    #     self.assertAllEqual([0., -np.inf], dist.log_prob([1., 1.]))
+    #     self.assertAllEqual([-np.inf, 0.], dist.log_prob([0., 0.]))
+    #     self.assertAllEqual([np.nan, np.nan], dist.log_prob([np.nan, np.nan]))
+
+    # @test_util.numpy_disable_gradient_test
+    # def testLogProbGrads(self):
+    #     # probs = [1/2, 1, 0].
+    #     logits = tf.constant([0., np.inf, -np.inf], dtype=tf.float32)
+    #     _, grad = tfp.math.value_and_gradient(
+    #         lambda x: -tfd.Bernoulli(logits=x).log_prob([1., 1., 0.]),
+    #         logits)
+    #
+    #     # For finite logits, the grad is as expected (finite...to get value do math)
+    #     # For infinite logits, you can reason that a small perturbation of the
+    #     # logits doesn't change anything (adding epsilon to +-Inf doesn't change
+    #     # it), and thus gradient = 0 is expected.
+    #     self.assertAllEqual(grad, [-0.5, 0., 0.])
+
+    # def testEntropyWithInfiniteLogits(self):
+    #     logits = [np.inf, -np.inf]  # probs = [1, 0]
+    #     dist = tfd.Bernoulli(logits=logits)
+    #     self.assertAllEqual([0., 0.], dist.entropy())
+
+    # def testEntropyWithZeroOneProbs(self):
+    #     probs = [1., 0.]  # logits = [np.inf, -np.inf]
+    #     dist = tfd.Bernoulli(probs=probs)
+    #     self.assertAllEqual([0., 0.], dist.entropy())
+
+    # def testMeanWithInfiniteLogits(self):
+    #     logits = [np.inf, -np.inf]  # probs = [1, 0]
+    #     dist = tfd.Bernoulli(logits=logits, validate_args=True)
+    #     self.assertAllEqual([1., 0.], dist.mean())
+
+
+class _MakeSlicer(object):
+
+    def __getitem__(self, slices):
+        return lambda x: x[slices]
+
+make_slicer = _MakeSlicer()
+
+
+@test_util.test_all_tf_execution_regimes
+class ContinuousBernoulliSlicingTest(test_util.TestCase):
+
+    def testScalarSlice(self):
+        logits = self.evaluate(tf.random.normal([], seed=test_util.test_seed()))
+        dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
+        self.assertAllEqual([], dist.batch_shape)
+        self.assertAllEqual([1], dist[tf.newaxis].batch_shape)
+        self.assertAllEqual([], dist[...].batch_shape)
+        self.assertAllEqual([1, 1], dist[tf.newaxis, ..., tf.newaxis].batch_shape)
+
+    def testSlice(self):
+        logits = self.evaluate(tf.random.normal(
+            [20, 3, 1, 5], seed=test_util.test_seed()))
+        dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
+        batch_shape = tensorshape_util.as_list(dist.batch_shape)
+        dist_noshape = tfd.ContinuousBernoulli(
+            logits=tf1.placeholder_with_default(logits, shape=None),
+            validate_args=True)
+
+        def check(*slicers):
+            for ds, assert_static_shape in (dist, True), (dist_noshape, False):
+                bs = batch_shape
+                prob = self.evaluate(dist.prob(0))
+                for slicer in slicers:
+                    ds = slicer(ds)
+                    bs = slicer(np.zeros(bs)).shape
+                    prob = slicer(prob)
+                    if assert_static_shape or tf.executing_eagerly():
+                        self.assertAllEqual(bs, ds.batch_shape)
+                    else:
+                        self.assertIsNone(tensorshape_util.rank(ds.batch_shape))
+                    self.assertAllEqual(bs, self.evaluate(ds.batch_shape_tensor()))
+                    self.assertAllClose(prob, self.evaluate(ds.prob(0)))
+
+        check(make_slicer[3])
+        check(make_slicer[tf.newaxis])
+        check(make_slicer[3::7])
+        check(make_slicer[:, :2])
+        check(make_slicer[tf.newaxis, :, ..., 0, :2])
+        check(make_slicer[tf.newaxis, :, ..., 3:, tf.newaxis])
+        check(make_slicer[..., tf.newaxis, 3:, tf.newaxis])
+        check(make_slicer[..., tf.newaxis, -3:, tf.newaxis])
+        check(make_slicer[tf.newaxis, :-3, tf.newaxis, ...])
+        def halfway(x):
+            if isinstance(x, tfd.ContinuousBernoulli):
+                return x.batch_shape_tensor()[0] // 2
+            return x.shape[0] // 2
+        check(lambda x: x[halfway(x)])
+        check(lambda x: x[:halfway(x)])
+        check(lambda x: x[halfway(x):])
+        check(make_slicer[:-3, tf.newaxis], make_slicer[..., 0, :2],
+              make_slicer[::2])
+        if tf.executing_eagerly(): return
+        with self.assertRaisesRegexp((ValueError, tf.errors.InvalidArgumentError),
+                                     'Index out of range.*input has only 4 dims'):
+            check(make_slicer[19, tf.newaxis, 2, ..., :, 0, 4])
+        with self.assertRaisesRegexp((ValueError, tf.errors.InvalidArgumentError),
+                                     'slice index.*out of bounds'):
+            check(make_slicer[..., 2, :])  # ...,1,5 -> 2 is oob.
+
+    def testSliceSequencePreservesOrigVarGradLinkage(self):
+        logits = tf.Variable(tf.random.normal(
+            [20, 3, 1, 5], seed=test_util.test_seed()))
+        self.evaluate(logits.initializer)
+        dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
+        for slicer in [make_slicer[:5], make_slicer[..., -1], make_slicer[:, 1::2]]:
+            with tf.GradientTape() as tape:
+                dist = slicer(dist)
+                lp = dist.log_prob(0.1)
+            dlpdlogits = tape.gradient(lp, logits)
+            self.assertIsNotNone(dlpdlogits)
+            self.assertGreater(
+                self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
+
+    def testSliceThenCopyPreservesOrigVarGradLinkage(self):
+        logits = tf.Variable(
+            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed()))
+        self.evaluate(logits.initializer)
+        dist = tfd.ContinuousBernoulli(logits=logits, validate_args=True)
+        dist = dist[:5]
+        with tf.GradientTape() as tape:
+            dist = dist.copy(name='contbern2')
+            lp = dist.log_prob(0.1)
+        dlpdlogits = tape.gradient(lp, logits)
+        self.assertIn('contbern2', dist.name)
+        self.assertIsNotNone(dlpdlogits)
+        self.assertGreater(
+            self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
+        with tf.GradientTape() as tape:
+            dist = dist[:3]
+            lp = dist.log_prob(0)
+        dlpdlogits = tape.gradient(lp, logits)
+        self.assertIn('contbern2', dist.name)
+        self.assertIsNotNone(dlpdlogits)
+        self.assertGreater(
+            self.evaluate(tf.reduce_sum(tf.abs(dlpdlogits))), 0)
+
+    def testCopyUnknownRank(self):
+        logits = tf1.placeholder_with_default(
+            tf.random.normal([20, 3, 1, 5], seed=test_util.test_seed()), shape=None)
+        dist = tfd.ContinuousBernoulli(logits=logits, name='cb1', validate_args=True)
+        self.assertIn('cb1', dist.name)
+        dist = dist.copy(name='cb2')
+        self.assertIn('cb2', dist.name)
+
+    def testSliceCopyOverrideNameSliceAgainCopyOverrideLogitsSliceAgain(self):
+        seed_stream = test_util.test_seed_stream('slice_continuous_bernoulli')
+        logits = tf.random.normal([20, 3, 2, 5], seed=seed_stream())
+        dist = tfd.ContinuousBernoulli(logits=logits, name='cb1', validate_args=True)
+        self.assertIn('cb1', dist.name)
+        dist = dist[:10].copy(name='cb2')
+        self.assertAllEqual((10, 3, 2, 5), dist.batch_shape)
+        self.assertIn('cb2', dist.name)
+        dist = dist.copy(name='cb3')[..., 1]
+        self.assertAllEqual((10, 3, 2), dist.batch_shape)
+        self.assertIn('cb3', dist.name)
+        dist = dist.copy(logits=tf.random.normal([2], seed=seed_stream()))
+        self.assertAllEqual((2,), dist.batch_shape)
+        self.assertIn('cb3', dist.name)
+
+    def testDocstrSliceExample(self):
+        # batch shape [3, 5, 7, 9]
+        cb = tfd.ContinuousBernoulli(logits=tf.zeros([3, 5, 7, 9]), validate_args=True)
+        self.assertAllEqual((3, 5, 7, 9), cb.batch_shape)
+        cb2 = cb[:, tf.newaxis, ..., -2:, 1::2]  # batch shape [3, 1, 5, 2, 4]
+        self.assertAllEqual((3, 1, 5, 2, 4), cb2.batch_shape)
+
+
+@test_util.test_all_tf_execution_regimes
+class ContinuousBernoulliFromVariableTest(test_util.TestCase):
+
+    @test_util.tf_tape_safety_test
+    def testGradientLogits(self):
+        x = tf.Variable([-1., 1])
+        self.evaluate(x.initializer)
+        d = tfd.ContinuousBernoulli(logits=x, validate_args=True)
+        with tf.GradientTape() as tape:
+            loss = -d.log_prob([0.1, 0.9])
+        g = tape.gradient(loss, d.trainable_variables)
+        self.assertLen(g, 1)
+        self.assertAllNotNone(g)
+
+    @test_util.tf_tape_safety_test
+    def testGradientProbs(self):
+        x = tf.Variable([0.1, 0.7])
+        self.evaluate(x.initializer)
+        d = tfd.ContinuousBernoulli(lams=x, validate_args=True)
+        with tf.GradientTape() as tape:
+            loss = -d.log_prob([0.1, 0.9])
+        g = tape.gradient(loss, d.trainable_variables)
+        self.assertLen(g, 1)
+        self.assertAllNotNone(g)
+
+
+if __name__ == '__main__':
+    tf.test.main()

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -94,7 +94,7 @@ def quantile(p, lams):
     ) / (np.log(lams) - np.log(1.0 - lams))
 
 
-#@test_util.test_all_tf_execution_regimes
+@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliTest(test_util.TestCase):
     def testLam(self):
         lam = [0.2, 0.4]
@@ -481,7 +481,7 @@ class _MakeSlicer(object):
 make_slicer = _MakeSlicer()
 
 
-#@test_util.test_all_tf_execution_regimes
+@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliSlicingTest(test_util.TestCase):
     def testScalarSlice(self):
         logits = self.evaluate(tf.random.normal([], seed=test_util.test_seed()))
@@ -638,7 +638,7 @@ class ContinuousBernoulliSlicingTest(test_util.TestCase):
         self.assertAllEqual((3, 1, 5, 2, 4), cb2.batch_shape)
 
 
-#@test_util.test_all_tf_execution_regimes
+@test_util.test_all_tf_execution_regimes
 class ContinuousBernoulliFromVariableTest(test_util.TestCase):
     @test_util.tf_tape_safety_test
     def testGradientLogits(self):


### PR DESCRIPTION
We recently had a NeurIPS paper (https://arxiv.org/abs/1907.06845 and https://papers.nips.cc/paper/9484-the-continuous-bernoulli-fixing-a-pervasive-error-in-variational-autoencoders) where we introduce a new (0,1)-supported distribution: the continuous Bernoulli. This pull request implements this distribution in tensorflow distributions, as well as a unit test for the continuous Bernoulli, which follows the unit test provided for the Bernoulli distribution (with appropriate modifications). Currently passing all the tests locally, except for a slicing test, where I get an error that I do not fully understand:

tensorflow.python.framework.errors_impl.UnimplementedError: Broadcast between [1,20,3,1,2,1] and [1,20,3,1,2,1] is not supported yet.