### PR TITLE
fix: Use cloudpickle v1.5.0 API

### DIFF
--- a/tensorflow_probability/python/layers/distribution_layer.py
+++ b/tensorflow_probability/python/layers/distribution_layer.py
@@ -25,7 +25,7 @@ import io
 import pickle
 
 # Dependency imports
-from cloudpickle.cloudpickle import CloudPickler
+from cloudpickle import CloudPickler
 import numpy as np
 import six
 import tensorflow.compat.v2 as tf


### PR DESCRIPTION
Resolves #991

In [`cloudpickle` `v1.5.0`](https://pypi.org/project/cloudpickle/1.5.0/) `CloudPickler` moved from `cloudpickle.cloudpickle` to ~`cloudpickle.cloudpickle_fast`~ the top level `cloudpickle` in the API. (**edit** following [clarifying correction in `cloudpickle` Issue](https://github.com/cloudpipe/cloudpickle/issues/390#issuecomment-652833748))

As a result, this PR requires `cloudpickle >= 1.3` in `setup.py` (**edit:** v1.3 being a minimum with the available import and in keeping with the existing requirements in `setup.py`) and then adopts the `v1.5.0` API in [`tensorflow_probability/python/layers/distribution_layer.py`](https://github.com/tensorflow/probability/blob/8f67456798615f9bf60ced2ce6db5d3dba3515fe/tensorflow_probability/python/layers/distribution_layer.py#L28) (the only time `CloudPickler` is imported).

As `cloudpickle` was pinned to `v1.3` "[to unbreak Kokoro build](https://github.com/tensorflow/probability/commit/5cc832b9d28ed5562961385a3b30ad242d76aac1)" there might be specific motivation that a TFP core dev can explain RE: `TODO(b/155109696)`.
