### PR TITLE
Add a cross_entropy_with_quantiles method

### DIFF
--- a/tensorflow_probability/python/distributions/exponential.py
+++ b/tensorflow_probability/python/distributions/exponential.py
@@ -122,7 +122,7 @@ class Exponential(gamma.Gamma):
 
   def _log_survival_function(self, value):
     rate = tf.convert_to_tensor(self._rate)
-    return self._log_prob(value, rate=rate) - tf.math.log(rate)
+    return - value * rate
 
   def _sample_n(self, n, seed=None):
     rate = tf.convert_to_tensor(self.rate)


### PR DESCRIPTION
- Make use of log_cdf and log_survival_function to comput the cross entropy  and avoid numerical overflow.

- Test it with the exponential distribution

- Improve log_survival_function of the exponential distribution