### PR TITLE
Adding `WithReductions` wrapper Transition Kernel to tfp.experimental.mcmc

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -397,7 +397,6 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # tensorflow dep,
-        ":sample",
         "//tensorflow_probability/python/mcmc:kernel",
         "//tensorflow_probability/python/mcmc/internal:util",
     ],

--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -45,6 +45,7 @@ py_library(
         ":sample_sequential_monte_carlo",
         ":sequential_monte_carlo_kernel",
         ":weighted_resampling",
+        ":with_reductions",
         # tensorflow dep,
         "//tensorflow_probability/python/internal:all_util",
     ],
@@ -384,6 +385,30 @@ py_test(
     deps = [
         ":covariance_reducer",
         ":sample",
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
+    name = "with_reductions",
+    srcs = ["with_reductions.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        # tensorflow dep,
+        ":sample",
+        "//tensorflow_probability/python/mcmc:kernel",
+        "//tensorflow_probability/python/mcmc/internal:util",
+    ],
+)
+
+# py2and3
+py_test(
+    name = "with_reductions_test",
+    shard_count = 5,
+    srcs = ["with_reductions_test.py"],
+    deps = [
         # tensorflow dep,
         "//tensorflow_probability",
         "//tensorflow_probability/python/internal:test_util",

--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -406,7 +406,6 @@ py_library(
 # py2and3
 py_test(
     name = "with_reductions_test",
-    shard_count = 5,
     srcs = ["with_reductions_test.py"],
     deps = [
         # tensorflow dep,

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""TensorFlow Probability experimental packaging."""
+"""TensorFlow Probability experimental MCMC package."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""TensorFlow Probability experimental NUTS package."""
+"""TensorFlow Probability experimental packaging."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -46,10 +46,9 @@ from tensorflow_probability.python.experimental.mcmc.weighted_resampling import 
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_stratified
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_systematic
 from tensorflow_probability.python.experimental.mcmc.with_reductions import WithReductions
-from tensorflow_probability.python.internal import all_util
 
 
-_allowed_symbols = [
+__all__ = [
     'CovarianceReducer',
     'EllipticalSliceSampler',
     'NoUTurnSampler',
@@ -79,5 +78,3 @@ _allowed_symbols = [
     'VarianceReducer',
     'WithReductions',
 ]
-
-all_util.remove_undocumented(__name__, _allowed_symbols)

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -45,6 +45,7 @@ from tensorflow_probability.python.experimental.mcmc.weighted_resampling import 
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_independent
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_stratified
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_systematic
+from tensorflow_probability.python.experimental.mcmc.with_reductions import WithReductions
 from tensorflow_probability.python.internal import all_util
 
 
@@ -75,7 +76,8 @@ _allowed_symbols = [
     'sample_sequential_monte_carlo',
     'simple_heuristic_tuning',
     'step_kernel',
-    'VarianceReducer'
+    'VarianceReducer',
+    'WithReductions',
 ]
 
 all_util.remove_undocumented(__name__, _allowed_symbols)

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions.py
@@ -116,7 +116,7 @@ class WithReductions(kernel_base.TransitionKernel):
           lambda r, state: r.one_step(
               sample,
               state,
-              previous_kernel_results=previous_kernel_results,),
+              previous_kernel_results=inner_kernel_results),
           self.reducers, previous_kernel_results.streaming_calculations,
           check_types=False)
       kernel_results = WithReductionsKernelResults(

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions.py
@@ -1,0 +1,168 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""WithReductions Transition Kernel."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.experimental.mcmc import step_kernel
+from tensorflow_probability.python.mcmc import kernel as kernel_base
+from tensorflow_probability.python.mcmc.internal import util as mcmc_util
+from tensorflow.python.util import nest
+
+
+__all__ = [
+    'WithReductions',
+]
+
+
+class WithReductionsKernelResults(
+    mcmc_util.PrettyNamedTupleMixin,
+    collections.namedtuple('WithReductionsKernelResults',
+                           ['streaming_calculations',
+                            'inner_results'])):
+  """Reducer state and diagnositics for `WithReductions`"""
+  __slots__ = ()
+
+
+class WithReductions(kernel_base.TransitionKernel):
+  """Applies `Reducer`s to stream over MCMC samples.
+
+  `WithReductions` is intended to be a composable piece in the
+  Streaming MCMC framework that seemlessly faciliates the use of
+  `Reducer`s. Its purpose is twofold: it generates an appropriate
+  sample from its `inner_kernel`, then invokes each reducer's
+  `one_step` method on that sample. The updated reducer states are
+  stored in the `streaming_calculations` field of `WithReductions`'
+  kernel results.
+
+  This `TransitionKernel` can also accept an arbitrary structure of
+  reducers. It then invokes all reducers in that structure with
+  one `WithReductions.one_step` call. The resulting reducer state
+  will identically mimic the structure of the provided reducers.
+  """
+
+  def __init__(self, inner_kernel, reducers, name=None):
+    """Instantiates this object.
+
+    Args:
+      inner_kernel: `TransitionKernel`-like object whose `one_step` will
+        generate MCMC sample(s).
+      reducers: A (possibly nested) structure of `Reducer`s to be evaluated
+        on the `inner_kernel`'s samples.
+      name: Python `str` name prefixed to Ops created by this function.
+        Default value: `None` (i.e., "reduced_kernel").
+    """
+    self._parameters = dict(
+        inner_kernel=inner_kernel,
+        reducers=reducers,
+        name=name or 'reduced_kernel'
+    )
+
+  def one_step(
+      self, current_state, previous_kernel_results=None, seed=None
+  ):
+    """Updates all `Reducer`s with a new sample from the `inner_kernel`.
+
+    Args:
+      current_state: `Tensor` or Python `list` of `Tensor`s
+        representing the current state(s) of the Markov chain(s),
+      previous_kernel_results: `WithReductionsKernelResults` named tuple,
+        or `None`. `WithReductionsKernelResults` contain the state of
+        `streaming_calculations` and a reference to kernel results of
+        nested `TransitionKernel`s. If `None`, the kernel will cold
+        start with a call to `bootstrap_results`.
+      seed: Optional seed for reproducible sampling.
+
+    Returns:
+      sample: Newest MCMC sample drawn from the `inner_kernel`.
+      kernel_results: `WithReductionsKernelResults` representing updated
+        kernel results. Reducer states are stored in the
+        `streaming_calculations` field. The state structure is identical
+        to `self.reducers`.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'with_reductions', 'one_step')):
+      if previous_kernel_results is None:
+        previous_kernel_results = self.bootstrap_results(current_state)
+      sample, inner_kernel_results = step_kernel(
+          num_steps=1,
+          current_state=current_state,
+          previous_kernel_results=previous_kernel_results.inner_results,
+          kernel=self.inner_kernel,
+          return_final_kernel_results=True,
+          seed=seed,
+          name=self.name,
+      )
+      new_reducers_state = nest.map_structure_up_to(
+          self.reducers,
+          lambda r, state: r.one_step(
+              sample,
+              state,
+              previous_kernel_results=previous_kernel_results,),
+          self.reducers, previous_kernel_results.streaming_calculations,
+          check_types=False)
+      kernel_results = WithReductionsKernelResults(
+          new_reducers_state, inner_kernel_results)
+      return sample, kernel_results
+
+  def bootstrap_results(self, init_state):
+    """Instantiates reducer states with identical structure to the `init_state`.
+
+    Args:
+      init_state: `Tensor` or Python `list` of `Tensor`s representing the a
+        state(s) of the Markov chain(s). For consistency, the initial state does
+        not count as a "sample". Hence, all reducer states will reflect empty
+        streams.
+
+    Returns:
+      kernel_results: `WithReductionsKernelResults` representing updated
+        kernel results. Reducer states are stored in the
+        `streaming_calculations` field. The state structure is identical
+        to `self.reducers`.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'with_reductions', 'bootstrap_results')):
+      inner_kernel_results = self.inner_kernel.bootstrap_results(init_state)
+      return WithReductionsKernelResults(
+          tf.nest.map_structure(
+              lambda r: r.initialize(init_state, inner_kernel_results),
+              self.reducers),
+          inner_kernel_results)
+
+  @property
+  def is_calibrated(self):
+    return self.inner_kernel.is_calibrated
+
+  @property
+  def parameters(self):
+    return self._parameters
+
+  @property
+  def inner_kernel(self):
+    return self._parameters['inner_kernel']
+
+  @property
+  def reducers(self):
+    return self._parameters['reducers']
+
+  @property
+  def name(self):
+    return self._parameters['name']

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions.py
@@ -54,7 +54,7 @@ class WithReductions(kernel_base.TransitionKernel):
   kernel results.
 
   This `TransitionKernel` can also accept an arbitrary structure of
-  reducers. It then invokes all reducers in that structure with
+  reducers. It then applies all reducers in that structure with
   one `WithReductions.one_step` call. The resulting reducer state
   will identically mimic the structure of the provided reducers.
   """

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -486,6 +486,9 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     self.assertEqual(kernel_results.inner_results.counter_1, 6)
     self.assertEqual(kernel_results.inner_results.counter_2, 12)
 
+  # TODO(Ru): once TracingReducer gets merged, add a test for building the onion
+  # when kernel results need to be traced
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -1,0 +1,488 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for WithReductions TransitionKernel."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+from absl.testing import parameterized
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.experimental.mcmc import CovarianceReducer
+from tensorflow_probability.python.experimental.mcmc import VarianceReducer
+from tensorflow_probability.python.experimental.mcmc import WithReductions
+from tensorflow_probability.python.internal import test_util
+
+
+class TestReducer(tfp.experimental.mcmc.Reducer):
+  """Simple Reducer that just keeps track of the last sample"""
+
+  def initialize(self, initial_chain_state=None, initial_kernel_results=None):
+    return None
+
+  def one_step(self, sample, current_reducer_state, previous_kernel_results):
+    return sample
+
+
+class MeanReducer(tfp.experimental.mcmc.Reducer):
+  """Simple Reducer that (naively) computes the mean"""
+
+  def initialize(self, initial_chain_state=None, initial_kernel_results=None):
+    return tf.zeros((2,))
+
+  def one_step(self, sample, current_reducer_state, previous_kernel_results):
+    return current_reducer_state + tf.convert_to_tensor([1, sample])
+
+  def finalize(self, final_state):
+    return final_state[1] / final_state[0]
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic Transition Kernel"""
+
+  def __init__(self, shape=(), target_log_prob_fn=None, is_calibrated=True):
+    self._is_calibrated = is_calibrated
+    self._shape = shape
+    # for composition purposes
+    self.parameters = dict(
+        target_log_prob_fn=target_log_prob_fn)
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    return (current_state + tf.ones(self._shape),
+            TestTransitionKernelResults(
+                counter_1=previous_kernel_results.counter_1 + 1,
+                counter_2=previous_kernel_results.counter_2 + 2))
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()),
+        counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+@test_util.test_all_tf_execution_regimes
+class WithReductionsTest(test_util.TestCase):
+
+  def test_simple_operation(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=fake_reducer,
+    )
+    new_sample, kernel_results = reducer_kernel.one_step(0.,)
+    new_sample, kernel_results = self.evaluate([
+        new_sample, kernel_results])
+    self.assertEqual(kernel_results.streaming_calculations, 1)
+    self.assertEqual(new_sample, 1)
+    self.assertEqual(kernel_results.inner_results.counter_1, 1)
+    self.assertEqual(kernel_results.inner_results.counter_2, 2)
+
+  def test_boostrap_results(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=fake_reducer,
+    )
+    pkr = reducer_kernel.bootstrap_results(9.)
+    inner_pkr = self.evaluate(pkr.inner_results)
+    self.assertEqual(pkr.streaming_calculations, None)
+    self.assertEqual(inner_pkr.counter_1, 0)
+    self.assertEqual(inner_pkr.counter_2, 0)
+
+  def test_is_calibrated(self):
+    fake_calibrated_kernel = TestTransitionKernel()
+    fake_uncalibrated_kernel = TestTransitionKernel(is_calibrated=False)
+    fake_reducer = TestReducer()
+    calibrated_reducer_kernel = WithReductions(
+        inner_kernel=fake_calibrated_kernel,
+        reducers=fake_reducer,
+    )
+    uncalibrated_reducer_kernel = WithReductions(
+        inner_kernel=fake_uncalibrated_kernel,
+        reducers=fake_reducer,
+    )
+    self.assertTrue(calibrated_reducer_kernel.is_calibrated)
+    self.assertFalse(uncalibrated_reducer_kernel.is_calibrated)
+
+  def test_tf_while(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=fake_reducer,
+    )
+    initial_sample, initial_kernel_results = reducer_kernel.one_step(0.,)
+
+    def _loop_body(i, curr_state, pkr):
+      new_state, kernel_results = reducer_kernel.one_step(curr_state, pkr)
+      return (i + 1, new_state, kernel_results)
+    _, new_sample, kernel_results = tf.while_loop(
+        lambda i, _, __: i < 5,
+        _loop_body,
+        (0., initial_sample, initial_kernel_results)
+    )
+
+    new_sample, kernel_results = self.evaluate([
+        new_sample, kernel_results])
+    self.assertEqual(kernel_results.streaming_calculations, 6)
+    self.assertEqual(new_sample, 6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 6)
+    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+
+  def test_nested_reducers(self):
+    fake_kernel = TestTransitionKernel()
+    nested_reducers = [[TestReducer(), TestReducer()], [TestReducer()]]
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=nested_reducers,
+    )
+    new_sample, kernel_results = reducer_kernel.one_step(0.,)
+    new_sample, kernel_results = self.evaluate([
+        new_sample, kernel_results])
+
+    self.assertEqual(
+        len(kernel_results.streaming_calculations[0]), 2)
+    self.assertEqual(
+        len(kernel_results.streaming_calculations[1]), 1)
+    self.assertEqual(
+        np.array(kernel_results.streaming_calculations).shape,
+        (2,))
+
+    self.assertAllEqual(
+        kernel_results.streaming_calculations,
+        [[1, 1], [1]])
+    self.assertEqual(new_sample, 1)
+    self.assertEqual(kernel_results.inner_results.counter_1, 1)
+    self.assertEqual(kernel_results.inner_results.counter_2, 2)
+
+  def test_nested_state_dependent_reducers(self):
+    fake_kernel = TestTransitionKernel()
+    nested_reducers = [[MeanReducer(), MeanReducer()], [MeanReducer()]]
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=nested_reducers,
+    )
+    new_sample, kernel_results = reducer_kernel.one_step(0.,)
+    new_sample, kernel_results = self.evaluate([
+        new_sample, kernel_results])
+
+    self.assertEqual(
+        len(kernel_results.streaming_calculations[0]), 2)
+    self.assertEqual(
+        len(kernel_results.streaming_calculations[1]), 1)
+    self.assertEqual(
+        np.array(kernel_results.streaming_calculations).shape,
+        (2,))
+
+    self.assertAllEqualNested(
+        kernel_results.streaming_calculations,
+        [[[1, 1], [1, 1]], [[1, 1]]])
+    self.assertEqual(new_sample, 1)
+    self.assertEqual(kernel_results.inner_results.counter_1, 1)
+    self.assertEqual(kernel_results.inner_results.counter_2, 2)
+
+
+@test_util.test_all_tf_execution_regimes
+class CovarianceWithReductionsTest(test_util.TestCase):
+
+  @parameterized.parameters(0, 1)
+  def test_covariance_reducer(self, ddof):
+    fake_kernel = TestTransitionKernel()
+    cov_reducer = CovarianceReducer(ddof=ddof)
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=cov_reducer,
+    )
+
+    chain_state, kernel_results = 0., None
+    for _ in range(6):
+      chain_state, kernel_results = reducer_kernel.one_step(
+          chain_state, kernel_results)
+
+    kernel_results, final_cov = self.evaluate([
+        kernel_results,
+        cov_reducer.finalize(
+            kernel_results.streaming_calculations)])
+    self.assertEqual(kernel_results.streaming_calculations.mean, 3.5)
+    self.assertNear(
+        final_cov,
+        np.cov(np.arange(1, 7), ddof=ddof).tolist(),
+        err=1e-6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 6)
+    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+
+  def test_covariance_with_batching(self):
+    fake_kernel = TestTransitionKernel((9, 3))
+    cov_reducer = CovarianceReducer(event_ndims=1)
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=cov_reducer,
+    )
+    state, kernel_results = tf.zeros((9, 3)), None
+    for _ in range(6):
+      state, kernel_results = reducer_kernel.one_step(
+          state, kernel_results)
+    kernel_results, final_cov = self.evaluate([
+        kernel_results,
+        cov_reducer.finalize(kernel_results.streaming_calculations)
+    ])
+    self.assertEqual(
+        kernel_results.streaming_calculations.mean.shape, (9, 3))
+    self.assertEqual(final_cov.shape, (9, 3, 3))
+
+  @parameterized.parameters(0, 1)
+  def test_variance_reducer(self, ddof):
+    fake_kernel = TestTransitionKernel()
+    reducer = VarianceReducer(ddof=ddof)
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=reducer,
+    )
+
+    chain_state, kernel_results = 0., None
+    for _ in range(6):
+      chain_state, kernel_results = reducer_kernel.one_step(
+          chain_state, kernel_results)
+
+    kernel_results, final_var = self.evaluate([
+        kernel_results,
+        reducer.finalize(
+            kernel_results.streaming_calculations)])
+    self.assertEqual(kernel_results.streaming_calculations.mean, 3.5)
+    self.assertNear(
+        final_var,
+        np.var(np.arange(1, 7), ddof=ddof).tolist(),
+        err=1e-6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 6)
+    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+
+  def test_multivariate_normal_covariance_with_sample_chain(self):
+    mu = [1, 2, 3]
+    cov = [[0.36, 0.12, 0.06],
+           [0.12, 0.29, -0.13],
+           [0.06, -0.13, 0.26]]
+    target = tfp.distributions.MultivariateNormalFullCovariance(
+        loc=mu, covariance_matrix=cov
+    )
+    fake_kernel = tfp.mcmc.HamiltonianMonteCarlo(
+        target_log_prob_fn=target.log_prob,
+        step_size=1/3,
+        num_leapfrog_steps=27
+    )
+    cov_reducer = CovarianceReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=cov_reducer,
+    )
+    samples, _, kernel_results = tfp.mcmc.sample_chain(
+        num_results=20,
+        current_state=tf.convert_to_tensor([1., 2., 3.]),
+        kernel=reducer_kernel,
+        trace_fn=None,
+        return_final_kernel_results=True,
+        seed=test_util.test_seed()
+    )
+    samples, kernel_results, final_cov = self.evaluate([
+        samples,
+        kernel_results,
+        cov_reducer.finalize(kernel_results.streaming_calculations)
+    ])
+    self.assertAllClose(
+        kernel_results.streaming_calculations.mean,
+        np.mean(samples, axis=0),
+        rtol=1e-6)
+    self.assertAllClose(
+        final_cov, np.cov(samples.T, ddof=0), rtol=1e-6)
+
+  def test_covariance_with_step_kernel(self):
+    fake_kernel = TestTransitionKernel()
+    cov_reducer = CovarianceReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=cov_reducer,
+    )
+    chain_state, kernel_results = tfp.experimental.mcmc.step_kernel(
+        num_steps=6,
+        current_state=0.,
+        kernel=reducer_kernel,
+        return_final_kernel_results=True,
+    )
+    chain_state, kernel_results, final_cov = self.evaluate([
+        chain_state,
+        kernel_results,
+        cov_reducer.finalize(kernel_results.streaming_calculations)
+    ])
+    self.assertEqual(chain_state, 6)
+    self.assertEqual(kernel_results.streaming_calculations.mean, 3.5)
+    self.assertNear(
+        final_cov,
+        np.cov(np.arange(1, 7), ddof=0).tolist(),
+        err=1e-6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 6)
+    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+
+  def test_covariance_before_transformation(self):
+    fake_kernel = TestTransitionKernel(lambda x: -x**2 / 2)
+    cov_reducer = CovarianceReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=cov_reducer,
+    )
+    transformed_kernel = tfp.mcmc.TransformedTransitionKernel(
+        inner_kernel=reducer_kernel,
+        bijector=tfp.bijectors.Exp(),
+    )
+    samples, _, kernel_results = tfp.mcmc.sample_chain(
+        num_results=10,
+        current_state=1.,
+        kernel=transformed_kernel,
+        trace_fn=None,
+        return_final_kernel_results=True,
+        seed=test_util.test_seed())
+    samples, kernel_results, final_cov = self.evaluate([
+        samples,
+        kernel_results,
+        cov_reducer.finalize(
+            kernel_results.inner_results.streaming_calculations)
+    ])
+    self.assertAllClose(
+        kernel_results.inner_results.streaming_calculations.mean,
+        np.mean(np.log(samples), axis=0),
+        rtol=1e-6)
+    self.assertAllClose(
+        final_cov, np.cov(np.log(samples).T, ddof=0), rtol=1e-6)
+
+  def test_covariance_after_transformation(self):
+    fake_kernel = TestTransitionKernel(lambda x: -x**2 / 2)
+    transformed_kernel = tfp.mcmc.TransformedTransitionKernel(
+        inner_kernel=fake_kernel,
+        bijector=tfp.bijectors.Exp(),
+    )
+    cov_reducer = CovarianceReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=transformed_kernel,
+        reducers=cov_reducer,
+    )
+    samples, _, kernel_results = tfp.mcmc.sample_chain(
+        num_results=10,
+        current_state=1.,
+        kernel=reducer_kernel,
+        trace_fn=None,
+        return_final_kernel_results=True,
+        seed=test_util.test_seed())
+    samples, kernel_results, final_cov = self.evaluate([
+        samples,
+        kernel_results,
+        cov_reducer.finalize(
+            kernel_results.streaming_calculations)
+    ])
+    self.assertAllClose(
+        kernel_results.streaming_calculations.mean,
+        np.mean(samples, axis=0),
+        rtol=1e-6)
+    self.assertAllClose(
+        final_cov, np.cov(samples.T, ddof=0), rtol=1e-6)
+
+  def test_nested_in_step_size_adaptation(self):
+    target_dist = tfp.distributions.MultivariateNormalDiag(
+        loc=[0., 0.], scale_diag=[1., 10.])
+    hmc_kernel = tfp.mcmc.HamiltonianMonteCarlo(
+        target_log_prob_fn=target_dist.log_prob,
+        num_leapfrog_steps=27,
+        step_size=10)
+    cov_reducer = CovarianceReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=hmc_kernel,
+        reducers=cov_reducer
+    )
+    step_adapted_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
+        inner_kernel=reducer_kernel,
+        adaptation_rate=0.8,
+        num_adaptation_steps=9)
+    samples, _, kernel_results = tfp.mcmc.sample_chain(
+        num_results=10,
+        current_state=tf.convert_to_tensor([0., 0.]),
+        kernel=step_adapted_kernel,
+        trace_fn=None,
+        return_final_kernel_results=True,
+        seed=test_util.test_seed())
+    samples, kernel_results, final_cov = self.evaluate([
+        samples,
+        kernel_results,
+        cov_reducer.finalize(
+            kernel_results.inner_results.streaming_calculations)
+    ])
+
+    mean = kernel_results.inner_results.streaming_calculations.mean
+    self.assertEqual(mean.shape, (2,))
+    self.assertAllClose(mean, np.mean(samples, axis=0), rtol=1e-6)
+    self.assertEqual(final_cov.shape, (2, 2))
+    self.assertAllClose(
+        final_cov, np.cov(samples.T, ddof=0), rtol=1e-6)
+
+  def test_nested_reducers(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    mean_reducer = MeanReducer()
+    cov_reducer = CovarianceReducer()
+    reducer_kernel = WithReductions(
+        inner_kernel=fake_kernel,
+        reducers=[[mean_reducer, cov_reducer], [fake_reducer]],
+    )
+
+    chain_state, kernel_results = 0., None
+    for _ in range(6):
+      chain_state, kernel_results = reducer_kernel.one_step(
+          chain_state, kernel_results)
+
+    kernel_results, final_cov, final_mean = self.evaluate([
+        kernel_results,
+        cov_reducer.finalize(
+            kernel_results.streaming_calculations[0][1]),
+        mean_reducer.finalize(
+            kernel_results.streaming_calculations[0][0])
+        ])
+    self.assertEqual(len(kernel_results.streaming_calculations), 2)
+    self.assertEqual(len(kernel_results.streaming_calculations[0]), 2)
+    self.assertEqual(len(kernel_results.streaming_calculations[1]), 1)
+
+    self.assertEqual(final_mean, 3.5)
+    self.assertEqual(kernel_results.streaming_calculations[0][1].mean, 3.5)
+    self.assertEqual(kernel_results.streaming_calculations[1][0], 6)
+    self.assertNear(
+        final_cov,
+        np.cov(np.arange(1, 7), ddof=0).tolist(),
+        err=1e-6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 6)
+    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -486,9 +486,6 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     self.assertEqual(kernel_results.inner_results.counter_1, 6)
     self.assertEqual(kernel_results.inner_results.counter_2, 12)
 
-  # TODO(Ru): once TracingReducer gets merged, add a test for building the onion
-  # when kernel results need to be traced
-
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -38,8 +38,9 @@ class TestReducer(tfp.experimental.mcmc.Reducer):
   def initialize(self, initial_chain_state=None, initial_kernel_results=None):
     return None
 
-  def one_step(self, sample, current_reducer_state, previous_kernel_results):
-    return sample
+  def one_step(
+      self, new_chain_state, current_reducer_state, previous_kernel_results):
+    return new_chain_state
 
 
 class MeanReducer(tfp.experimental.mcmc.Reducer):
@@ -48,8 +49,9 @@ class MeanReducer(tfp.experimental.mcmc.Reducer):
   def initialize(self, initial_chain_state=None, initial_kernel_results=None):
     return tf.zeros((2,))
 
-  def one_step(self, sample, current_reducer_state, previous_kernel_results):
-    return current_reducer_state + tf.convert_to_tensor([1, sample])
+  def one_step(
+      self, new_chain_state, current_reducer_state, previous_kernel_results):
+    return current_reducer_state + tf.convert_to_tensor([1, new_chain_state])
 
   def finalize(self, final_state):
     return final_state[1] / final_state[0]

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Tests for WithReductions TransitionKernel."""
+"""Tests for tfp.experimental.mcmc.WithReductions TransitionKernel."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -26,9 +26,6 @@ import numpy as np
 
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
-from tensorflow_probability.python.experimental.mcmc import CovarianceReducer
-from tensorflow_probability.python.experimental.mcmc import VarianceReducer
-from tensorflow_probability.python.experimental.mcmc import WithReductions
 from tensorflow_probability.python.internal import test_util
 
 
@@ -93,7 +90,7 @@ class WithReductionsTest(test_util.TestCase):
   def test_simple_operation(self):
     fake_kernel = TestTransitionKernel()
     fake_reducer = TestReducer()
-    reducer_kernel = WithReductions(
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=fake_reducer,
     )
@@ -101,32 +98,32 @@ class WithReductionsTest(test_util.TestCase):
     new_sample, kernel_results = reducer_kernel.one_step(0., pkr)
     new_sample, kernel_results = self.evaluate([
         new_sample, kernel_results])
-    self.assertEqual(kernel_results.streaming_calculations, 1)
-    self.assertEqual(new_sample, 1)
-    self.assertEqual(kernel_results.inner_results.counter_1, 1)
-    self.assertEqual(kernel_results.inner_results.counter_2, 2)
+    self.assertEqual(1, kernel_results.streaming_calculations)
+    self.assertEqual(1, new_sample)
+    self.assertEqual(1, kernel_results.inner_results.counter_1)
+    self.assertEqual(2, kernel_results.inner_results.counter_2)
 
   def test_boostrap_results(self):
     fake_kernel = TestTransitionKernel()
     fake_reducer = TestReducer()
-    reducer_kernel = WithReductions(
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=fake_reducer,
     )
     pkr = self.evaluate(reducer_kernel.bootstrap_results(9.))
-    self.assertEqual(pkr.streaming_calculations, 0)
-    self.assertEqual(pkr.inner_results.counter_1, 0)
-    self.assertEqual(pkr.inner_results.counter_2, 0)
+    self.assertEqual(0, pkr.streaming_calculations, 0)
+    self.assertEqual(0, pkr.inner_results.counter_1, 0)
+    self.assertEqual(0, pkr.inner_results.counter_2, 0)
 
   def test_is_calibrated(self):
     fake_calibrated_kernel = TestTransitionKernel()
     fake_uncalibrated_kernel = TestTransitionKernel(is_calibrated=False)
     fake_reducer = TestReducer()
-    calibrated_reducer_kernel = WithReductions(
+    calibrated_reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_calibrated_kernel,
         reducers=fake_reducer,
     )
-    uncalibrated_reducer_kernel = WithReductions(
+    uncalibrated_reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_uncalibrated_kernel,
         reducers=fake_reducer,
     )
@@ -136,7 +133,7 @@ class WithReductionsTest(test_util.TestCase):
   def test_tf_while(self):
     fake_kernel = TestTransitionKernel()
     fake_reducer = TestReducer()
-    reducer_kernel = WithReductions(
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=fake_reducer,
     )
@@ -157,15 +154,15 @@ class WithReductionsTest(test_util.TestCase):
 
     new_sample, kernel_results = self.evaluate([
         new_sample, kernel_results])
-    self.assertEqual(kernel_results.streaming_calculations, 6)
-    self.assertEqual(new_sample, 6)
-    self.assertEqual(kernel_results.inner_results.counter_1, 6)
-    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+    self.assertEqual(6, kernel_results.streaming_calculations)
+    self.assertEqual(6, new_sample)
+    self.assertEqual(6, kernel_results.inner_results.counter_1)
+    self.assertEqual(12, kernel_results.inner_results.counter_2)
 
   def test_nested_reducers(self):
     fake_kernel = TestTransitionKernel()
     nested_reducers = [[TestReducer(), TestReducer()], [TestReducer()]]
-    reducer_kernel = WithReductions(
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=nested_reducers,
     )
@@ -175,24 +172,24 @@ class WithReductionsTest(test_util.TestCase):
         new_sample, kernel_results])
 
     self.assertEqual(
-        len(kernel_results.streaming_calculations[0]), 2)
+        2, len(kernel_results.streaming_calculations[0]))
     self.assertEqual(
-        len(kernel_results.streaming_calculations[1]), 1)
+        1, len(kernel_results.streaming_calculations[1]))
     self.assertEqual(
-        np.array(kernel_results.streaming_calculations).shape,
-        (2,))
+        (2,),
+        np.array(kernel_results.streaming_calculations).shape)
 
     self.assertAllEqual(
-        kernel_results.streaming_calculations,
-        [[1, 1], [1]])
-    self.assertEqual(new_sample, 1)
-    self.assertEqual(kernel_results.inner_results.counter_1, 1)
-    self.assertEqual(kernel_results.inner_results.counter_2, 2)
+        [[1, 1], [1]],
+        kernel_results.streaming_calculations)
+    self.assertEqual(1, new_sample)
+    self.assertEqual(1, kernel_results.inner_results.counter_1)
+    self.assertEqual(2, kernel_results.inner_results.counter_2)
 
   def test_nested_state_dependent_reducers(self):
     fake_kernel = TestTransitionKernel()
     nested_reducers = [[MeanReducer(), MeanReducer()], [MeanReducer()]]
-    reducer_kernel = WithReductions(
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=nested_reducers,
     )
@@ -202,19 +199,22 @@ class WithReductionsTest(test_util.TestCase):
         new_sample, kernel_results])
 
     self.assertEqual(
-        len(kernel_results.streaming_calculations[0]), 2)
+        2,
+        len(kernel_results.streaming_calculations[0]))
     self.assertEqual(
-        len(kernel_results.streaming_calculations[1]), 1)
+        1,
+        len(kernel_results.streaming_calculations[1]))
     self.assertEqual(
-        np.array(kernel_results.streaming_calculations).shape,
-        (2,))
+        (2,),
+        np.array(kernel_results.streaming_calculations).shape)
 
     self.assertAllEqualNested(
         kernel_results.streaming_calculations,
-        [[[1, 1], [1, 1]], [[1, 1]]])
-    self.assertEqual(new_sample, 1)
-    self.assertEqual(kernel_results.inner_results.counter_1, 1)
-    self.assertEqual(kernel_results.inner_results.counter_2, 2)
+        [[[1, 1], [1, 1]], [[1, 1]]],
+    )
+    self.assertEqual(1, new_sample)
+    self.assertEqual(1, kernel_results.inner_results.counter_1)
+    self.assertEqual(2, kernel_results.inner_results.counter_2)
 
 
 @test_util.test_all_tf_execution_regimes
@@ -223,8 +223,8 @@ class CovarianceWithReductionsTest(test_util.TestCase):
   @parameterized.parameters(0, 1)
   def test_covariance_reducer(self, ddof):
     fake_kernel = TestTransitionKernel()
-    cov_reducer = CovarianceReducer(ddof=ddof)
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer(ddof=ddof)
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=cov_reducer,
     )
@@ -238,18 +238,18 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         kernel_results,
         cov_reducer.finalize(
             kernel_results.streaming_calculations)])
-    self.assertEqual(kernel_results.streaming_calculations.cov_state.mean, 3.5)
+    self.assertEqual(3.5, kernel_results.streaming_calculations.cov_state.mean)
     self.assertNear(
-        final_cov,
         np.cov(np.arange(1, 7), ddof=ddof).tolist(),
+        final_cov,
         err=1e-6)
-    self.assertEqual(kernel_results.inner_results.counter_1, 6)
-    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+    self.assertEqual(6, kernel_results.inner_results.counter_1)
+    self.assertEqual(12, kernel_results.inner_results.counter_2)
 
   def test_covariance_with_batching(self):
     fake_kernel = TestTransitionKernel((9, 3))
-    cov_reducer = CovarianceReducer(event_ndims=1)
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer(event_ndims=1)
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=cov_reducer,
     )
@@ -263,14 +263,14 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         cov_reducer.finalize(kernel_results.streaming_calculations)
     ])
     self.assertEqual(
-        kernel_results.streaming_calculations.cov_state.mean.shape, (9, 3))
-    self.assertEqual(final_cov.shape, (9, 3, 3))
+        (9, 3), kernel_results.streaming_calculations.cov_state.mean.shape)
+    self.assertEqual((9, 3, 3), final_cov.shape)
 
   @parameterized.parameters(0, 1)
   def test_variance_reducer(self, ddof):
     fake_kernel = TestTransitionKernel()
-    reducer = VarianceReducer(ddof=ddof)
-    reducer_kernel = WithReductions(
+    reducer = tfp.experimental.mcmc.VarianceReducer(ddof=ddof)
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=reducer,
     )
@@ -284,13 +284,13 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         kernel_results,
         reducer.finalize(
             kernel_results.streaming_calculations)])
-    self.assertEqual(kernel_results.streaming_calculations.cov_state.mean, 3.5)
+    self.assertEqual(3.5, kernel_results.streaming_calculations.cov_state.mean)
     self.assertNear(
-        final_var,
         np.var(np.arange(1, 7), ddof=ddof).tolist(),
+        final_var,
         err=1e-6)
-    self.assertEqual(kernel_results.inner_results.counter_1, 6)
-    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+    self.assertEqual(6, kernel_results.inner_results.counter_1)
+    self.assertEqual(12, kernel_results.inner_results.counter_2)
 
   def test_multivariate_normal_covariance_with_sample_chain(self):
     mu = [1, 2, 3]
@@ -305,8 +305,8 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         step_size=1/3,
         num_leapfrog_steps=27
     )
-    cov_reducer = CovarianceReducer()
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=cov_reducer,
     )
@@ -324,16 +324,16 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         cov_reducer.finalize(kernel_results.streaming_calculations)
     ])
     self.assertAllClose(
-        kernel_results.streaming_calculations.cov_state.mean,
         np.mean(samples, axis=0),
+        kernel_results.streaming_calculations.cov_state.mean,
         rtol=1e-6)
     self.assertAllClose(
-        final_cov, np.cov(samples.T, ddof=0), rtol=1e-6)
+        np.cov(samples.T, ddof=0), final_cov, rtol=1e-6)
 
   def test_covariance_with_step_kernel(self):
     fake_kernel = TestTransitionKernel()
-    cov_reducer = CovarianceReducer()
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=cov_reducer,
     )
@@ -348,19 +348,19 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         kernel_results,
         cov_reducer.finalize(kernel_results.streaming_calculations)
     ])
-    self.assertEqual(chain_state, 6)
-    self.assertEqual(kernel_results.streaming_calculations.cov_state.mean, 3.5)
+    self.assertEqual(6, chain_state)
+    self.assertEqual(3.5, kernel_results.streaming_calculations.cov_state.mean)
     self.assertNear(
-        final_cov,
         np.cov(np.arange(1, 7), ddof=0).tolist(),
+        final_cov,
         err=1e-6)
-    self.assertEqual(kernel_results.inner_results.counter_1, 6)
-    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+    self.assertEqual(6, kernel_results.inner_results.counter_1)
+    self.assertEqual(12, kernel_results.inner_results.counter_2)
 
   def test_covariance_before_transformation(self):
     fake_kernel = TestTransitionKernel(lambda x: -x**2 / 2)
-    cov_reducer = CovarianceReducer()
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=cov_reducer,
     )
@@ -382,11 +382,11 @@ class CovarianceWithReductionsTest(test_util.TestCase):
             kernel_results.inner_results.streaming_calculations)
     ])
     self.assertAllClose(
-        kernel_results.inner_results.streaming_calculations.cov_state.mean,
         np.mean(np.log(samples), axis=0),
+        kernel_results.inner_results.streaming_calculations.cov_state.mean,
         rtol=1e-6)
     self.assertAllClose(
-        final_cov, np.cov(np.log(samples).T, ddof=0), rtol=1e-6)
+        np.cov(np.log(samples).T, ddof=0), final_cov, rtol=1e-6)
 
   def test_covariance_after_transformation(self):
     fake_kernel = TestTransitionKernel(lambda x: -x**2 / 2)
@@ -394,8 +394,8 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         inner_kernel=fake_kernel,
         bijector=tfp.bijectors.Exp(),
     )
-    cov_reducer = CovarianceReducer()
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=transformed_kernel,
         reducers=cov_reducer,
     )
@@ -413,11 +413,11 @@ class CovarianceWithReductionsTest(test_util.TestCase):
             kernel_results.streaming_calculations)
     ])
     self.assertAllClose(
-        kernel_results.streaming_calculations.cov_state.mean,
         np.mean(samples, axis=0),
+        kernel_results.streaming_calculations.cov_state.mean,
         rtol=1e-6)
     self.assertAllClose(
-        final_cov, np.cov(samples.T, ddof=0), rtol=1e-6)
+        np.cov(samples.T, ddof=0), final_cov, rtol=1e-6)
 
   def test_nested_in_step_size_adaptation(self):
     target_dist = tfp.distributions.MultivariateNormalDiag(
@@ -426,8 +426,8 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         target_log_prob_fn=target_dist.log_prob,
         num_leapfrog_steps=27,
         step_size=10)
-    cov_reducer = CovarianceReducer()
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=hmc_kernel,
         reducers=cov_reducer
     )
@@ -450,18 +450,18 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     ])
 
     mean = kernel_results.inner_results.streaming_calculations.cov_state.mean
-    self.assertEqual(mean.shape, (2,))
-    self.assertAllClose(mean, np.mean(samples, axis=0), rtol=1e-6)
-    self.assertEqual(final_cov.shape, (2, 2))
+    self.assertEqual((2,), mean.shape)
+    self.assertAllClose(np.mean(samples, axis=0), mean, rtol=1e-6)
+    self.assertEqual((2, 2), final_cov.shape)
     self.assertAllClose(
-        final_cov, np.cov(samples.T, ddof=0), rtol=1e-6)
+        np.cov(samples.T, ddof=0), final_cov, rtol=1e-6)
 
   def test_nested_reducers(self):
     fake_kernel = TestTransitionKernel()
     fake_reducer = TestReducer()
     mean_reducer = MeanReducer()
-    cov_reducer = CovarianceReducer()
-    reducer_kernel = WithReductions(
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
         reducers=[[mean_reducer, cov_reducer], [fake_reducer]],
     )
@@ -478,20 +478,20 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         mean_reducer.finalize(
             kernel_results.streaming_calculations[0][0])
         ])
-    self.assertEqual(len(kernel_results.streaming_calculations), 2)
-    self.assertEqual(len(kernel_results.streaming_calculations[0]), 2)
-    self.assertEqual(len(kernel_results.streaming_calculations[1]), 1)
+    self.assertEqual(2, len(kernel_results.streaming_calculations))
+    self.assertEqual(2, len(kernel_results.streaming_calculations[0]))
+    self.assertEqual(1, len(kernel_results.streaming_calculations[1]))
 
-    self.assertEqual(final_mean, 3.5)
+    self.assertEqual(3.5, final_mean)
     self.assertEqual(
-        kernel_results.streaming_calculations[0][1].cov_state.mean, 3.5)
-    self.assertEqual(kernel_results.streaming_calculations[1][0], 6)
+        3.5, kernel_results.streaming_calculations[0][1].cov_state.mean)
+    self.assertEqual(6, kernel_results.streaming_calculations[1][0])
     self.assertNear(
-        final_cov,
         np.cov(np.arange(1, 7), ddof=0).tolist(),
+        final_cov,
         err=1e-6)
-    self.assertEqual(kernel_results.inner_results.counter_1, 6)
-    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+    self.assertEqual(6, kernel_results.inner_results.counter_1)
+    self.assertEqual(12, kernel_results.inner_results.counter_2)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -36,11 +36,10 @@ class TestReducer(tfp.experimental.mcmc.Reducer):
   """Simple Reducer that just keeps track of the last sample"""
 
   def initialize(self, initial_chain_state, initial_kernel_results=None):
-    return tf.zeros(tf.convert_to_tensor(initial_chain_state).shape)
+    return tf.zeros_like(initial_chain_state)
 
   def one_step(
       self, new_chain_state, current_reducer_state, previous_kernel_results):
-    print(new_chain_state)
     return new_chain_state
 
 

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -230,7 +230,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         kernel_results,
         cov_reducer.finalize(
             kernel_results.streaming_calculations)])
-    self.assertEqual(kernel_results.streaming_calculations.mean, 3.5)
+    self.assertEqual(kernel_results.streaming_calculations.cov_state.mean, 3.5)
     self.assertNear(
         final_cov,
         np.cov(np.arange(1, 7), ddof=ddof).tolist(),
@@ -254,7 +254,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         cov_reducer.finalize(kernel_results.streaming_calculations)
     ])
     self.assertEqual(
-        kernel_results.streaming_calculations.mean.shape, (9, 3))
+        kernel_results.streaming_calculations.cov_state.mean.shape, (9, 3))
     self.assertEqual(final_cov.shape, (9, 3, 3))
 
   @parameterized.parameters(0, 1)
@@ -275,7 +275,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         kernel_results,
         reducer.finalize(
             kernel_results.streaming_calculations)])
-    self.assertEqual(kernel_results.streaming_calculations.mean, 3.5)
+    self.assertEqual(kernel_results.streaming_calculations.cov_state.mean, 3.5)
     self.assertNear(
         final_var,
         np.var(np.arange(1, 7), ddof=ddof).tolist(),
@@ -315,7 +315,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         cov_reducer.finalize(kernel_results.streaming_calculations)
     ])
     self.assertAllClose(
-        kernel_results.streaming_calculations.mean,
+        kernel_results.streaming_calculations.cov_state.mean,
         np.mean(samples, axis=0),
         rtol=1e-6)
     self.assertAllClose(
@@ -340,7 +340,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
         cov_reducer.finalize(kernel_results.streaming_calculations)
     ])
     self.assertEqual(chain_state, 6)
-    self.assertEqual(kernel_results.streaming_calculations.mean, 3.5)
+    self.assertEqual(kernel_results.streaming_calculations.cov_state.mean, 3.5)
     self.assertNear(
         final_cov,
         np.cov(np.arange(1, 7), ddof=0).tolist(),
@@ -373,7 +373,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
             kernel_results.inner_results.streaming_calculations)
     ])
     self.assertAllClose(
-        kernel_results.inner_results.streaming_calculations.mean,
+        kernel_results.inner_results.streaming_calculations.cov_state.mean,
         np.mean(np.log(samples), axis=0),
         rtol=1e-6)
     self.assertAllClose(
@@ -404,7 +404,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
             kernel_results.streaming_calculations)
     ])
     self.assertAllClose(
-        kernel_results.streaming_calculations.mean,
+        kernel_results.streaming_calculations.cov_state.mean,
         np.mean(samples, axis=0),
         rtol=1e-6)
     self.assertAllClose(
@@ -440,7 +440,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
             kernel_results.inner_results.streaming_calculations)
     ])
 
-    mean = kernel_results.inner_results.streaming_calculations.mean
+    mean = kernel_results.inner_results.streaming_calculations.cov_state.mean
     self.assertEqual(mean.shape, (2,))
     self.assertAllClose(mean, np.mean(samples, axis=0), rtol=1e-6)
     self.assertEqual(final_cov.shape, (2, 2))
@@ -474,7 +474,8 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     self.assertEqual(len(kernel_results.streaming_calculations[1]), 1)
 
     self.assertEqual(final_mean, 3.5)
-    self.assertEqual(kernel_results.streaming_calculations[0][1].mean, 3.5)
+    self.assertEqual(
+        kernel_results.streaming_calculations[0][1].cov_state.mean, 3.5)
     self.assertEqual(kernel_results.streaming_calculations[1][0], 6)
     self.assertNear(
         final_cov,

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -48,7 +48,7 @@ class MeanReducer(tfp.experimental.mcmc.Reducer):
 
   def one_step(
       self, new_chain_state, current_reducer_state, previous_kernel_results):
-    return current_reducer_state + tf.convert_to_tensor([1, new_chain_state])
+    return current_reducer_state + tf.stack([1, new_chain_state])
 
   def finalize(self, final_state):
     return final_state[1] / final_state[0]


### PR DESCRIPTION
Adding a composable piece in the streaming MCMC framework (with temporary name). `WithReductions` is a wrapper Transition Kernel that allows `Reducer`s to seamlessly fit into the framework and compose with other `TransitionKernel`s. 