### PR TITLE
Add bijectors: FillDiagonal and FillScaleDiagonal

### DIFF
--- a/tensorflow_probability/python/bijectors/BUILD
+++ b/tensorflow_probability/python/bijectors/BUILD
@@ -59,6 +59,8 @@ multi_substrate_py_library(
         ":exp",
         ":expm1",
         ":ffjord",
+        ":fill_diagonal",
+        ":fill_scale_diagonal",
         ":fill_scale_tril",
         ":fill_triangular",
         ":generalized_pareto",
@@ -397,6 +399,19 @@ multi_substrate_py_library(
 )
 
 multi_substrate_py_library(
+    name = "fill_diagonal",
+    srcs = ["fill_diagonal.py"],
+    deps = [
+        ":bijector",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:assert_util",
+        "//tensorflow_probability/python/internal:distribution_util",
+        "//tensorflow_probability/python/internal:tensorshape_util",
+    ],
+)
+
+multi_substrate_py_library(
     name = "generalized_pareto",
     srcs = ["generalized_pareto.py"],
     deps = [
@@ -612,6 +627,21 @@ multi_substrate_py_library(
         "//tensorflow_probability/python/internal:dtype_util",
         "//tensorflow_probability/python/internal:tensor_util",
         "//tensorflow_probability/python/internal:tensorshape_util",
+    ],
+)
+
+multi_substrate_py_library(
+    name = "fill_scale_diagonal",
+    srcs = ["fill_scale_diagonal.py"],
+    deps = [
+        ":affine_scalar",
+        ":chain",
+        ":fill_diagonal",
+        ":softplus",
+        ":transform_diagonal",
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:dtype_util",
+        "//tensorflow_probability/python/internal:tensor_util",
     ],
 )
 
@@ -1417,6 +1447,30 @@ multi_substrate_py_test(
 )
 
 multi_substrate_py_test(
+    name = "fill_diagonal_test",
+    size = "small",
+    srcs = ["fill_diagonal_test.py"],
+    deps = [
+        ":bijectors",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+multi_substrate_py_test(
+    name = "fill_scale_diagonal_test",
+    size = "small",
+    srcs = ["fill_scale_diagonal_test.py"],
+    deps = [
+        ":bijectors",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+multi_substrate_py_test(
     name = "sigmoid_test",
     size = "small",
     srcs = ["sigmoid_test.py"],
@@ -1628,6 +1682,10 @@ exports_files(
         "exp_test.py",
         "expm1.py",
         "expm1_test.py",
+        "fill_diagonal.py",
+        "fill_diagonal_test.py",
+        "fill_scale_diagonal.py",
+        "fill_scale_diagonal_test.py",
         "fill_scale_tril.py",
         "fill_scale_tril_test.py",
         "fill_triangular.py",

--- a/tensorflow_probability/python/bijectors/__init__.py
+++ b/tensorflow_probability/python/bijectors/__init__.py
@@ -38,6 +38,8 @@ from tensorflow_probability.python.bijectors.exp import Log
 from tensorflow_probability.python.bijectors.expm1 import Expm1
 from tensorflow_probability.python.bijectors.expm1 import Log1p
 from tensorflow_probability.python.bijectors.ffjord import FFJORD
+from tensorflow_probability.python.bijectors.fill_diagonal import FillDiagonal
+from tensorflow_probability.python.bijectors.fill_scale_diagonal import FillScaleDiagonal
 from tensorflow_probability.python.bijectors.fill_scale_tril import FillScaleTriL
 from tensorflow_probability.python.bijectors.fill_scale_tril import ScaleTriL
 from tensorflow_probability.python.bijectors.fill_triangular import FillTriangular
@@ -104,6 +106,8 @@ __all__ = [
     "Exp",
     "Expm1",
     "FFJORD",
+    "FillDiagonal",
+    "FillScaleDiagonal",
     "FillScaleTriL",
     "FillTriangular",
     "GeneralizedPareto",

--- a/tensorflow_probability/python/bijectors/fill_diagonal.py
+++ b/tensorflow_probability/python/bijectors/fill_diagonal.py
@@ -1,8 +1,25 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
 """FillDiagonal bijector."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import tensorflow.compat.v2 as tf
+
 from tensorflow_probability.python.bijectors import bijector
 from tensorflow_probability.python.internal import assert_util
 from tensorflow_probability.python.internal import tensorshape_util
@@ -11,7 +28,7 @@ __all__ = ["FillDiagonal"]
 
 
 class FillDiagonal(bijector.Bijector):
-  """Transforms vectors to diagonal matrices.
+    """Transforms vectors to diagonal matrices.
 
   Given input with shape `batch_shape + [d]`, produces output with
   shape `batch_shape + [d, d]`.
@@ -27,62 +44,62 @@ class FillDiagonal(bijector.Bijector):
 
   ```
   """
-  def __init__(self, validate_args=False, name="fill_diagonal"):
-    """Instantiates the `FillDiagonal` bijector.
+    def __init__(self, validate_args=False, name="fill_diagonal"):
+        """Instantiates the `FillDiagonal` bijector.
 
     Args:
       validate_args: Python `bool` indicating whether arguments should be
         checked for correctness.
       name: Python `str` name given to ops managed by this object.
     """
-    super(FillDiagonal, self).__init__(
-        forward_min_event_ndims=1,
-        inverse_min_event_ndims=2,
-        is_constant_jacobian=True,
-        validate_args=validate_args,
-        name=name,
-    )
+        super(FillDiagonal, self).__init__(
+            forward_min_event_ndims=1,
+            inverse_min_event_ndims=2,
+            is_constant_jacobian=True,
+            validate_args=validate_args,
+            name=name,
+        )
 
-  def _forward(self, x):
-    return tf.linalg.diag(x)
+    def _forward(self, x):
+        return tf.linalg.diag(x)
 
-  def _inverse(self, y):
-    return tf.linalg.diag_part(y)
+    def _inverse(self, y):
+        return tf.linalg.diag_part(y)
 
-  def _forward_log_det_jacobian(self, x):
-    return tf.zeros([], dtype=x.dtype)
+    def _forward_log_det_jacobian(self, x):
+        return tf.zeros([], dtype=x.dtype)
 
-  def _inverse_log_det_jacobian(self, y):
-    return tf.zeros([], dtype=y.dtype)
+    def _inverse_log_det_jacobian(self, y):
+        return tf.zeros([], dtype=y.dtype)
 
-  def _forward_event_shape(self, input_shape):
-    batch_shape, d = input_shape[:-1], tf.compat.dimension_value(
-        input_shape[-1])
-    return tensorshape_util.concatenate(batch_shape, [d, d])
+    def _forward_event_shape(self, input_shape):
+        batch_shape, d = input_shape[:-1], tf.compat.dimension_value(
+            input_shape[-1])
+        return tensorshape_util.concatenate(batch_shape, [d, d])
 
-  def _inverse_event_shape(self, output_shape):
-    batch_shape, n1, n2 = (
-        output_shape[:-2],
-        tf.compat.dimension_value(output_shape[-2]),
-        tf.compat.dimension_value(output_shape[-1]),
-    )
-    if n1 is None or n2 is None:
-      m = None
-    elif n1 != n2:
-      raise ValueError("Matrix must be square. (saw [{}, {}])".format(n1, n2))
-    else:
-      m = n1
-    return tensorshape_util.concatenate(batch_shape, [m])
+    def _inverse_event_shape(self, output_shape):
+        batch_shape, n1, n2 = (
+            output_shape[:-2],
+            tf.compat.dimension_value(output_shape[-2]),
+            tf.compat.dimension_value(output_shape[-1]),
+        )
+        if n1 is None or n2 is None:
+            m = None
+        elif n1 != n2:
+            raise ValueError("Matrix must be square. (saw [{}, {}])".format(n1, n2))
+        else:
+            m = n1
+        return tensorshape_util.concatenate(batch_shape, [m])
 
-  def _forward_event_shape_tensor(self, input_shape_tensor):
-    batch_shape, d = input_shape_tensor[:-1], input_shape_tensor[-1]
-    return tf.concat([batch_shape, [d, d]], axis=0)
+    def _forward_event_shape_tensor(self, input_shape_tensor):
+        batch_shape, d = input_shape_tensor[:-1], input_shape_tensor[-1]
+        return tf.concat([batch_shape, [d, d]], axis=0)
 
-  def _inverse_event_shape_tensor(self, output_shape_tensor):
-    batch_shape, n = output_shape_tensor[:-2], output_shape_tensor[-1]
-    if self.validate_args:
-      is_square_matrix = assert_util.assert_equal(
-          n, output_shape_tensor[-2], message="Matrix must be square.")
-      with tf.control_dependencies([is_square_matrix]):
-        n = tf.identity(n)
-    return tf.concat([batch_shape, [n]], axis=0)
+    def _inverse_event_shape_tensor(self, output_shape_tensor):
+        batch_shape, n = output_shape_tensor[:-2], output_shape_tensor[-1]
+        if self.validate_args:
+            is_square_matrix = assert_util.assert_equal(
+                n, output_shape_tensor[-2], message="Matrix must be square.")
+            with tf.control_dependencies([is_square_matrix]):
+                n = tf.identity(n)
+        return tf.concat([batch_shape, [n]], axis=0)

--- a/tensorflow_probability/python/bijectors/fill_diagonal.py
+++ b/tensorflow_probability/python/bijectors/fill_diagonal.py
@@ -1,0 +1,88 @@
+"""FillDiagonal bijector."""
+
+from __future__ import absolute_import, division, print_function
+
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python.bijectors import bijector
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import tensorshape_util
+
+__all__ = ["FillDiagonal"]
+
+
+class FillDiagonal(bijector.Bijector):
+  """Transforms vectors to diagonal matrices.
+
+  Given input with shape `batch_shape + [d]`, produces output with
+  shape `batch_shape + [d, d]`.
+
+  #### Example
+
+  ```python
+  b = tfb.FillDiagonal()
+  b.forward([1, 2, 3])
+  # ==> [[1, 0, 0],
+  #      [0, 2, 0],
+  #      [0, 0, 3]]
+
+  ```
+  """
+  def __init__(self, validate_args=False, name="fill_diagonal"):
+    """Instantiates the `FillDiagonal` bijector.
+
+    Args:
+      validate_args: Python `bool` indicating whether arguments should be
+        checked for correctness.
+      name: Python `str` name given to ops managed by this object.
+    """
+    super(FillDiagonal, self).__init__(
+        forward_min_event_ndims=1,
+        inverse_min_event_ndims=2,
+        is_constant_jacobian=True,
+        validate_args=validate_args,
+        name=name,
+    )
+
+  def _forward(self, x):
+    return tf.linalg.diag(x)
+
+  def _inverse(self, y):
+    return tf.linalg.diag_part(y)
+
+  def _forward_log_det_jacobian(self, x):
+    return tf.zeros([], dtype=x.dtype)
+
+  def _inverse_log_det_jacobian(self, y):
+    return tf.zeros([], dtype=y.dtype)
+
+  def _forward_event_shape(self, input_shape):
+    batch_shape, d = input_shape[:-1], tf.compat.dimension_value(
+        input_shape[-1])
+    return tensorshape_util.concatenate(batch_shape, [d, d])
+
+  def _inverse_event_shape(self, output_shape):
+    batch_shape, n1, n2 = (
+        output_shape[:-2],
+        tf.compat.dimension_value(output_shape[-2]),
+        tf.compat.dimension_value(output_shape[-1]),
+    )
+    if n1 is None or n2 is None:
+      m = None
+    elif n1 != n2:
+      raise ValueError("Matrix must be square. (saw [{}, {}])".format(n1, n2))
+    else:
+      m = n1
+    return tensorshape_util.concatenate(batch_shape, [m])
+
+  def _forward_event_shape_tensor(self, input_shape_tensor):
+    batch_shape, d = input_shape_tensor[:-1], input_shape_tensor[-1]
+    return tf.concat([batch_shape, [d, d]], axis=0)
+
+  def _inverse_event_shape_tensor(self, output_shape_tensor):
+    batch_shape, n = output_shape_tensor[:-2], output_shape_tensor[-1]
+    if self.validate_args:
+      is_square_matrix = assert_util.assert_equal(
+          n, output_shape_tensor[-2], message="Matrix must be square.")
+      with tf.control_dependencies([is_square_matrix]):
+        n = tf.identity(n)
+    return tf.concat([batch_shape, [n]], axis=0)

--- a/tensorflow_probability/python/bijectors/fill_diagonal.py
+++ b/tensorflow_probability/python/bijectors/fill_diagonal.py
@@ -24,7 +24,9 @@ from tensorflow_probability.python.bijectors import bijector
 from tensorflow_probability.python.internal import assert_util
 from tensorflow_probability.python.internal import tensorshape_util
 
-__all__ = ["FillDiagonal"]
+__all__ = [
+  "FillDiagonal",
+]
 
 
 class FillDiagonal(bijector.Bijector):

--- a/tensorflow_probability/python/bijectors/fill_diagonal_test.py
+++ b/tensorflow_probability/python/bijectors/fill_diagonal_test.py
@@ -1,0 +1,95 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for FillDiagonal bijector."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python import bijectors as tfb
+from tensorflow_probability.python.internal import tensorshape_util
+from tensorflow_probability.python.internal import test_util
+
+
+@test_util.test_all_tf_execution_regimes
+class FillDiagonalBijectorTest(test_util.TestCase):
+  """Tests the correctness of the FillDiagonal bijector."""
+
+  def testBijector(self):
+    x = np.float32(np.array([1., 2., 3.]))
+    y = np.float32(np.array([[1., 0.],
+                             [0., 2.]]))
+
+    b = tfb.FillDiagonal()
+
+    y_ = self.evaluate(b.forward(x))
+    self.assertAllClose(y, y_)
+
+    x_ = self.evaluate(b.inverse(y))
+    self.assertAllClose(x, x_)
+
+    fldj = self.evaluate(b.forward_log_det_jacobian(x, event_ndims=1))
+    self.assertAllClose(fldj, 0.)
+
+    ildj = self.evaluate(b.inverse_log_det_jacobian(y, event_ndims=2))
+    self.assertAllClose(ildj, 0.)
+
+  def testShape(self):
+    x_shape = tf.TensorShape([5, 4, 3])
+    y_shape = tf.TensorShape([5, 4, 3, 3])
+
+    b = tfb.FillDiagonal(validate_args=True)
+
+    x = tf.ones(shape=x_shape, dtype=tf.float32)
+    y_ = b.forward(x)
+    self.assertAllEqual(
+        tensorshape_util.as_list(y_.shape), tensorshape_util.as_list(y_shape))
+    x_ = b.inverse(y_)
+    self.assertAllEqual(
+        tensorshape_util.as_list(x_.shape), tensorshape_util.as_list(x_shape))
+
+    y_shape_ = b.forward_event_shape(x_shape)
+    self.assertAllEqual(
+        tensorshape_util.as_list(y_shape_), tensorshape_util.as_list(y_shape))
+    x_shape_ = b.inverse_event_shape(y_shape)
+    self.assertAllEqual(
+        tensorshape_util.as_list(x_shape_), tensorshape_util.as_list(x_shape))
+
+    y_shape_tensor = self.evaluate(
+        b.forward_event_shape_tensor(tensorshape_util.as_list(x_shape)))
+    self.assertAllEqual(y_shape_tensor, tensorshape_util.as_list(y_shape))
+    x_shape_tensor = self.evaluate(
+        b.inverse_event_shape_tensor(tensorshape_util.as_list(y_shape)))
+    self.assertAllEqual(x_shape_tensor, tensorshape_util.as_list(x_shape))
+
+  def testShapeError(self):
+
+    b = tfb.FillDiagonal(validate_args=True)
+
+    y_shape_bad = tf.TensorShape([5, 4, 3, 2])
+    with self.assertRaisesRegexp(ValueError, 'Matrix must be square'):
+      b.inverse_event_shape(y_shape_bad)
+    with self.assertRaisesOpError('Matrix must be square'):
+      self.evaluate(
+          b.inverse_event_shape_tensor(tensorshape_util.as_list(y_shape_bad)))
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/bijectors/fill_diagonal_test.py
+++ b/tensorflow_probability/python/bijectors/fill_diagonal_test.py
@@ -33,7 +33,7 @@ class FillDiagonalBijectorTest(test_util.TestCase):
   """Tests the correctness of the FillDiagonal bijector."""
 
   def testBijector(self):
-    x = np.float32(np.array([1., 2., 3.]))
+    x = np.float32(np.array([1., 2.]))
     y = np.float32(np.array([[1., 0.],
                              [0., 2.]]))
 

--- a/tensorflow_probability/python/bijectors/fill_scale_diagonal.py
+++ b/tensorflow_probability/python/bijectors/fill_scale_diagonal.py
@@ -1,0 +1,99 @@
+"""FillScaleDiagonal bijector."""
+
+from __future__ import absolute_import, division, print_function
+
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python.bijectors import chain
+from tensorflow_probability.python.bijectors import fill_diagonal
+from tensorflow_probability.python.bijectors import shift
+from tensorflow_probability.python.bijectors import softplus
+from tensorflow_probability.python.bijectors import transform_diagonal
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import tensor_util
+
+__all__ = ["FillScaleDiagonal"]
+
+
+class FillScaleDiagonal(chain.Chain):
+  """Transforms unconstrained vectors to Diag matrices with positive diagonal.
+  This is implemented as a simple `tfb.Chain` of `tfb.FillDiagonal`
+  followed by `tfb.TransformDiagonal`, and provided mostly as a
+  convenience. The default setup is somewhat opinionated, using a
+  Softplus transformation followed by a small shift (`1e-5`) which
+  attempts to avoid numerical issues from zeros on the diagonal.
+  #### Examples
+  ```python
+  tfb = tfp.distributions.bijectors
+  b = tfb.FillScaleDiagonal(
+       diag_bijector=tfb.Exp(),
+       diag_shift=None)
+  b.forward(x=[0., 0.])
+  # Result: [[1., 0.],
+  #          [0., 1.]]
+  b.inverse(y=[[1., 0],
+               [0, 2]])
+  # Result: [log(1), log(2)]
+  # Define a distribution over PSD matrices of shape `[3, 3]`,
+  # with `3` degrees of freedom.
+  dist = tfd.TransformedDistribution(
+          tfd.Normal(tf.zeros(3), tf.ones(3)),
+          tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleDiagonal()]))
+  # Using an identity transformation, FillScaleDiagonal is equivalent to
+  # tfb.FillDiagonal.
+  b = tfb.FillScaleDiagonal(
+       diag_bijector=tfb.Identity(),
+       diag_shift=None)
+  # For greater control over initialization, one can manually encode
+  # pre- and post- shifts inside of `diag_bijector`.
+  b = tfb.FillScaleDiagonal(
+       diag_bijector=tfb.Chain([
+         tfb.Shift(1e-3),
+         tfb.Softplus(),
+         tfb.Shift(0.5413)]),  # tfp.math.softplus_inverse(1.)
+                               #  = log(expm1(1.)) = 0.5413
+       diag_shift=None)
+  ```
+  """
+  def __init__(self,
+               diag_bijector=None,
+               diag_shift=1e-5,
+               validate_args=False,
+               name="fill_scale_diagonal"):
+    """Instantiates the `FillScaleDiagonal` bijector.
+    Args:
+      diag_bijector: `Bijector` instance, used to transform the output diagonal
+        to be positive.
+        Default value: `None` (i.e., `tfb.Softplus()`).
+      diag_shift: Float value broadcastable and added to all diagonal entries
+        after applying the `diag_bijector`. Setting a positive
+        value forces the output diagonal entries to be positive, but
+        prevents inverting the transformation for matrices with
+        diagonal entries less than this value.
+        Default value: `1e-5`.
+      validate_args: Python `bool` indicating whether arguments should be
+        checked for correctness.
+        Default value: `False` (i.e., arguments are not validated).
+      name: Python `str` name given to ops managed by this object.
+        Default value: `fill_scale_tril`.
+    """
+    with tf.name_scope(name) as name:
+      if diag_bijector is None:
+        diag_bijector = softplus.Softplus(validate_args=validate_args)
+
+      if diag_shift is not None:
+        dtype = dtype_util.common_dtype([diag_bijector, diag_shift],
+                                        tf.float32)
+        diag_shift = tensor_util.convert_nonref_to_tensor(
+            diag_shift, name="diag_shift", dtype=dtype)
+        diag_bijector = chain.Chain(
+            [shift.Shift(shift=diag_shift), diag_bijector])
+
+      super(FillScaleDiagonal, self).__init__(
+          [
+              transform_diagonal.TransformDiagonal(
+                  diag_bijector=diag_bijector),
+              fill_diagonal.FillDiagonal()
+          ],
+          validate_args=validate_args,
+          name=name,
+      )

--- a/tensorflow_probability/python/bijectors/fill_scale_diagonal.py
+++ b/tensorflow_probability/python/bijectors/fill_scale_diagonal.py
@@ -1,6 +1,22 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
 """FillScaleDiagonal bijector."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import tensorflow.compat.v2 as tf
 from tensorflow_probability.python.bijectors import chain
@@ -11,11 +27,13 @@ from tensorflow_probability.python.bijectors import transform_diagonal
 from tensorflow_probability.python.internal import dtype_util
 from tensorflow_probability.python.internal import tensor_util
 
-__all__ = ["FillScaleDiagonal"]
+__all__ = [
+  "FillScaleDiagonal",
+]
 
 
 class FillScaleDiagonal(chain.Chain):
-  """Transforms unconstrained vectors to Diag matrices with positive diagonal.
+    """Transforms unconstrained vectors to Diag matrices with positive diagonal.
   This is implemented as a simple `tfb.Chain` of `tfb.FillDiagonal`
   followed by `tfb.TransformDiagonal`, and provided mostly as a
   convenience. The default setup is somewhat opinionated, using a
@@ -54,12 +72,12 @@ class FillScaleDiagonal(chain.Chain):
        diag_shift=None)
   ```
   """
-  def __init__(self,
-               diag_bijector=None,
-               diag_shift=1e-5,
-               validate_args=False,
-               name="fill_scale_diagonal"):
-    """Instantiates the `FillScaleDiagonal` bijector.
+    def __init__(self,
+                 diag_bijector=None,
+                 diag_shift=1e-5,
+                 validate_args=False,
+                 name="fill_scale_diagonal"):
+        """Instantiates the `FillScaleDiagonal` bijector.
     Args:
       diag_bijector: `Bijector` instance, used to transform the output diagonal
         to be positive.
@@ -76,24 +94,24 @@ class FillScaleDiagonal(chain.Chain):
       name: Python `str` name given to ops managed by this object.
         Default value: `fill_scale_diagonal`.
     """
-    with tf.name_scope(name) as name:
-      if diag_bijector is None:
-        diag_bijector = softplus.Softplus(validate_args=validate_args)
+        with tf.name_scope(name) as name:
+            if diag_bijector is None:
+                diag_bijector = softplus.Softplus(validate_args=validate_args)
 
-      if diag_shift is not None:
-        dtype = dtype_util.common_dtype([diag_bijector, diag_shift],
-                                        tf.float32)
-        diag_shift = tensor_util.convert_nonref_to_tensor(
-            diag_shift, name="diag_shift", dtype=dtype)
-        diag_bijector = chain.Chain(
-            [shift.Shift(shift=diag_shift), diag_bijector])
+            if diag_shift is not None:
+                dtype = dtype_util.common_dtype([diag_bijector, diag_shift],
+                                                tf.float32)
+                diag_shift = tensor_util.convert_nonref_to_tensor(
+                    diag_shift, name="diag_shift", dtype=dtype)
+                diag_bijector = chain.Chain(
+                    [shift.Shift(shift=diag_shift), diag_bijector])
 
-      super(FillScaleDiagonal, self).__init__(
-          [
-              transform_diagonal.TransformDiagonal(
-                  diag_bijector=diag_bijector),
-              fill_diagonal.FillDiagonal()
-          ],
-          validate_args=validate_args,
-          name=name,
-      )
+            super(FillScaleDiagonal, self).__init__(
+                [
+                    transform_diagonal.TransformDiagonal(
+                        diag_bijector=diag_bijector),
+                    fill_diagonal.FillDiagonal()
+                ],
+                validate_args=validate_args,
+                name=name,
+            )

--- a/tensorflow_probability/python/bijectors/fill_scale_diagonal.py
+++ b/tensorflow_probability/python/bijectors/fill_scale_diagonal.py
@@ -74,7 +74,7 @@ class FillScaleDiagonal(chain.Chain):
         checked for correctness.
         Default value: `False` (i.e., arguments are not validated).
       name: Python `str` name given to ops managed by this object.
-        Default value: `fill_scale_tril`.
+        Default value: `fill_scale_diagonal`.
     """
     with tf.name_scope(name) as name:
       if diag_bijector is None:

--- a/tensorflow_probability/python/bijectors/fill_scale_diagonal_test.py
+++ b/tensorflow_probability/python/bijectors/fill_scale_diagonal_test.py
@@ -31,7 +31,7 @@ class FillScaleDiagonalBijectorTest(test_util.TestCase):
 
   def testComputesCorrectValues(self):
     shift = 1.61803398875
-    x = np.float32(np.array([-1, .5, 2]))
+    x = np.float32(np.array([-1, 2]))
     y = np.float32(np.array([[np.exp(-1) + shift, 0.],
                              [0., np.exp(2) + shift]]))
 

--- a/tensorflow_probability/python/bijectors/fill_scale_diagonal_test.py
+++ b/tensorflow_probability/python/bijectors/fill_scale_diagonal_test.py
@@ -1,0 +1,67 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for FillScaleDiagonal bijector."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+import numpy as np
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python import bijectors as tfb
+from tensorflow_probability.python.internal import test_util
+
+
+@test_util.test_all_tf_execution_regimes
+class FillScaleDiagonalBijectorTest(test_util.TestCase):
+  """Tests the correctness of the FillScaleDiagonal bijector."""
+
+  def testComputesCorrectValues(self):
+    shift = 1.61803398875
+    x = np.float32(np.array([-1, .5, 2]))
+    y = np.float32(np.array([[np.exp(-1) + shift, 0.],
+                             [0., np.exp(2) + shift]]))
+
+    b = tfb.FillScaleDiagonal(
+        diag_bijector=tfb.Exp(), diag_shift=shift)
+
+    y_ = self.evaluate(b.forward(x))
+    self.assertAllClose(y, y_, rtol=1e-4)
+
+    x_ = self.evaluate(b.inverse(y))
+    self.assertAllClose(x, x_, rtol=1e-4)
+
+  def testInvertible(self):
+
+    # Generate random inputs from an unconstrained space, with
+    # event size 6 to specify 3x3 triangular matrices.
+    batch_shape = [2, 1]
+    x = np.random.randn(*(batch_shape + [3])).astype(np.float32)
+    b = tfb.FillScaleDiagonal(
+        diag_bijector=tfb.Softplus(), diag_shift=3.14159)
+    y = self.evaluate(b.forward(x))
+    self.assertAllEqual(y.shape, batch_shape + [3, 3])
+
+    x_ = self.evaluate(b.inverse(y))
+    self.assertAllClose(x, x_, rtol=1e-4)
+
+    fldj = self.evaluate(b.forward_log_det_jacobian(x, event_ndims=1))
+    ildj = self.evaluate(b.inverse_log_det_jacobian(y, event_ndims=2))
+    self.assertAllClose(fldj, -ildj, rtol=1e-4)
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Following #791, this implements the `FillDiagonal` and `FillScaleDiagonal` bijectors.
I also added some tests, similar to those for `FillTriangular` and `FillScaleTriL`.