### PR TITLE
Corrected example for batch_interp_regular_nd_grid function

### DIFF
--- a/tensorflow_probability/python/math/interpolation.py
+++ b/tensorflow_probability/python/math/interpolation.py
@@ -551,11 +551,11 @@ def batch_interp_regular_nd_grid(x,
   Interpolate a function of one variable.
 
   ```python
-  y_ref = tf.exp(tf.linspace(start=0., stop=10., 20))
+  y_ref = tf.exp(tf.linspace(start=0., stop=10., num=20))
 
   tfp.math.batch_interp_regular_nd_grid(
       # x.shape = [3, 1], x_ref_min/max.shape = [1].  Trailing `1` for `1-D`.
-      x=[[6.0], [0.5], [3.3]], x_ref_min=[0.], x_ref_max=[1.], y_ref=y_ref)
+      x=[[6.0], [0.5], [3.3]], x_ref_min=[0.], x_ref_max=[10.], y_ref=y_ref, axis=0)
   ==> approx [exp(6.0), exp(0.5), exp(3.3)]
   ```
 

--- a/tensorflow_probability/python/math/interpolation.py
+++ b/tensorflow_probability/python/math/interpolation.py
@@ -555,7 +555,8 @@ def batch_interp_regular_nd_grid(x,
 
   tfp.math.batch_interp_regular_nd_grid(
       # x.shape = [3, 1], x_ref_min/max.shape = [1].  Trailing `1` for `1-D`.
-      x=[[6.0], [0.5], [3.3]], x_ref_min=[0.], x_ref_max=[10.], y_ref=y_ref, axis=0)
+      x=[[6.0], [0.5], [3.3]], x_ref_min=[0.], x_ref_max=[10.], y_ref=y_ref,
+      axis=0)
   ==> approx [exp(6.0), exp(0.5), exp(3.3)]
   ```
 


### PR DESCRIPTION
1. SyntaxError: positional argument follows keyword argument
2. Wrong x_ref_max value (1, instead of 10)
3. Missing 1 required positional argument: 'axis'