### PR TITLE
Fixing ridiculous loop unrolling in `smart_for_loop`

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/sample_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_test.py
@@ -170,17 +170,16 @@ class StepKernelTest(test_util.TestCase):
       self.assertNotEqual(first_final_state, last_state)
       last_state_t = first_final_state_t
 
-  @test_util.test_graph_and_eager_modes
-  def test_smart_for_loop_uses_tf_function(self):
+  @test_util.test_graph_mode_only
+  def test_smart_for_loop_uses_tf_while(self):
     dtype = np.float32
     true_mean = dtype([0, 0])
     true_cov = dtype([[1, 0.5],
                       [0.5, 1]])
     true_cov_chol = np.linalg.cholesky(true_cov)
-    num_results = 1000
+    num_results = 100
     counter = collections.Counter()
 
-    @tf.function
     def target_log_prob(x, y):
       counter['target_calls'] += 1
       z = tf.stack([x, y], axis=-1) - true_mean
@@ -197,7 +196,7 @@ class StepKernelTest(test_util.TestCase):
         return_final_kernel_results=False,
         seed=test_util.test_seed())
 
-    self.assertAllEqual(dict(target_calls=1), counter)
+    self.assertAllEqual(dict(target_calls=4), counter)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/mcmc/internal/util.py
+++ b/tensorflow_probability/python/mcmc/internal/util.py
@@ -332,8 +332,10 @@ def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
   """
   with tf.name_scope(name or 'smart_for_loop'):
     loop_num_iter_ = tf.get_static_value(loop_num_iter)
-    if (loop_num_iter_ is None or tf.executing_eagerly() or
-        control_flow_util.GraphOrParentsInXlaContext(
+    if (loop_num_iter_ is None
+        or tf.executing_eagerly()
+        or loop_num_iter_ > 1
+        or control_flow_util.GraphOrParentsInXlaContext(
             tf1.get_default_graph())):
       # Cast to int32 to run the comparison against i in host memory,
       # where while/LoopCond needs it.

--- a/tensorflow_probability/python/mcmc/internal/util.py
+++ b/tensorflow_probability/python/mcmc/internal/util.py
@@ -306,7 +306,7 @@ def maybe_call_fn_and_grads(fn,
 
 
 def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
-                   parallel_iterations=10, name=None):
+                   parallel_iterations=10, unroll_threshold=1, name=None):
   """Construct a for loop, preferring a python loop if `n` is statically known.
 
   Given `loop_num_iter` and `body_fn`, return an op corresponding to executing
@@ -325,6 +325,11 @@ def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
     parallel_iterations: The number of iterations allowed to run in parallel.
       It must be a positive integer. See `tf.while_loop` for more details.
       Default value: `10`.
+    unroll_threshold: Integer denoting the maximum number of iterations to
+      unroll, if possible. If `loop_num_iter > unroll_threshold` a
+      `tf.while_loop` will always be used, even if `loop_num_iter` is
+      statically known.
+      Default value: `1`.
     name: Python `str` name prefixed to Ops created by this function.
       Default value: `None` (i.e., "smart_for_loop").
   Returns:
@@ -336,7 +341,7 @@ def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
         or tf.executing_eagerly()
         # large values for loop_num_iter_ will cause ridiculously slow
         # graph compilation time (GitHub issue #1033)
-        or loop_num_iter_ > 1
+        or loop_num_iter_ > unroll_threshold
         or control_flow_util.GraphOrParentsInXlaContext(
             tf1.get_default_graph())):
       # Cast to int32 to run the comparison against i in host memory,
@@ -349,7 +354,6 @@ def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
           parallel_iterations=parallel_iterations
       )[1:]
     result = initial_loop_vars
-    # loop_num_iter_ is no more than 1
     for _ in range(loop_num_iter_):
       result = body_fn(*result)
     return result

--- a/tensorflow_probability/python/mcmc/internal/util.py
+++ b/tensorflow_probability/python/mcmc/internal/util.py
@@ -334,6 +334,8 @@ def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
     loop_num_iter_ = tf.get_static_value(loop_num_iter)
     if (loop_num_iter_ is None
         or tf.executing_eagerly()
+        # large values for loop_num_iter_ will cause ridiculously slow
+        # graph compilation time (GitHub issue #1033)
         or loop_num_iter_ > 1
         or control_flow_util.GraphOrParentsInXlaContext(
             tf1.get_default_graph())):
@@ -347,6 +349,7 @@ def smart_for_loop(loop_num_iter, body_fn, initial_loop_vars,
           parallel_iterations=parallel_iterations
       )[1:]
     result = initial_loop_vars
+    # loop_num_iter_ is no more than 1
     for _ in range(loop_num_iter_):
       result = body_fn(*result)
     return result

--- a/tensorflow_probability/python/mcmc/internal/util_test.py
+++ b/tensorflow_probability/python/mcmc/internal/util_test.py
@@ -196,8 +196,28 @@ class GradientTest(test_util.TestCase):
 @test_util.test_all_tf_execution_regimes
 class SmartForLoopTest(test_util.TestCase):
 
-  def test_python_for_loop(self):
+  @parameterized.parameters(0, 1)
+  def test_python_for_loop(self, loop_iters):
     counter = None
+    # following loop variables not @parameterized because the tf.constants
+    # would be executed outside the Eager mode that
+    # @test_util.test_all_tf_execution_regimes creates
+    for n in [loop_iters, tf.constant(loop_iters, dtype=tf.int64),
+              tf.constant(loop_iters, dtype=tf.int32)]:
+      counter = collections.Counter()
+      def body(x):
+        counter['body_calls'] += 1
+        return [x + 1]
+
+      result = util.smart_for_loop(
+          loop_num_iter=n, body_fn=body, initial_loop_vars=[tf.constant(1)])
+      expected_calls = 1 if JAX_MODE else loop_iters  # JAX always traces loops
+      self.assertEqual(expected_calls, counter['body_calls'])
+      self.assertAllClose([loop_iters + 1], self.evaluate(result))
+
+  def test_tf_while_on_large_iters(self):
+    counter = None
+    iters = 10
     # Not @parameterized because the tf.constants would be executed outside the
     # Eager mode that @test_util.test_all_tf_execution_regimes creates, and
     # TF is unhappy about that.
@@ -210,8 +230,10 @@ class SmartForLoopTest(test_util.TestCase):
 
       result = util.smart_for_loop(
           loop_num_iter=n, body_fn=body, initial_loop_vars=[tf.constant(1)])
-      expected_calls = 1 if JAX_MODE else 10  # JAX always traces loops
-      self.assertEqual(expected_calls, counter['body_calls'])
+      if tf.executing_eagerly() and not JAX_MODE:  # JAX always traces loops
+        self.assertEqual(iters, counter['body_calls'])
+      else:
+        self.assertEqual(1, counter['body_calls'])
       self.assertAllClose([11], self.evaluate(result))
 
   def test_tf_while_loop(self):


### PR DESCRIPTION
A direct fix of the issue described in https://github.com/tensorflow/probability/issues/1033. I've also added a test for `tfp.experimental.mcmc.step_kernel` to ensure that future building blocks in the streaming MCMC framework will work as intended