### PR TITLE
Fix bug in which `concat` wrongly interprets empty static shape as having float dtype

### DIFF
--- a/tensorflow_probability/python/distributions/linear_gaussian_ssm.py
+++ b/tensorflow_probability/python/distributions/linear_gaussian_ssm.py
@@ -1078,11 +1078,12 @@ class LinearGaussianStateSpaceModel(distribution.Distribution):
       # than the distribution, we'll need to draw extra samples to match.
       result_sample_and_batch_shape = prefer_static.concat([
           distribution_util.expand_to_vector(sample_shape),
-          functools.reduce(prefer_static.broadcast_shape, [
+          tf.convert_to_tensor(
+            functools.reduce(prefer_static.broadcast_shape, [
               prefer_static.shape(x)[:-2],
               prefer_static.shape(mask)[:-1] if mask is not None else [],
-              batch_shape,
-          ])], axis=0)
+              batch_shape]), dtype_hint=tf.int32)
+          ], axis=0)
       sample_size = tf.cast(
           prefer_static.reduce_prod(result_sample_and_batch_shape) /
           prefer_static.reduce_prod(batch_shape), tf.int32)

--- a/tensorflow_probability/python/distributions/linear_gaussian_ssm_test.py
+++ b/tensorflow_probability/python/distributions/linear_gaussian_ssm_test.py
@@ -992,6 +992,10 @@ class KalmanSmootherTest(test_util.TestCase):
         dtype=np.float32)  # shape = [1, 5, 2]
     mask = np.array([[[False, False, True, False, False]]])  # shape = [1, 1, 5]
 
+    single_posterior_sample = kf.posterior_sample(
+        obs[0, ...], [], seed=test_util.test_seed(), mask=mask[0, 0, :])
+    self.assertAllEqual(single_posterior_sample.shape, [5, 3])
+
     sample_shape = [8000, 2]
     posterior_samples = kf.posterior_sample(
         obs, sample_shape, seed=test_util.test_seed(), mask=mask)


### PR DESCRIPTION
Brought up by https://stackoverflow.com/questions/60237047/how-to-decompose-and-visualise-slope-component-in-tensorflow-probability/60253426#60253426.