### PR TITLE
Fixed inconsistent spaces in tfb.Chain docstring

### DIFF
--- a/tensorflow_probability/python/bijectors/chain.py
+++ b/tensorflow_probability/python/bijectors/chain.py
@@ -121,25 +121,25 @@ class Chain(bijector.Bijector):
 
   * Forward:
 
-   ```python
-   exp = Exp()
-   softplus = Softplus()
-   Chain([exp, softplus]).forward(x)
-   = exp.forward(softplus.forward(x))
-   = tf.exp(tf.log(1. + tf.exp(x)))
-   = 1. + tf.exp(x)
-   ```
+    ```python
+    exp = Exp()
+    softplus = Softplus()
+    Chain([exp, softplus]).forward(x)
+    = exp.forward(softplus.forward(x))
+    = tf.exp(tf.log(1. + tf.exp(x)))
+    = 1. + tf.exp(x)
+    ```
 
   * Inverse:
 
-   ```python
-   exp = Exp()
-   softplus = Softplus()
-   Chain([exp, softplus]).inverse(y)
-   = softplus.inverse(exp.inverse(y))
-   = tf.log(tf.exp(tf.log(y)) - 1.)
-   = tf.log(y - 1.)
-   ```
+    ```python
+    exp = Exp()
+    softplus = Softplus()
+    Chain([exp, softplus]).inverse(y)
+    = softplus.inverse(exp.inverse(y))
+    = tf.log(tf.exp(tf.log(y)) - 1.)
+    = tf.log(y - 1.)
+    ```
 
   """
 


### PR DESCRIPTION
The [tfb.Chain](https://www.tensorflow.org/probability/api_docs/python/tfp/bijectors/Chain) documentation is not rendered correctly. Maybe because of inconsistent spacing. This PR addresses the same. 
I also want to know if there is some way to build docs locally?