### PR TITLE
Removed unnecessary 'output' variable in _test_grad_finite()

### DIFF
--- a/tensorflow_probability/python/internal/special_math_test.py
+++ b/tensorflow_probability/python/internal/special_math_test.py
@@ -185,8 +185,6 @@ class NdtrGradientTest(test_util.TestCase):
 
   def _test_grad_finite(self, dtype):
     x = tf.constant([-100., 0., 100.], dtype=dtype)
-    output = (special_math.log_ndtr(x) if self._use_log
-              else special_math.ndtr(x))
     fn = special_math.log_ndtr if self._use_log else special_math.ndtr
     # Not having the lambda sanitzer means we'd get an `IndexError` whenever
     # the user supplied function has default args.


### PR DESCRIPTION
Hello,
The assignment to `output` is unnecessary as it is redefined in line 193 before the value is used. This makes the first assignment useless.

https://github.com/tensorflow/probability/blob/ab414b238654db5fe7749a6cb5ad2e0855e908e4/tensorflow_probability/python/internal/special_math_test.py#L186-L197

This is a common weakness enumeration based on https://cwe.mitre.org/data/definitions/563.html