### PR TITLE
fix: Use ascending sort for percentile

### DIFF
--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -552,7 +552,7 @@ def percentile(x,
 
     # Sort (in ascending order) everything which allows multiple calls to sort
     # only once (under the hood) and use CSE.
-    sorted_y = _sort_tensor(y)
+    sorted_y = tf.sort(y, axis=-1, direction='ASCENDING')
 
     d = tf.cast(tf.shape(y)[-1], tf.float64)
 
@@ -893,11 +893,3 @@ def _move_dims_to_flat_end(x, axis, x_ndims, right_end=True):
     full_shape = tf.concat(
         [other_shape, [-1]] if right_end else [[-1], other_shape], axis=0)
   return tf.reshape(x_permed, shape=full_shape)
-
-
-def _sort_tensor(tensor):
-  """Use `sort` to sort a `Tensor` in ascending order along
-     the last dimension."""
-  sorted_ = tf.sort(tensor, axis=-1, direction='ASCENDING')
-  tensorshape_util.set_shape(sorted_, tensor.shape)
-  return sorted_

--- a/tensorflow_probability/python/stats/quantiles_test.py
+++ b/tensorflow_probability/python/stats/quantiles_test.py
@@ -720,6 +720,15 @@ class PercentileTestWithNearestInterpolation(test_util.TestCase):
       self.assertAllEqual((), pct.shape)
       self.assertAllClose(expected_percentile, self.evaluate(pct))
 
+  def test_one_dim_numpy_docs_example(self):
+    x = [[10.0, 7.0, 4.0], [3.0, 2.0, 1.0]]
+    for q in [0, 10.1, 25.1, 49.9, 50.0, 50.1, 50.01, 89, 100]:
+      expected_percentile = np.percentile(
+          x, q=q, interpolation=self._interpolation)
+      pct = tfp.stats.percentile(x, q=q, interpolation=self._interpolation)
+      self.assertAllEqual((), pct.shape)
+      self.assertAllClose(expected_percentile, self.evaluate(pct))
+
   def test_invalid_interpolation_raises(self):
     x = [1., 5., 3., 2., 4.]
     with self.assertRaisesRegexp(ValueError, 'interpolation'):


### PR DESCRIPTION
Resolves #864

This changes the behavior of `percentile` and `quantiles`, as previously the sort order had been descending. This is being changed as it differs in behavior from [NumPy's `percentile` function](https://numpy.org/doc/1.18/reference/generated/numpy.percentile.html) and the docstring describes behavior that is consistent with NumPy's implementation.

The main change occurs replacing `_sort_tensor` with a single call to [`tf.sort`](https://www.tensorflow.org/versions/r2.1/api_docs/python/tf/sort), which is then used in `percentile`. In `_sort_tensor` [`tf.math.top_k`](https://www.tensorflow.org/versions/r2.1/api_docs/python/tf/math/top_k) (which results in descending sort) was used. When swapped for [`tf.sort`](https://www.tensorflow.org/versions/r2.1/api_docs/python/tf/sort) (with the default values of `k=-1, direction='ASCENDING'` explicitly passed to make the behavior more clear to a reader) there is no longer a need to ensure that the output is reshaped properly. As `_sort_tensor` is now just a single function call it is then removed in favor of `tf.sort`. This then necessitates the change in definition of `frac_at_q_or_above` such that it is renamed to `frac_at_q_or_above` and the swap of `tf.math.ceil` and `tf.math.floor`.

This could have also been achieved with

```python
sorted_, _ = tf.math.top_k(tensor, k=tf.shape(tensor)[-1])
sorted_ = tf.reverse(sorted_, [-1])
```

but as there doesn't seem to be a clear reason to use `tf.math.top_k` over `tf.sort`, one function call seemed preferable to two.

A test is also added that validates the edge case discussed in Issue #864 that prompted this PR.

cc @lukasheinrich @kratsg