### PR TITLE
fix prob batch shape bug in OrderedLogistic and fix out-of-bound category probs

### DIFF
--- a/tensorflow_probability/python/distributions/distribution_properties_test.py
+++ b/tensorflow_probability/python/distributions/distribution_properties_test.py
@@ -163,7 +163,6 @@ SAMPLE_AUTOVECTORIZATION_IS_BROKEN = [
     'DirichletMultinomial',  # No converter for TensorListFromTensor
     'FiniteDiscrete',  # No converter for SparseSoftmaxCrossEntropyWithLogits
     'Multinomial',  # No converter for TensorListFromTensor
-    'OrderedLogistic',  # No converter for SparseSoftmaxCrossEntropyWithLogits
     'PlackettLuce',  # No converter for TopKV2
     'TruncatedNormal',  # No converter for ParameterizedTruncatedNormal
     'VonMises',  # No converter for While
@@ -179,7 +178,6 @@ LOGPROB_AUTOVECTORIZATION_IS_BROKEN = [
     'NegativeBinomial',  # Numeric inconsistency: b/147743999
     'Multinomial',  # Seemingly runs, but gives `NaN`s sometimes.
     'OneHotCategorical',  # Seemingly runs, but gives `NaN`s sometimes.
-    'OrderedLogistic',  # No converter for SparseSoftmaxCrossEntropyWithLogits
     'PlackettLuce',  # Shape error because pfor gather ignores `batch_dims`.
     'ProbitBernoulli',  # Seemingly runs, but gives `NaN`s sometimes.
     'TruncatedNormal',  # Numerical problem: b/145554459

--- a/tensorflow_probability/python/distributions/ordered_logistic.py
+++ b/tensorflow_probability/python/distributions/ordered_logistic.py
@@ -38,13 +38,11 @@ from tensorflow_probability.python.internal import tensorshape_util
 
 def _broadcast_cat_event_and_params(event, params, base_dtype):
   """Broadcasts the event or distribution parameters."""
-  if dtype_util.is_integer(event.dtype):
-    pass
-  elif dtype_util.is_floating(event.dtype):
+  if dtype_util.is_floating(event.dtype):
     # When `validate_args=True` we've already ensured int/float casting
     # is closed.
     event = tf.cast(event, dtype=tf.int32)
-  else:
+  elif not dtype_util.is_integer(event.dtype):
     raise TypeError('`value` should have integer `dtype` or '
                     '`self.dtype` ({})'.format(base_dtype))
   shape_known_statically = (

--- a/tensorflow_probability/python/distributions/ordered_logistic.py
+++ b/tensorflow_probability/python/distributions/ordered_logistic.py
@@ -256,8 +256,7 @@ class OrderedLogistic(distribution.Distribution):
 
   def categorical_log_probs(self):
     """Log probabilities for the `K+1` ordered categories."""
-    log_survival = tf.math.log_sigmoid(
-        self.loc[..., tf.newaxis] - self._augmented_cutpoints())
+    log_survival = self._augmented_log_survival_function()
     return tfp_math.log_sub_exp(
         log_survival[..., :-1], log_survival[..., 1:])
 

--- a/tensorflow_probability/python/distributions/ordered_logistic.py
+++ b/tensorflow_probability/python/distributions/ordered_logistic.py
@@ -254,7 +254,8 @@ class OrderedLogistic(distribution.Distribution):
 
   def categorical_log_probs(self):
     """Log probabilities for the `K+1` ordered categories."""
-    log_survival = self._augmented_log_survival_function()
+    log_survival = tf.math.log_sigmoid(
+        self.loc[..., tf.newaxis] - self._augmented_cutpoints())
     return tfp_math.log_sub_exp(
         log_survival[..., :-1], log_survival[..., 1:])
 
@@ -268,10 +269,6 @@ class OrderedLogistic(distribution.Distribution):
         prefer_static.shape(cutpoints[..., :1]),
         tf.constant(np.inf, dtype=cutpoints.dtype))
     return tf.concat([-inf, cutpoints, inf], axis=-1)
-
-  def _augmented_log_survival_function(self):
-    return tf.math.log_sigmoid(
-        self.loc[..., tf.newaxis] - self._augmented_cutpoints())
 
   def _num_categories(self):
     return prefer_static.shape(self.cutpoints, out_type=self.dtype)[-1] + 1
@@ -310,7 +307,8 @@ class OrderedLogistic(distribution.Distribution):
     num_categories = self._num_categories()
     x, augmented_log_survival = _broadcast_cat_event_and_params(
         event=x,
-        params=self._augmented_log_survival_function(),
+        params=tf.math.log_sigmoid(
+            self.loc[..., tf.newaxis] - self._augmented_cutpoints()),
         base_dtype=dtype_util.base_dtype(self.dtype))
     x_flat = tf.reshape(x, [-1, 1])
     augmented_log_survival_flat = tf.reshape(
@@ -339,7 +337,8 @@ class OrderedLogistic(distribution.Distribution):
     num_categories = self._num_categories()
     x, augmented_log_survival = _broadcast_cat_event_and_params(
         event=x,
-        params=self._augmented_log_survival_function(),
+        params=tf.math.log_sigmoid(
+            self.loc[..., tf.newaxis] - self._augmented_cutpoints()),
         base_dtype=dtype_util.base_dtype(self.dtype))
     x_flat = tf.reshape(x, [-1, 1])
     augmented_log_survival_flat = tf.reshape(


### PR DESCRIPTION
Hi,

Unfortunately when I was coding up some MCMC stuff using `tfd.OrderedLogistic` I couldn't get it to work and realised the code I had previously submitted wasn't quite fit for purpose - sorry about that.

I've added some more tests which show this and I've changed the code to make them pass. Unfortunately it is a bit more complicated and slower now. I also copy-pasted the `_broadcast_cat_event_and_params` from categorical.py - hope that is OK. The broadcast/flatten/gather pattern is also based on the cdf code in categorical.py.

Thanks again!