### PR TITLE
Add LambertW distributions to `__init__.py`

### DIFF
--- a/tensorflow_probability/python/distributions/__init__.py
+++ b/tensorflow_probability/python/distributions/__init__.py
@@ -68,6 +68,8 @@ from tensorflow_probability.python.distributions.joint_distribution_auto_batched
 from tensorflow_probability.python.distributions.joint_distribution_sequential import JointDistributionSequential
 from tensorflow_probability.python.distributions.joint_distribution_auto_batched import JointDistributionSequentialAutoBatched
 from tensorflow_probability.python.distributions.kumaraswamy import Kumaraswamy
+from tensorflow_probability.python.distributions.lambertw_f import LambertWDistribution
+from tensorflow_probability.python.distributions.lambertw_f import LambertWNormal
 from tensorflow_probability.python.distributions.laplace import Laplace
 from tensorflow_probability.python.distributions.linear_gaussian_ssm import LinearGaussianStateSpaceModel
 from tensorflow_probability.python.distributions.lkj import LKJ
@@ -194,6 +196,8 @@ __all__ = [
     'JointDistributionSequentialAutoBatched',
     'Kumaraswamy',
     'LinearGaussianStateSpaceModel',
+    'LambertWDistribution',
+    'LambertWNormal',
     'Laplace',
     'LKJ',
     'Logistic',


### PR DESCRIPTION
Hello,

this PR adds the module names of the Lambert W families to `__init__.py`, since they where missing before.

Cheers,
Simon