### PR TITLE
New blog URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ environment.
   or answer technical questions.
 * [GitHub](https://github.com/tensorflow/probability/issues): Report bugs or
   make feature requests.
-* [TensorFlow Blog](https://medium.com/tensorflow): Stay up to date on content
+* [TensorFlow Blog](https://blog.tensorflow.org/): Stay up to date on content
   from the TensorFlow team and best articles from the community.
 * [Youtube Channel](http://youtube.com/tensorflow/): Follow TensorFlow shows.
 * [tfprobability@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfprobability):


### PR DESCRIPTION
Apologies if you would prefer this request against a different branch. 

The new blog URL is https://blog.tensorflow.org/ and the README originally linked to https://medium.com/tensorflow. 
