### PR TITLE
TransformedTransitionKernel call with missing `target_log_prob_fn` bugfix

### DIFF
--- a/tensorflow_probability/python/mcmc/kernel.py
+++ b/tensorflow_probability/python/mcmc/kernel.py
@@ -90,16 +90,16 @@ class TransitionKernel(object):
 
     Args:
       override_parameter_kwargs: Python String/value `dictionary` of
-      initialization arguments to override with new values.
+        initialization arguments to override with new values.
 
     Returns:
-      new_kernel: A `TransitionKernel` object of same type as `self`,
-      initialized with override_parameter_kwargs
+      new_kernel: `TransitionKernel` object of same type as `self`,
+        initialized with the union of self.parameters and
+        override_parameter_kwargs, with any shared keys overridden by the
+        value of override_parameter_kwargs, i.e.,
+        `dict(self.parameters, **override_parameters_kwargs)`.
     """
     parameters = dict(self.parameters, **override_parameter_kwargs)
     new_kernel = type(self)(**parameters)
-    # pylint: disable=protected-access
-    new_kernel._parameters = parameters
-    # pylint: enable=protected-access
-    new_kernel = type(self)(**parameters)
+    new_kernel._parameters = parameters # pylint: disable=protected-access
     return new_kernel

--- a/tensorflow_probability/python/mcmc/kernel.py
+++ b/tensorflow_probability/python/mcmc/kernel.py
@@ -84,3 +84,22 @@ class TransitionKernel(object):
         `Tensor`s representing internal calculations made within this function.
     """
     return []
+
+  def copy(self, **override_parameter_kwargs):
+    """Non-destructively creates a deep copy of the kernel
+
+    Args:
+      override_parameter_kwargs: Python String/value `dictionary` of
+      initialization arguments to override with new values.
+
+    Returns:
+      new_kernel: A `TransitionKernel` object of same type as `self`,
+      initialized with override_parameter_kwargs
+    """
+    parameters = dict(self.parameters, **override_parameter_kwargs)
+    new_kernel = type(self)(**parameters)
+    # pylint: disable=protected-access
+    new_kernel._parameters = parameters
+    # pylint: enable=protected-access
+    new_kernel = type(self)(**parameters)
+    return new_kernel

--- a/tensorflow_probability/python/mcmc/kernel.py
+++ b/tensorflow_probability/python/mcmc/kernel.py
@@ -101,5 +101,4 @@ class TransitionKernel(object):
     """
     parameters = dict(self.parameters, **override_parameter_kwargs)
     new_kernel = type(self)(**parameters)
-    new_kernel._parameters = parameters # pylint: disable=protected-access
     return new_kernel

--- a/tensorflow_probability/python/mcmc/transformed_kernel.py
+++ b/tensorflow_probability/python/mcmc/transformed_kernel.py
@@ -111,7 +111,7 @@ def target_log_prob_getter(kernel):
   while 'target_log_prob_fn' not in kernel.parameters:
     if 'inner_kernel' not in kernel.parameters:
       raise ValueError('"None of the nested `inner_kernel`s contains a '
-                      '`target_log_prob_fn`."')
+                       '`target_log_prob_fn`."')
     kernel = kernel.inner_kernel
     kernel_stack.append(kernel)
   return kernel.parameters['target_log_prob_fn'], kernel_stack
@@ -153,9 +153,9 @@ class TransformedTransitionKernel(kernel_base.TransitionKernel):
   of arbitrary `TransitionKernel`s, e.g., one could use bijectors
   `tfp.bijectors.Affine`, `tfp.bijectors.RealNVP`, etc. with transition kernels
   `tfp.mcmc.HamiltonianMonteCarlo`, `tfp.mcmc.RandomWalkMetropolis`,
-  etc. 
-  
-  If the provided `inner_kernel` doesn't have a `target_log_prob_fn`, 
+  etc.
+
+  If the provided `inner_kernel` doesn't have a `target_log_prob_fn`,
   `TransformedTransitionKernel` will iteratively look through deeper layers of
   kernels to find one that does. It will then apply the transformation to that
   `target_log_prob_fn` and propogate those changes if necessary.
@@ -169,7 +169,7 @@ class TransformedTransitionKernel(kernel_base.TransitionKernel):
     inner_kernel=tfp.mcmc.SimpleStepSizeAdaptation(
       inner_kernel=tfp.mcmc.HamiltonianMonteCarlo(
         ... # doesn't matter
-      ), 
+      ),
       num_adaptation_steps=9)
     bijector=tfb.Identity()))
   ```

--- a/tensorflow_probability/python/mcmc/transformed_kernel.py
+++ b/tensorflow_probability/python/mcmc/transformed_kernel.py
@@ -110,8 +110,8 @@ def target_log_prob_getter(kernel):
   kernel_stack = [kernel]
   while 'target_log_prob_fn' not in kernel.parameters:
     if 'inner_kernel' not in kernel.parameters:
-      raise ValueError("None of the nested `inner_kernel`s contains '
-                      '`target_log_prob_fn`")
+      raise ValueError('"None of the nested `inner_kernel`s contains a '
+                      '`target_log_prob_fn`."')
     kernel = kernel.inner_kernel
     kernel_stack.append(kernel)
   return kernel.parameters['target_log_prob_fn'], kernel_stack

--- a/tensorflow_probability/python/mcmc/transformed_kernel.py
+++ b/tensorflow_probability/python/mcmc/transformed_kernel.py
@@ -109,6 +109,9 @@ def make_transformed_log_prob(
 def target_log_prob_getter(kernel):
   kernel_stack = [kernel]
   while 'target_log_prob_fn' not in kernel.parameters:
+    if 'inner_kernel' not in kernel.parameters:
+      raise ValueError("None of the nested `inner_kernel`s contains '
+                      '`target_log_prob_fn`")
     kernel = kernel.inner_kernel
     kernel_stack.append(kernel)
   return kernel.parameters['target_log_prob_fn'], kernel_stack

--- a/tensorflow_probability/python/mcmc/transformed_kernel.py
+++ b/tensorflow_probability/python/mcmc/transformed_kernel.py
@@ -161,9 +161,10 @@ class TransformedTransitionKernel(kernel_base.TransitionKernel):
   etc.
 
   ### Transforming nested kernels
- 
- `TransformedTransitionKernel` can operate on multiply nested kernels, as in the following example:
- 
+
+ `TransformedTransitionKernel` can operate on multiply nested kernels, as in
+ the following example:
+
  ```python
  tfp.mcmc.TransformedTransitionKernel(
    inner_kernel=tfp.mcmc.SimpleStepSizeAdaptation(
@@ -173,9 +174,9 @@ class TransformedTransitionKernel(kernel_base.TransitionKernel):
      num_adaptation_steps=9)
    bijector=tfb.Identity()))
  ```
- 
- Upon construction, `TransformedTransitionKernel` searches through the "stack" of
- nested `inner_kernel`s until it finds one with a field called
+
+ Upon construction, `TransformedTransitionKernel` searches through the "stack"
+ of nested `inner_kernel`s until it finds one with a field called
  `target_log_prob_fn`, and replaces this with the transformed function. If no
  `inner_kernel` has such a target log prob a `ValueError` is raised.
 


### PR DESCRIPTION
Currently, calling `TransformedTransitionKernel` on an `inner_kernel` without a `target_log_prob_fn` will result in an error. For example, calling `TransformedTransitionKernel` on a `SimpleStepSizeAdaptation` object as the inner kernel.

Akin to how `SimpleStepSizeAdaptation` edits `step_size`, `TransformedTransitionKernel` now iterates through `inner_kernel`s until it finds a valid one, then propagates that change. Tests are included, docstring edited to reflect the change, and a `ValueError` is thrown if no `inner_kernel` satisfies the condition.

