### PR TITLE
Fixed the example

### DIFF
--- a/tensorflow_probability/g3doc/api_docs/python/tfp/bijectors/MaskedAutoregressiveFlow.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/bijectors/MaskedAutoregressiveFlow.md
@@ -169,7 +169,7 @@ maf = tfd.TransformedDistribution(
 
 x = maf.sample()  # Expensive; uses `tf.while_loop`, no Bijector caching.
 maf.log_prob(x)   # Almost free; uses Bijector caching.
-maf.log_prob(tf.zeros([dims]))  # Cheap; no `tf.while_loop` despite no Bijector caching.
+maf.log_prob(tf.zeros(dims))  # Cheap; no `tf.while_loop` despite no Bijector caching.
 
 # [Papamakarios et al. (2016)][3] also describe an Inverse Autoregressive
 # Flow [(Kingma et al., 2016)][2]:
@@ -182,7 +182,7 @@ iaf = tfd.TransformedDistribution(
 
 x = iaf.sample()  # Cheap; no `tf.while_loop` despite no Bijector caching.
 iaf.log_prob(x)   # Almost free; uses Bijector caching.
-iaf.log_prob(tf.zeros([dims]))  # Expensive; uses `tf.while_loop`, no Bijector caching.
+iaf.log_prob(tf.zeros(dims))  # Expensive; uses `tf.while_loop`, no Bijector caching.
 
 # In many (if not most) cases the default `shift_and_log_scale_fn` will be a
 # poor choice. Here's an example of using a 'shift only' version and with a

--- a/tensorflow_probability/g3doc/api_docs/python/tfp/bijectors/MaskedAutoregressiveFlow.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/bijectors/MaskedAutoregressiveFlow.md
@@ -156,7 +156,7 @@ def inverse(y):
 tfd = tfp.distributions
 tfb = tfp.bijectors
 
-dims = 5
+dims = 2
 
 # A common choice for a normalizing flow is to use a Gaussian for the base
 # distribution. (However, any continuous distribution would work.) E.g.,
@@ -169,7 +169,7 @@ maf = tfd.TransformedDistribution(
 
 x = maf.sample()  # Expensive; uses `tf.while_loop`, no Bijector caching.
 maf.log_prob(x)   # Almost free; uses Bijector caching.
-maf.log_prob(0.)  # Cheap; no `tf.while_loop` despite no Bijector caching.
+maf.log_prob([0., 0.])  # Cheap; no `tf.while_loop` despite no Bijector caching.
 
 # [Papamakarios et al. (2016)][3] also describe an Inverse Autoregressive
 # Flow [(Kingma et al., 2016)][2]:
@@ -182,7 +182,7 @@ iaf = tfd.TransformedDistribution(
 
 x = iaf.sample()  # Cheap; no `tf.while_loop` despite no Bijector caching.
 iaf.log_prob(x)   # Almost free; uses Bijector caching.
-iaf.log_prob(0.)  # Expensive; uses `tf.while_loop`, no Bijector caching.
+iaf.log_prob([0., 0.])  # Expensive; uses `tf.while_loop`, no Bijector caching.
 
 # In many (if not most) cases the default `shift_and_log_scale_fn` will be a
 # poor choice. Here's an example of using a 'shift only' version and with a

--- a/tensorflow_probability/g3doc/api_docs/python/tfp/bijectors/MaskedAutoregressiveFlow.md
+++ b/tensorflow_probability/g3doc/api_docs/python/tfp/bijectors/MaskedAutoregressiveFlow.md
@@ -169,7 +169,7 @@ maf = tfd.TransformedDistribution(
 
 x = maf.sample()  # Expensive; uses `tf.while_loop`, no Bijector caching.
 maf.log_prob(x)   # Almost free; uses Bijector caching.
-maf.log_prob([0., 0.])  # Cheap; no `tf.while_loop` despite no Bijector caching.
+maf.log_prob(tf.zeros([dims]))  # Cheap; no `tf.while_loop` despite no Bijector caching.
 
 # [Papamakarios et al. (2016)][3] also describe an Inverse Autoregressive
 # Flow [(Kingma et al., 2016)][2]:
@@ -182,7 +182,7 @@ iaf = tfd.TransformedDistribution(
 
 x = iaf.sample()  # Cheap; no `tf.while_loop` despite no Bijector caching.
 iaf.log_prob(x)   # Almost free; uses Bijector caching.
-iaf.log_prob([0., 0.])  # Expensive; uses `tf.while_loop`, no Bijector caching.
+iaf.log_prob(tf.zeros([dims]))  # Expensive; uses `tf.while_loop`, no Bijector caching.
 
 # In many (if not most) cases the default `shift_and_log_scale_fn` will be a
 # poor choice. Here's an example of using a 'shift only' version and with a


### PR DESCRIPTION
Example didn't run previously with the higher dimension and non-matrix input to .log_prob()