### PR TITLE
docs: Advocate for tf-nightly install for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ cd probability
 bazel build --copt=-O3 --copt=-march=native :pip_pkg
 PKGDIR=$(mktemp -d)
 ./bazel-bin/pip_pkg $PKGDIR
-pip install --user --upgrade $PKGDIR/*.whl
+python -m pip install --upgrade --user $PKGDIR/*.whl
 ```
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -158,10 +158,13 @@ python -m pip install --upgrade --user tf-nightly tfp-nightly
 ### Installing from Source
 
 You can also install from source. This requires the [Bazel](
-https://bazel.build/) build system.
+https://bazel.build/) build system. It is highly recommended that you install
+the nightly build of TensorFlow (`tf-nightly`) before trying to build
+TensorFlow Probability from source.
 
 ```shell
 # sudo apt-get install bazel git python-pip  # Ubuntu; others, see above links.
+python -m pip install --upgrade --user tf-nightly
 git clone https://github.com/tensorflow/probability.git
 cd probability
 bazel build --copt=-O3 --copt=-march=native :pip_pkg

--- a/tensorflow_probability/g3doc/install.md
+++ b/tensorflow_probability/g3doc/install.md
@@ -33,16 +33,19 @@ releases.
 ## Install from source
 
 You can also install from source. This requires the
-[Bazel](https://bazel.build/){:.external} build system.
+[Bazel](https://bazel.build/){:.external} build system. It is highly recommended
+that you install the nightly build of TensorFlow (`tf-nightly`) before trying to
+build TensorFlow Probability from source.
 
 <!-- common_typos_disable -->
 <pre class="devsite-click-to-copy">
   <code class="devsite-terminal">sudo apt-get install bazel git python-pip</code>
+  <code class="devsite-terminal">python -m pip install --upgrade --user tf-nightly</code>
   <code class="devsite-terminal">git clone https://github.com/tensorflow/probability.git</code>
   <code class="devsite-terminal">cd probability</code>
   <code class="devsite-terminal">bazel build --copt=-O3 --copt=-march=native :pip_pkg</code>
   <code class="devsite-terminal">PKGDIR=$(mktemp -d)</code>
   <code class="devsite-terminal">./bazel-bin/pip_pkg $PKGDIR</code>
-  <code class="devsite-terminal">pip install --user --upgrade $PKGDIR/*.whl</code>
+  <code class="devsite-terminal">python -m pip install --upgrade --user $PKGDIR/*.whl</code>
 </pre>
 <!-- common_typos_enable -->


### PR DESCRIPTION
Resolves #910 

To try and make first time contributions as easy as possible, advocate in the `README` for having `tf-nightly` installed in the environment before attempting to build TensorFlow Probability from source. Additionally replicate this information to `tensorflow_probability/g3doc/install.md` as this also covers the same material. Finally, use `python -m pip` to match the syntax used in the rest of the `README` and to adhere to best practices for `pip`, and flip the order of `--user` and `--upgrade` to match the order used in other instances in the `README`.