### PR TITLE
A change for Inhomogeneous Poisson Process to work

### DIFF
--- a/tensorflow_probability/python/vi/optimization.py
+++ b/tensorflow_probability/python/vi/optimization.py
@@ -250,7 +250,7 @@ def fit_surrogate_posterior(target_log_prob_fn,
     latent_rates = yield Root(tfd.Independent(
       tfd.Normal(loc=logit_locs, scale=tf.nn.softplus(logit_softplus_scales)),
       reinterpreted_batch_ndims=1))
-    y = yield tfd.VectorDeterministic(y)
+    y = yield tfd.VectorDeterministic(observed_counts)
   q = tfd.JointDistributionCoroutine(variational_model_fn)
   ```
 


### PR DESCRIPTION
Previously, the following error was embedded in the variational distribution function `variational_model_fn` when attempting to perform Inhomogeneous Poisson process.

```
<ipython-input-15-e3db9282b77d> in variational_model_fn()
      6     tfd.Normal(loc=logit_locs, scale=tf.nn.softplus(logit_softplus_scales)),
      7     reinterpreted_batch_ndims=1))
----> 8     y = yield tfd.VectorDeterministic(y)
      9 q = tfd.JointDistributionCoroutine(variational_model_fn)

UnboundLocalError: local variable 'y' referenced before assignment
``` 

This change will allow the observations to be incorporated directory into this variational distribution.