### PR TITLE
small optimization for `batch_evaluate_objective=True` in Nelder Mead optimizer

### DIFF
--- a/tensorflow_probability/python/optimizer/nelder_mead.py
+++ b/tensorflow_probability/python/optimizer/nelder_mead.py
@@ -801,21 +801,18 @@ def _prepare_args_with_initial_vertex(objective_function,
   simplex_face = initial_vertex + step_sizes * unit_vectors_along_axes
   simplex = tf.concat([tf.expand_dims(initial_vertex, axis=0),
                        simplex_face], axis=0)
-  num_evaluations = 0
   # Evaluate the objective function at the simplex vertices.
   if objective_at_initial_vertex is None:
-    objective_at_initial_vertex = objective_function(initial_vertex)
-    num_evaluations += 1
-
-  objective_at_simplex_face, num_evals = _evaluate_objective_multiple(
-      objective_function, simplex_face, batch_evaluate_objective)
-  num_evaluations += num_evals
-
-  objective_at_simplex = tf.concat(
-      [
-          tf.expand_dims(objective_at_initial_vertex, axis=0),
-          objective_at_simplex_face
-      ], axis=0)
+    objective_at_simplex, num_evaluations = _evaluate_objective_multiple(
+        objective_function, simplex, batch_evaluate_objective)
+  else:
+    objective_at_simplex_face, num_evaluations = _evaluate_objective_multiple(
+        objective_function, simplex_face, batch_evaluate_objective)
+    objective_at_simplex = tf.concat(
+        [
+            tf.expand_dims(objective_at_initial_vertex, axis=0),
+            objective_at_simplex_face
+        ], axis=0)
 
   return (dim,
           num_vertices,


### PR DESCRIPTION
Hi,

I have an expensive objective function which I am trying to optimize with Nelder Mead, it supports batching and stepping through the code I noticed we could take advantage of that a little more with this change, I think.

In short, previously when `objective_at_initial_vertex is None` then the code would call `objective_function` then `_evaluate_objective_multiple`. I've changed it to make a single call to `_evaluate_objective_multiple` with a bigger batch which I think is almost always preferred.

Hope it is useful, let me know if there is anything else I can do with this.

Jeff