### PR TITLE
Adding a seed reproducibility test to `sample_chain`

### DIFF
--- a/tensorflow_probability/python/mcmc/sample_test.py
+++ b/tensorflow_probability/python/mcmc/sample_test.py
@@ -37,6 +37,7 @@ TestTransitionKernelResults = collections.namedtuple(
 
 @test_util.test_all_tf_execution_regimes
 class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic `TransitionKernel` for testing purposes"""
 
   def __init__(self, is_calibrated=True, accepts_seed=True):
     self._is_calibrated = is_calibrated
@@ -58,6 +59,11 @@ class TestTransitionKernel(tfp.mcmc.TransitionKernel):
 
 
 class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
+   """Fake `TransitionKernel` that randomly assigns the next state.
+
+  Regardless of the current state, the `one_step` method will always
+  randomly sample from a Reyleigh Distribution.
+  """
 
   def __init__(self, is_calibrated=True, accepts_seed=True):
     self._is_calibrated = is_calibrated

--- a/tensorflow_probability/python/mcmc/sample_test.py
+++ b/tensorflow_probability/python/mcmc/sample_test.py
@@ -35,7 +35,6 @@ TestTransitionKernelResults = collections.namedtuple(
     'TestTransitionKernelResults', 'counter_1, counter_2')
 
 
-@test_util.test_all_tf_execution_regimes
 class TestTransitionKernel(tfp.mcmc.TransitionKernel):
   """Fake deterministic `TransitionKernel` for testing purposes"""
 
@@ -59,7 +58,7 @@ class TestTransitionKernel(tfp.mcmc.TransitionKernel):
 
 
 class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
-   """Fake `TransitionKernel` that randomly assigns the next state.
+  """Fake `TransitionKernel` that randomly assigns the next state.
 
   Regardless of the current state, the `one_step` method will always
   randomly sample from a Reyleigh Distribution.
@@ -80,6 +79,7 @@ class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
     return self._is_calibrated
 
 
+@test_util.test_all_tf_execution_regimes
 class SampleChainTest(test_util.TestCase):
 
   def setUp(self):

--- a/tensorflow_probability/python/mcmc/sample_test.py
+++ b/tensorflow_probability/python/mcmc/sample_test.py
@@ -27,6 +27,7 @@ import numpy as np
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
 
+from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensorshape_util
 from tensorflow_probability.python.internal import test_util
 
@@ -50,6 +51,23 @@ class TestTransitionKernel(tfp.mcmc.TransitionKernel):
 
   def bootstrap_results(self, current_state):
     return TestTransitionKernelResults(counter_1=0, counter_2=0)
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
+
+  def __init__(self, is_calibrated=True, accepts_seed=True):
+    self._is_calibrated = is_calibrated
+    self._accepts_seed = accepts_seed
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    if seed is not None and not self._accepts_seed:
+      raise TypeError('seed arg not accepted')
+    random_next_state = tfp.random.rayleigh((), seed=seed)
+    return random_next_state, previous_kernel_results
 
   @property
   def is_calibrated(self):
@@ -308,6 +326,29 @@ class SampleChainTest(test_util.TestCase):
 
     # Checking that shape inference doesn't fail.
     sample(2)
+
+  def testSeedReproducibility(self):
+    first_fake_kernel = RandomTransitionKernel()
+    second_fake_kernel = RandomTransitionKernel()
+    seed = samplers.sanitize_seed(test_util.test_seed())
+    for num_results in range(2, 5):
+      first_final_state = tfp.mcmc.sample_chain(
+          num_results=num_results,
+          current_state=0.,
+          kernel=first_fake_kernel,
+          seed=seed,
+      )
+      second_final_state = tfp.mcmc.sample_chain(
+          num_results=num_results,
+          current_state=1., # difference should be irrelevant
+          kernel=second_fake_kernel,
+          seed=seed,
+      )
+      first_final_state, second_final_state = self.evaluate([
+          first_final_state, second_final_state
+      ])
+      self.assertAllCloseNested(
+          first_final_state, second_final_state, rtol=1e-6)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/mcmc/sample_test.py
+++ b/tensorflow_probability/python/mcmc/sample_test.py
@@ -31,6 +31,7 @@ from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensorshape_util
 from tensorflow_probability.python.internal import test_util
 
+
 TestTransitionKernelResults = collections.namedtuple(
     'TestTransitionKernelResults', 'counter_1, counter_2')
 

--- a/tensorflow_probability/python/mcmc/sample_test.py
+++ b/tensorflow_probability/python/mcmc/sample_test.py
@@ -62,7 +62,7 @@ class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
   """Fake `TransitionKernel` that randomly assigns the next state.
 
   Regardless of the current state, the `one_step` method will always
-  randomly sample from a Reyleigh Distribution.
+  randomly sample from a Rayleigh Distribution.
   """
 
   def __init__(self, is_calibrated=True, accepts_seed=True):
@@ -72,7 +72,7 @@ class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
   def one_step(self, current_state, previous_kernel_results, seed=None):
     if seed is not None and not self._accepts_seed:
       raise TypeError('seed arg not accepted')
-    random_next_state = tfp.random.rayleigh((), seed=seed)
+    random_next_state = tfp.random.rayleigh(current_state.shape, seed=seed)
     return random_next_state, previous_kernel_results
 
   @property
@@ -338,24 +338,23 @@ class SampleChainTest(test_util.TestCase):
     first_fake_kernel = RandomTransitionKernel()
     second_fake_kernel = RandomTransitionKernel()
     seed = samplers.sanitize_seed(test_util.test_seed())
-    for num_results in range(2, 5):
-      first_final_state = tfp.mcmc.sample_chain(
-          num_results=num_results,
-          current_state=0.,
-          kernel=first_fake_kernel,
-          seed=seed,
-      )
-      second_final_state = tfp.mcmc.sample_chain(
-          num_results=num_results,
-          current_state=1., # difference should be irrelevant
-          kernel=second_fake_kernel,
-          seed=seed,
-      )
-      first_final_state, second_final_state = self.evaluate([
-          first_final_state, second_final_state
-      ])
-      self.assertAllCloseNested(
-          first_final_state, second_final_state, rtol=1e-6)
+    first_final_state = tfp.mcmc.sample_chain(
+        num_results=5,
+        current_state=0.,
+        kernel=first_fake_kernel,
+        seed=seed,
+    )
+    second_final_state = tfp.mcmc.sample_chain(
+        num_results=5,
+        current_state=1.,  # difference should be irrelevant
+        kernel=second_fake_kernel,
+        seed=seed,
+    )
+    first_final_state, second_final_state = self.evaluate([
+        first_final_state, second_final_state
+    ])
+    self.assertAllCloseNested(
+        first_final_state, second_final_state, rtol=1e-6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After implementing `step_kernel` in `tfp.experimental.mcmc`, I realized `sample_chain` has no seed reproducibility test. Adding one as a sanity check for a comprehensive test suite and to hopefully better illustrate seeding semantics with some precedent. 