### PR TITLE
Handle app flags in pytest session hook to fix CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,3 +18,9 @@ collect_ignore = [
     "setup.py",
     "tensorflow_probability/python/experimental/substrates/"
 ]
+
+def pytest_sessionstart(session):
+  from absl import app
+  # Unlike bazel, `pytest` doesn't invoke `tf.test.run()` (which parses flags), so
+  # for external developers using pytest we just parse the flags directly.
+  app._register_and_parse_flags_with_usage()  # pylint: disable=protected-access

--- a/conftest.py
+++ b/conftest.py
@@ -13,14 +13,26 @@
 # limitations under the License.
 # ============================================================================
 """Blacklist for pytest."""
+
+from absl import app
+
+
 collect_ignore = [
     "discussion/",
     "setup.py",
     "tensorflow_probability/python/experimental/substrates/"
 ]
 
-def pytest_sessionstart(session):
-  from absl import app
-  # Unlike bazel, `pytest` doesn't invoke `tf.test.run()` (which parses flags), so
-  # for external developers using pytest we just parse the flags directly.
-  app._register_and_parse_flags_with_usage()  # pylint: disable=protected-access
+def pytest_addoption(parser):
+  parser.addoption(
+      "--absl-flag",
+      action="append",
+      help="flag to be passed to absl, e.g. `--absl-flag='--vary_seed'`",
+      default=[]
+  )
+
+def pytest_collection_finish(session):
+  # Unlike bazel, `pytest` doesn't invoke `tf.test.run()` (which parses flags),
+  # so for external developers using pytest we just parse the flags directly.
+  absl_flags = session.config.getoption('absl_flag', default=[])
+  app._register_and_parse_flags_with_usage(['test.py'] + absl_flags)  # pylint: disable=protected-access

--- a/tensorflow_probability/python/internal/test_util.py
+++ b/tensorflow_probability/python/internal/test_util.py
@@ -147,7 +147,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
     if overall_exception:
       final_msg += str(overall_exception)
       raise AssertionError(final_msg)
-    elif exceptions_with_paths:
+    if exceptions_with_paths:
       for i, one_structure in enumerate(structure):
         final_msg += 'Structure {}:\n{}\n\n'.format(i, one_structure)
       final_msg += 'Exceptions:\n\n'

--- a/tensorflow_probability/python/internal/test_util.py
+++ b/tensorflow_probability/python/internal/test_util.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 import contextlib
 import os
-import sys
 import unittest
 
 from absl import flags

--- a/tensorflow_probability/python/internal/test_util.py
+++ b/tensorflow_probability/python/internal/test_util.py
@@ -23,7 +23,6 @@ import os
 import sys
 import unittest
 
-from absl import app
 from absl import flags
 from absl import logging
 from absl.testing import parameterized
@@ -71,11 +70,6 @@ flags.DEFINE_bool('vary_seed', False,
 flags.DEFINE_string('fixed_seed', None,
                     ('PRNG seed to initialize every test with.  '
                      'Takes precedence over --vary-seed when both appear.'))
-
-# Unlike bazel, `pytest` doesn't invoke `tf.test.run()` (which parses flags), so
-# for external developers using pytest we just parse the flags directly.
-if 'pytest' in sys.modules:
-  app._register_and_parse_flags_with_usage()  # pylint: disable=protected-access
 
 
 class TestCase(tf.test.TestCase, parameterized.TestCase):


### PR DESCRIPTION
Not sure how flags were passed under pytest before, I got `unrecognized argument` error even on master. So added `--absl-flag` option to `pytest` which can be used as
```
pytest tensorflow_probability/python/distributions/mixture_same_family_test.py --absl-flag='--vary_seed'
```