### PR TITLE
Import CloudPickler from toplevel cloudpickle package

### DIFF
--- a/tensorflow_probability/python/layers/distribution_layer.py
+++ b/tensorflow_probability/python/layers/distribution_layer.py
@@ -25,7 +25,7 @@ import io
 import pickle
 
 # Dependency imports
-from cloudpickle.cloudpickle import CloudPickler
+from cloudpickle import CloudPickler
 import numpy as np
 import six
 import tensorflow.compat.v2 as tf


### PR DESCRIPTION
Fix #991

An internal refactoring moved the definition of the CloudPickler class in cloudpickle 1.5.0.