### PR TITLE
Fix code examples in sample and dual_averaging_step

### DIFF
--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -166,7 +166,8 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
                                pkr.inner_results.log_accept_ratio])
 
   # ~0.75
-  p_accept = tf.math.exp(tfp.math.reduce_logmeanexp(tf.minimum(log_accept_ratio, 0.)))
+  p_accept = tf.math.exp(tfp.math.reduce_logmeanexp(tf.minimum(
+      log_accept_ratio, 0.)))
   ```
   #### References
 

--- a/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
+++ b/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py
@@ -166,7 +166,7 @@ class DualAveragingStepSizeAdaptation(kernel_base.TransitionKernel):
                                pkr.inner_results.log_accept_ratio])
 
   # ~0.75
-  p_accept = tf.math.exp(tfp.math.reduce_logmeanexp(min(log_accept_ratio, 0.)))
+  p_accept = tf.math.exp(tfp.math.reduce_logmeanexp(tf.minimum(log_accept_ratio, 0.)))
   ```
   #### References
 

--- a/tensorflow_probability/python/mcmc/sample.py
+++ b/tensorflow_probability/python/mcmc/sample.py
@@ -293,10 +293,10 @@ def sample_chain(
   _, log_accept_ratio = sample_chain(trace_fn=trace_log_accept_ratio)
   _, kernel_results = sample_chain(trace_fn=trace_everything)
 
-  acceptance_prob = tf.math.exp(tf.minimum(log_accept_ratio_, 0.))
+  acceptance_prob = tf.math.exp(tf.minimum(log_accept_ratio, 0.))
   # Equivalent to, but more efficient than:
   acceptance_prob = tf.math.exp(tf.minimum(
-      kernel_results.log_accept_ratio_, 0.))
+      kernel_results.log_accept_ratio, 0.))
   ```
 
   #### References


### PR DESCRIPTION
Fixed code examples in - 
 - [mcmc/sample.py](https://github.com/tensorflow/probability/blob/v0.9.0/tensorflow_probability/python/mcmc/sample.py#L296-L299)
 - [mcmc/dual_averaging_step_size_adaptation.py](https://github.com/tensorflow/probability/blob/v0.9.0/tensorflow_probability/python/mcmc/dual_averaging_step_size_adaptation.py#L169)