### PR TITLE
Validate optimizer args

### DIFF
--- a/tensorflow_probability/python/optimizer/bfgs.py
+++ b/tensorflow_probability/python/optimizer/bfgs.py
@@ -78,6 +78,7 @@ def minimize(value_and_gradients_function,
              max_iterations=50,
              parallel_iterations=1,
              stopping_condition=None,
+             validate_args=True,
              name=None):
   """Applies the BFGS algorithm to minimize a differentiable function.
 
@@ -161,6 +162,10 @@ def minimize(value_and_gradients_function,
       which only stops when all batch members have either converged or failed.
       An alternative is tfp.optimizer.converged_any which stops as soon as one
       batch member has converged, or when all have failed.
+    validate_args: Python `bool`, default `True`. When `True` optimizer
+      parameters are checked for validity despite possibly degrading runtime
+      performance. When `False` invalid inputs may silently render incorrect
+      outputs.
     name: (Optional) Python str. The name prefixed to the ops created by this
       function. If not supplied, the default name 'minimize' is used.
 
@@ -226,7 +231,10 @@ def minimize(value_and_gradients_function,
           initial_inverse_hessian_estimate,
           dtype=dtype,
           name='initial_inv_hessian')
-      control_inputs = _inv_hessian_control_inputs(initial_inv_hessian)
+      if validate_args:
+        control_inputs = _inv_hessian_control_inputs(initial_inv_hessian)
+      else:
+        control_inputs = None
       hessian_shape = tf.concat([batch_shape, [domain_size, domain_size]], 0)
       initial_inv_hessian = tf.broadcast_to(initial_inv_hessian, hessian_shape)
 

--- a/tensorflow_probability/python/optimizer/bfgs_test.py
+++ b/tensorflow_probability/python/optimizer/bfgs_test.py
@@ -187,7 +187,7 @@ class BfgsTest(test_util.TestCase):
     self.assertTrue(results.converged)
     final_gradient = results.objective_gradient
     final_gradient_norm = _norm(final_gradient)
-    print (final_gradient_norm)
+    print(final_gradient_norm)
     self.assertLessEqual(final_gradient_norm, 1e-8)
     self.assertArrayNear(results.position, minimum, 1e-5)
 
@@ -258,7 +258,7 @@ class BfgsTest(test_util.TestCase):
       start = tf.constant(start, dtype=dtype)
       results = self.evaluate(tfp.optimizer.bfgs_minimize(
           himmelblau, initial_position=start, tolerance=1e-8))
-      print (results)
+      print(results)
       self.assertTrue(results.converged)
       self.assertArrayNear(results.position,
                            np.array(expected_minima, dtype=dtype),

--- a/tensorflow_probability/python/optimizer/bfgs_test.py
+++ b/tensorflow_probability/python/optimizer/bfgs_test.py
@@ -101,6 +101,11 @@ class BfgsTest(test_util.TestCase):
           quadratic, initial_position=start, tolerance=1e-8,
           initial_inverse_hessian_estimate=bad_inv_hessian))
 
+    # simply checking that this runs
+    _ = self.evaluate(tfp.optimizer.bfgs_minimize(
+        quadratic, initial_position=start, tolerance=1e-8,
+        initial_inverse_hessian_estimate=bad_inv_hessian, validate_args=False))
+
   def test_asymmetric_inverse_hessian_spec(self):
     """Checks that specifying a asymmetric inverse hessian fails."""
     minimum = np.array([1.0, 1.0], dtype=np.float32)


### PR DESCRIPTION
As per #764 this adds `validate_args=True` (so by default the previous behaviour is maintained) to `bfgs_minimize` to allow the option of experimenting with `@tf.function(experimental_compile=True)`.

@csuter tagging you incase this is at all useful for you.

Thanks!