### PR TITLE
Pixel cnn fixes 01

### DIFF
--- a/tensorflow_probability/python/distributions/pixel_cnn.py
+++ b/tensorflow_probability/python/distributions/pixel_cnn.py
@@ -122,9 +122,10 @@ class PixelCNN(distribution.Distribution):
   batch_size = 16
   train_it = train_data.map(image_preprocess).batch(batch_size).shuffle(1000)
 
+  image_shape = (28, 28, 1)
   # Define a Pixel CNN network
   dist = tfd.PixelCNN(
-      image_shape=(28, 28, 1),
+      image_shape=image_shape,
       num_resnet=1,
       num_hierarchies=2,
       num_filters=32,
@@ -133,7 +134,7 @@ class PixelCNN(distribution.Distribution):
   )
 
   # Define the model input
-  image_input = tfkl.Input(shape=input_shape)
+  image_input = tfkl.Input(shape=image_shape)
 
   # Define the log likelihood for the loss fn
   log_prob = dist.log_prob(image_input)

--- a/tensorflow_probability/python/distributions/pixel_cnn.py
+++ b/tensorflow_probability/python/distributions/pixel_cnn.py
@@ -444,7 +444,7 @@ class PixelCNN(distribution.Distribution):
       num_coeffs = num_channels * (num_channels - 1) // 2
       loc_tensors = tf.split(locs, num_channels, axis=-1)
       coef_tensors = tf.split(coeffs, num_coeffs, axis=-1)
-      channel_tensors = tf.split(value, num_channels, axis=-1)
+      channel_tensors = tf.split(transformed_value, num_channels, axis=-1)
 
       coef_count = 0
       for i in range(num_channels):

--- a/tensorflow_probability/python/distributions/pixel_cnn_test.py
+++ b/tensorflow_probability/python/distributions/pixel_cnn_test.py
@@ -60,7 +60,7 @@ class PixelCnnTest(test_util.TestCase):
         size=self.batch_shape + self.image_shape).astype(np.float32)
 
   def _make_fake_conditional(self):
-    return
+    return None
 
   def _make_fake_inputs(self):
     return self._make_fake_images()
@@ -70,7 +70,7 @@ class PixelCnnTest(test_util.TestCase):
 
   def _get_single_pixel_logit_gradients(self, dist, logit_ind, pixel_ind):
 
-    h = self._make_fake_conditional()
+    h = self._make_fake_conditional() # pylint: disable=assignment-from-none
     def g(x):
       x = (2. * (x - 0) / (self.high - 0)) - 1.
       inputs = [x, h] if h is not None else x
@@ -118,7 +118,7 @@ class PixelCnnTest(test_util.TestCase):
   def testLogProb(self):
     dist = self._make_pixel_cnn()
     images = self._make_fake_images()
-    h = self._make_fake_conditional()
+    h = self._make_fake_conditional() # pylint: disable=assignment-from-none
 
     self.evaluate([v.initializer for v in dist.network.weights])
     log_prob_values = self.evaluate(dist.log_prob(images, conditional_input=h))
@@ -131,7 +131,7 @@ class PixelCnnTest(test_util.TestCase):
   def testSample(self):
 
     num_samples = 2
-    h = self._make_fake_conditional()
+    h = self._make_fake_conditional() # pylint: disable=assignment-from-none
 
     # Weight normalization and data-dependent initialization work only in Eager
     # so we enable them only if executing eagerly. We use them only in this
@@ -220,7 +220,7 @@ class PixelCnnTest(test_util.TestCase):
 
   def testDtype(self):
     inputs = self._make_fake_images()
-    h = self._make_fake_conditional()
+    h = self._make_fake_conditional() # pylint: disable=assignment-from-none
     dist = self._make_pixel_cnn()
     num_samples = 4
 

--- a/tensorflow_probability/python/distributions/pixel_cnn_test.py
+++ b/tensorflow_probability/python/distributions/pixel_cnn_test.py
@@ -72,6 +72,7 @@ class PixelCnnTest(test_util.TestCase):
 
     h = self._make_fake_conditional()
     def g(x):
+      x = (2. * (x - 0) / (self.high - 0)) - 1.
       inputs = [x, h] if h is not None else x
       params = dist.network(inputs)
       out = self._apply_channel_conditioning(dist, x, *params)


### PR DESCRIPTION
Training multichannel images (using log_probability) used real pixel values instead of supposed transformed values. This caused green/blue channels to be wrongly used with coeffs, which resulted weird red images.

There seemed to be no 3 channel image example in the docs, but below is one way to test:
```
# Build a small Pixel CNN++ model to train on colored FASHION_MNIST.

import tensorflow as tf
import tensorflow_datasets as tfds
import tensorflow_probability as tfp

tfd = tfp.distributions
tfk = tf.keras
tfkl = tf.keras.layers

# Load FASHION_MNIST from tensorflow_datasets
data = tfds.load('fashion_mnist')
train_data, test_data = data['train'], data['test']

# Make colorful dataset by shifting blue channel pixel to right
def image_preprocess(x):
    x = tf.cast(x['image'], tf.float32)
    x_b = tf.roll(x, shift=1, axis=1)
    x = tf.concat((x, x, x_b), -1)
    return (x,)  # (input, output) of the model

batch_size = 16
train_it = train_data.map(image_preprocess).batch(batch_size).shuffle(1000)

image_shape = (28, 28, 3)
# Define a Pixel CNN network
dist = tfd.PixelCNN(
  image_shape=image_shape,
  num_resnet=1,
  num_hierarchies=2,
  num_filters=32,
  num_logistic_mix=5,
  dropout_p=.3,
)

# Define the model input
image_input = tfkl.Input(shape=image_shape)

# Define the log likelihood for the loss fn
log_prob = dist.log_prob(image_input)

# Define the model
model = tfk.Model(inputs=image_input, outputs=log_prob)
model.add_loss(-tf.reduce_mean(log_prob))

# Compile and train the model
model.compile(
    optimizer=tfk.optimizers.Adam(.001),
    metrics=[])

model.fit(train_it, epochs=8, verbose=True)

# sample five images from the trained model
samples = dist.sample(2)


```