### PR TITLE
Add some helper scripts for running tests and use them in travis tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,21 +62,69 @@ for recommended test setup.
 Unit tests ensure new features (a) work correctly and (b) guard against future
 breaking changes (thus lower maintenance costs).
 
-To run existing unit-tests on CPU, use the command:
+### Setup
 
+#### `bazel`
+
+We use [`bazel`](https://bazel.build/) to manage building, packaging, and
+testing TFP. You'll need to install `bazel` before running our tests (we have
+recently added some experimental support for running some tests with pytest, but
+for a variety of reasons this will probably never work 100%). See instructions
+[here](https://docs.bazel.build/versions/3.2.0/install-os-x.html) on installing
+`bazel`.
+
+#### `virtualenv`
+
+We strongly recommend running unit tests in an active
+[virtualenv](https://virtualenv.pypa.io/en/latest/). Doing so requires some
+extra bazel flags, so we created a wrapper script, which we suggest using. An
+example invocation (presumed to run from the root of the TFP repo:
+
+#### Helper scripts
 
 ```shell
-bazel test --copt=-O3 --copt=-march=native //tensorflow_probability/...
+# Run all TFP tests.
+./testing/tfp_test.sh //tensorflow_probability/...
 ```
 
-from the root of the `tensorflow_probability` repository. To run tests on GPU,
-you just need to ensure the GPU-enabled version of TensorFlow is installed.
-However, you will also need to include the flag `--jobs=1`, since by default
-Bazel will run many tests in parallel, and each one will try to claim all the
-GPU memory:
+See comments at the top of the script for more info.
+
+For convenience, also consider sourcing the following script to alias `tfp_test`
+to the above script:
 
 ```shell
-bazel test --jobs=1 --copt=-O3 --copt=-march=native //tensorflow_probability/...
+source ./testing/define_testing_alias.sh
+# Run all TFP tests.
+tfp_test //tensorflow_probability/...
+```
+
+#### Dependencies
+
+To run the unit tests, you'll need several packages installed (again, we
+strongly recommend you work in a virtualenv). We include a script to do this for
+you, which also does some sanity checks on the environtment:
+
+```shell
+./testing/install_test_dependencies.sh
+```
+
+See the
+[header comments in that script](https://github.com/tensorflow/probability/blob/master/testing/install_test_dependencies.sh)
+for more details.
+
+### Additional considerations
+
+As of early 2020, tensorflow and tf-nightly include GPU support by default,
+which means if you have a GPU installed and run tests with the default
+`tf-nightly` pip package, tests will try to run using the GPU. To avoid this,
+the dependency install script installs tf-nightly-cpu by default. If you *want*
+to run tests on the GPU, you can use pass --enable_gpu flag to
+`testing/install_test_dependencies.sh`. In this case, you will also need to
+include the flag `--jobs=1`, since by default Bazel will run many tests in
+parallel, and each one will try to claim all the GPU memory:
+
+```shell
+tfp_test --jobs=1 //tensorflow_probability/...
 ```
 
 

--- a/testing/define_testing_alias.sh
+++ b/testing/define_testing_alias.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+#
+# Define convenient alias to the testing/run_tfp_test.sh script. Source this
+# file in your terminal session to define the alias `tfp_test`:
+#
+# ```bash
+# source testing/define_testing_alias.sh
+# alias tfp_test
+# # ==> /absolute/path/to/testing/run_tfp_test.sh
+# ```
+#
+# Optionally, provide a positional arguemnt to this script to create an
+# alternate alias name:
+#
+# ```bash
+# source testing/define_testing_alias.sh my_tfp_test_alias
+# alias my_tfp_test_alias
+# # ==> /absolute/path/to/testing/run_tfp_test.sh
+
+# Get the absolute path to the directory containing this script
+DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+# Read alias name from the first argument to the script, with a default of
+# `tfp_test`.
+ALIAS_NAME=${1:-tfp_test}
+
+alias $ALIAS_NAME="$DIR/run_tfp_test.sh"

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+#
+# This script installs TFP test dependencies using pip, and does some sanity
+# checks beforehand to make sure things look like they should work. Namely:
+#   1. Make sure a virtualenv is active, unless user has explicitly asked not
+#      to (by passing the --user flag to this script).
+#   2. Make sure no invalid tensorflow packages are already installed:
+#      a. no non-nightly versions (i.e. the stable `tensorflow` pip package)
+#      b. if a nightly version is present, it is consistent with the presence
+#         or absence of the --enable_gpu flag.
+#
+# Simple usage (from the root of the TFP repo, with a virtualenv active):
+#
+# ```bash
+#   $ ./testing/install_python_packages.sh
+# ```
+#
+# Usage outside of a virtualenv (not recommended):
+#
+# ```bash
+#   $ ./testing/install_python_packages.sh --user
+# ```
+#
+# The --user variant will simply forward the --user flag to pip install
+# commands, telling pip to install the dependencies in the user install
+# directory.
+
+virtualenv_is_active() {
+  # This is apparently the most reliable way to check whether the script is
+  # being run in a virtualenv. Source:
+  # https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv
+  python -c 'import sys; sys.exit(not hasattr(sys, "real_prefix"))'
+}
+
+SCRIPT_ARGS=$@
+user_flag_is_set() {
+  # We could use getopts but it's annoying and arguably overkill here. We should
+  # consider it if ever this script grows more complicated.
+  [[ "$SCRIPT_ARGS" =~ --user ]]
+}
+
+enable_gpu_flag_is_set() {
+  [[ "$SCRIPT_ARGS" =~ --enable_gpu ]]
+}
+
+if ! virtualenv_is_active && ! user_flag_is_set; then
+  echo "Looks like you're not in a virtualenv. We strongly recommend running"
+  echo "TFP tests inside of a virtualenv to avoid conflicts with preinstalled"
+  echo "libraries. If you're sure you want to proceed outside of a virtualenv,"
+  echo "rerun this script with the --user flag, which will indicate that we"
+  echo "should install TFP dependencies using \`pip install --user ...\`"
+  exit 1
+elif ! virtualenv_is_active && user_flag_is_set; then
+  PIP_FLAGS="--user"
+fi
+
+if enable_gpu_flag_is_set; then
+  TF_NIGHTLY_PACKAGE=tf-nightly
+else
+  TF_NIGHTLY_PACKAGE=tf-nightly-cpu
+fi
+
+find_good_tf_nightly_version_str() {
+  PKG_NAME=$1
+  # These are nightly builds we'd like to avoid for some reason; separated by
+  # regex OR operator.
+  BAD_NIGHTLY_DATES="20200112\|20200113"
+  # This will fail to find version 'X" and log available version strings to
+  # stderr. We then sort, remove bad versions and take the last entry. This
+  # allows us to avoid hardcoding the main version number, which would then need
+  # to be updated on every new TF release.
+  python -m pip install $PKG_NAME==X 2>&1 \
+    | grep -o "[0-9.]\+dev[0-9]\{8\}" \
+    | sort \
+    | grep -v "$BAD_NIGHTLY_DATES" \
+    | tail -n1
+}
+
+has_tensorflow_packages() {
+  python -m pip list | grep tensorflow &> /dev/null
+}
+
+has_tf_nightly_cpu_package() {
+  python -m pip list | grep tf-nightly-cpu &> /dev/null
+}
+
+has_tf_nightly_package() {
+  python -m pip list | grep -v tf-nightly-cpu | grep tf-nightly &> /dev/null
+}
+
+check_for_common_package_conflicts() {
+  if has_tensorflow_packages; then
+    echo "Looks like you have a non-nightly version of tensorflow (or a \
+          related non-nightly TF dependency like tensorflow-estimator). We \
+          recommend purging all non-nightly versions from your virtualenv \
+          before trying to run TFP tests. The safest way to do this is usually \
+          to deactivate and delete your current virtualenv, create and \
+          activate a new one, then rerun this script. These are the offending \
+          packages:"
+    echo
+    python -m pip list | grep tensorflow
+    exit 1
+  fi
+
+  if enable_gpu_flag_is_set && has_tf_nightly_cpu_package; then
+    echo "Looks like you have requested to install TF with GPU support, but \
+          also have tf-nightly-cpu installed. Having these present \
+          may not have the intended effect: which one gets used will depend on \
+          the order in which they were installed. We recommend removing the \
+          version you don't want used for testing. The safest way to do this \
+          is usually to deactivate and delete your current virtualenv, create \
+          and activate a new one, then rerun this script."
+    exit 1
+  fi
+
+  if ! enable_gpu_flag_is_set && has_tf_nightly_package; then
+    echo "Looks like you have a version of TF installed which includes GPU, \
+          but you haven't explictly run this script with the --enable_gpu \
+          flag. This is usually a mistake, so we're letting you know. If this \
+          was indeed a mistake, you can simply uninstall and rerun this \
+          script. If you *did* intend to run tests against the GPU-enabled TF \
+          installation, you'll just need to run this script with the explicit \
+          --enable_gpu flag to proceed. NOTE: you will probably also need to \
+          invoke tests using the --jobs=1 flag to \`bazel\`, otherwise it will \
+          try to run lots of jobs in parallel and they will all try to claim \
+          all the GPU RAM simultaneously."
+    exit 1
+  fi
+}
+
+install_python_packages() {
+  # Ensure newer than 18.x pip version, which is necessary after tf-nightly
+  # switched to manylinux2010.
+  python -m pip install $PIP_FLAGS --upgrade 'pip>=19.2'
+
+  # NB: tf-nightly pulls in other deps, like numpy, absl, and six, transitively.
+  TF_VERSION_STR=$(find_good_tf_nightly_version_str $TF_NIGHTLY_PACKAGE)
+  python -m pip install $PIP_FLAGS $TF_NIGHTLY_PACKAGE==$TF_VERSION_STR
+
+  # The following unofficial dependencies are used only by tests.
+  # TODO(b/148685448): Unpin Hypothesis and coverage versions.
+  python -m pip install $PIP_FLAGS hypothesis==3.56.5 coverage==4.4.2 matplotlib mock scipy
+
+  # Install additional TFP dependencies.
+  python -m pip install $PIP_FLAGS decorator cloudpickle dm-tree
+
+  # Upgrade numpy to the latest to address issues that happen when testing with
+  # Python 3 (https://github.com/tensorflow/tensorflow/issues/16488).
+  python -m pip install -U $PIP_FLAGS numpy
+
+  # Print out all versions, as an FYI in the logs.
+  python --version
+  python -m pip --version
+  python -m pip freeze
+}
+
+check_for_common_package_conflicts
+install_python_packages

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -20,6 +20,9 @@ set -x  # print commands as they are executed
 set -e  # fail and exit on any command erroring
 set -u  # fail and exit on any undefined variable reference
 
+# Get the absolute path to the directory containing this script.
+DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
 # Make sure the environment variables are set.
 if [ -z "${SHARD}" ]; then
   echo "SHARD is unset."
@@ -54,49 +57,13 @@ install_bazel() {
   sudo apt-get install bazel
 }
 
-find_version_str() {
-  PKG_NAME=$1
-  # These are nightly builds we'd like to avoid for some reason; separated by
-  # regex OR operator.
-  BAD_NIGHTLY_DATES="20200112\|20200113"
-  # This will fail to find version 'X" and log available version strings to
-  # stderr. We then sort, remove bad versions and take the last entry. This
-  # allows us to avoid hardcoding the main version number, which would then need
-  # to be updated on every new TF release.
-  pip install $PKG_NAME==X 2>&1 \
-    | grep -o "[0-9.]\+dev[0-9]\{8\}" \
-    | sort \
-    | grep -v "$BAD_NIGHTLY_DATES" \
-    | tail -n1
-}
-
 install_python_packages() {
-  # Ensure newer than 18.x pip version, which is necessary after tf-nightly
-  # switched to manylinux2010.
-  pip install --upgrade 'pip>=19.2'
-
-  # NB: tf-nightly pulls in other deps, like numpy, absl, and six, transitively.
-  TF_VERSION_STR=$(find_version_str tf-nightly)
-  pip install tf-nightly==$TF_VERSION_STR
-
-  # The following unofficial dependencies are used only by tests.
-  # TODO(b/148685448): Unpin Hypothesis and coverage versions.
-  pip install hypothesis==3.56.5 coverage==4.4.2 matplotlib mock scipy
-
-  # Install additional TFP dependencies.
-  pip install decorator cloudpickle dm-tree
-
-  # Upgrade numpy to the latest to address issues that happen when testing with
-  # Python 3 (https://github.com/tensorflow/tensorflow/issues/16488).
-  pip install -U numpy
-
-  # Print out all versions, as an FYI in the logs.
-  python --version
-  pip --version
-  pip freeze
+  ${DIR}/install_test_dependencies.sh
 }
 
-call_with_log_folding install_bazel
+# Only install bazel if not already present (useful for locally testing this
+# script).
+which bazel || call_with_log_folding install_bazel
 call_with_log_folding install_python_packages
 
 test_tags_to_skip="(gpu|requires-gpu-nvidia|notap|no-oss-ci|tfp_jax|tf2-broken|tf2-kokoro-broken)"
@@ -120,23 +87,9 @@ sharded_tests="$(query_and_shard_tests_by_size small)"
 sharded_tests="${sharded_tests} $(query_and_shard_tests_by_size medium)"
 sharded_tests="${sharded_tests} $(query_and_shard_tests_by_size large)"
 
-# Run tests. Notes on less obvious options:
+# Run tests using run_tfp_test.sh script. We append the following flags:
 #   --notest_keep_going -- stop running tests as soon as anything fails. This is
 #     to minimize load on Travis, where we share a limited number of concurrent
 #     jobs with a bunch of other TensorFlow projects.
-#   --test_timeout -- comma separated values correspond to various test sizes
-#     (short, moderate, long or eternal)
-#   --action_env -- specify environment vars to pass through to action
-#     environment. (We need these in order to run inside a virtualenv.)
-#     See https://github.com/bazelbuild/bazel/issues/6648 and b/121259040.
 echo "${sharded_tests}" \
-  | xargs bazel test \
-    --compilation_mode=opt \
-    --copt=-O3 \
-    --copt=-march=native \
-    --notest_keep_going \
-    --test_timeout 300,450,1200,3600 \
-    --test_env=TFP_HYPOTHESIS_MAX_EXAMPLES=2 \
-    --action_env=PATH \
-    --action_env=LD_LIBRARY_PATH \
-    --test_output=errors
+  | xargs $DIR/run_tfp_test.sh --notest_keep_going

--- a/testing/run_tfp_test.sh
+++ b/testing/run_tfp_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+#
+# Using bazel to run test TFP tests in a virtualenv (which we strongly
+# recommend) requires some special flags. Additionally, some tests are defined
+# but known not to be working and are therefore tagged as such; using an
+# additional flag ensures such tests are skipped. This script wraps the `bazel`
+# command and ensures these flags are set. Arguments to this test are passed
+# along to `bazel test` after the aforementioned flags
+#
+# ## Example 1: Run all tests (from TFP repo root dir)
+#
+# ```bash
+#  $ ./testing/run_tfp_test.sh //tensorflow_probability/...
+# ```
+#
+# ## Example 2: Repeat test with varying seeds
+#
+# ```bash
+#   $ ./testing/run_tfp_test.sh --test_arg="--vary_seed --runs_per_test=100" \
+#       //tensorflow_probability/path/to:stochastic_test
+# ```
+
+set -x
+
+if ! which bazel; then
+  echo '`bazel` must be installed to run TFP tests with this script.'
+  exit 1
+fi
+
+TEST_TAG_FILTERS="-gpu,-requires-gpu-nvidia,-notap,-no-oss-ci,-tf2-broken,-tf2-kokoro-broken"
+
+# Run tests. Notes on less obvious options:
+#   --test_timeout -- comma separated values correspond to various test sizes
+#     (short, moderate, long or eternal). We increase the timeouts from their
+#     defaults to allow for slower machines.
+#   --action_env -- specify environment vars to pass through to action
+#     environment. (We need these in order to run inside a virtualenv.)
+#     See https://github.com/bazelbuild/bazel/issues/6648 and b/121259040.
+#   --test_env=TFP_HYPOTHESIS_MAX_EXAMPLES=2 -- several tests in TFP use the
+#     hypothesis testing framework to automatically probe for bugs by generating
+#     test examples. This flag limits the number of examples to 2, which helps
+#     prevent extreme test slowness, but reduces coverage.
+bazel test \
+  --compilation_mode=opt \
+  --copt=-O3 \
+  --copt=-march=native \
+  --test_timeout 300,450,1200,3600 \
+  --test_tag_filters="${TEST_TAG_FILTERS}" \
+  --test_env=TFP_HYPOTHESIS_MAX_EXAMPLES=2 \
+  --action_env=PATH \
+  --action_env=LD_LIBRARY_PATH \
+  --test_output=errors \
+  $@


### PR DESCRIPTION
Specifically:
  - add a script wrapping bazel test invocation, setting commonly used flags
  - add a sourceable alias definition script, which aliases `tfp_test` to point to the tfp_test.sh script
  - add a script to install dependencies, along with checks for common pitfalls and helpful error messages.