### PR TITLE
Add `sample_fold` driver to `tfp.experimental.mcmc`

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -42,6 +42,7 @@ py_library(
         ":particle_filter_augmentation",
         ":reducer",
         ":sample",
+        ":sample_fold",
         ":sample_sequential_monte_carlo",
         ":sequential_monte_carlo_kernel",
         ":weighted_resampling",
@@ -407,6 +408,32 @@ py_test(
     name = "with_reductions_test",
     srcs = ["with_reductions_test.py"],
     deps = [
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
+    name = "sample_fold",
+    srcs = ["sample_fold.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        ":sample",
+        ":with_reductions",
+    ],
+)
+
+# py2and3
+py_test(
+    name = "sample_fold_test",
+    size = "small",
+    srcs = ["sample_fold_test.py"],
+    shard_count = 5,
+    deps = [
+        # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
         "//tensorflow_probability/python/internal:test_util",

--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -42,6 +42,7 @@ py_library(
         ":particle_filter_augmentation",
         ":reducer",
         ":sample",
+        ":sample_discarding_kernel",
         ":sample_fold",
         ":sample_sequential_monte_carlo",
         ":sequential_monte_carlo_kernel",
@@ -431,6 +432,32 @@ py_test(
     name = "sample_fold_test",
     size = "small",
     srcs = ["sample_fold_test.py"],
+    shard_count = 5,
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
+    name = "sample_discarding_kernel",
+    srcs = ["sample_discarding_kernel.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        # tensorflow dep,
+        ":sample",
+        "//tensorflow_probability/python/mcmc/internal",
+        "//tensorflow_probability/python/mcmc:kernel",
+    ],
+)
+
+# py2and3
+py_test(
+    name = "sample_discarding_kernel_test",
+    size = "small",
+    srcs = ["sample_discarding_kernel_test.py"],
     shard_count = 5,
     deps = [
         # numpy dep,

--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -423,6 +423,7 @@ py_library(
         # numpy dep,
         # tensorflow dep,
         ":sample",
+        ":sample_discarding_kernel",
         ":with_reductions",
     ],
 )

--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -459,7 +459,6 @@ py_test(
     name = "sample_discarding_kernel_test",
     size = "small",
     srcs = ["sample_discarding_kernel_test.py"],
-    shard_count = 5,
     deps = [
         # numpy dep,
         # tensorflow dep,

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -48,6 +48,7 @@ from tensorflow_probability.python.experimental.mcmc.weighted_resampling import 
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_stratified
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_systematic
 from tensorflow_probability.python.experimental.mcmc.with_reductions import WithReductions
+from tensorflow_probability.python.experimental.mcmc.with_reductions import WithReductionsKernelResults
 
 
 __all__ = [
@@ -81,4 +82,5 @@ __all__ = [
     'step_kernel',
     'VarianceReducer',
     'WithReductions',
+    'WithReductionsKernelResults',
 ]

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -31,6 +31,7 @@ from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentatio
 from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentation import StateWithHistory
 from tensorflow_probability.python.experimental.mcmc.reducer import Reducer
 from tensorflow_probability.python.experimental.mcmc.sample import step_kernel
+from tensorflow_probability.python.experimental.mcmc.sample_discarding_kernel import SampleDiscardingKernel
 from tensorflow_probability.python.experimental.mcmc.sample_fold import sample_fold
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import default_make_hmc_kernel_fn
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import gen_make_hmc_kernel_fn
@@ -73,6 +74,7 @@ __all__ = [
     'resample_independent',
     'resample_stratified',
     'resample_systematic',
+    'SampleDiscardingKernel',
     'sample_fold',
     'sample_sequential_monte_carlo',
     'simple_heuristic_tuning',

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -31,6 +31,7 @@ from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentatio
 from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentation import StateWithHistory
 from tensorflow_probability.python.experimental.mcmc.reducer import Reducer
 from tensorflow_probability.python.experimental.mcmc.sample import step_kernel
+from tensorflow_probability.python.experimental.mcmc.sample_fold import sample_fold
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import default_make_hmc_kernel_fn
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import gen_make_hmc_kernel_fn
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import gen_make_transform_hmc_kernel_fn
@@ -72,6 +73,7 @@ __all__ = [
     'resample_independent',
     'resample_stratified',
     'resample_systematic',
+    'sample_fold',
     'sample_sequential_monte_carlo',
     'simple_heuristic_tuning',
     'step_kernel',

--- a/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
@@ -70,7 +70,7 @@ class CovarianceReducer(reducer_base.Reducer):
 
   kernel = ...
   reducer = tfp.experimental.mcmc.CovarianceReducer()
-  covariance_estimate = tfp.experimental.mcmc.sample_fold(
+  covariance_estimate, _, _ = tfp.experimental.mcmc.sample_fold(
       num_steps=...,
       current_state=...,
       previous_kernel_results=...,

--- a/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
@@ -56,17 +56,17 @@ class CovarianceReducer(reducer_base.Reducer):
   There are two ways to stream over MCMC samples. The first is to manually
   wrap `CovarianceReducer` in a `tfp.experimental.mcmc.WithReductions`
   `TransitionKernel`. Doing so enables a wide variety of possible compositions.
-  For example, to perform covariance calculation on samples that survive thinning
-  and burn-in, `WithReductions` should wrap around an appropriate
+  For example, to perform covariance calculation on samples that survive
+  thinning and burn-in, `WithReductions` should wrap around an appropriate
   `SampleDiscardingKernel`.
-  
+
   If the sole objective is to estimate covariance, it may be more convenient to
-  use a pre-defined driver like `tfp.experimental.mcmc.sample_fold`. `sample_fold`
-  will automatically create the Transition Kernel onion, apply `kernel` samples
-  to update reducer states, and `finalize` calculations.
+  use a pre-defined driver like `tfp.experimental.mcmc.sample_fold`.
+  `sample_fold` will automatically create the Transition Kernel onion, apply
+  `kernel` samples to update reducer states, and `finalize` calculations.
 
   ```
-  python 
+  python
 
   kernel = ...
   reducer = tfp.experimental.mcmc.CovarianceReducer()

--- a/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
@@ -60,12 +60,10 @@ class CovarianceReducer(reducer_base.Reducer):
   and burn-in, `WithReductions` should wrap around an appropriate
   `SampleDiscardingKernel`.
   
-  If the sole objective is to compute some reduction statistic, it may be more
-  convenient to use a pre-defined driver like `tfp.experimental.mcmc.sample_fold`,
-  which accepts a kernel to sample from and a collection of reducers. `sample_fold`
-  will automatically create the Transition Kernel onion and call each reducer's
-  `finalize` method. This makes it easy to calculate streaming covariance over
-  MCMC samples.
+  If the sole objective is to estimate covariance, it may be more convenient to
+  use a pre-defined driver like `tfp.experimental.mcmc.sample_fold`. `sample_fold`
+  will automatically create the Transition Kernel onion, apply `kernel` samples
+  to update reducer states, and `finalize` calculations.
 
   ```
   python 
@@ -79,6 +77,7 @@ class CovarianceReducer(reducer_base.Reducer):
       kernel=kernel,
       reducers=reducer,
   )
+  covariance_estimate  # estimate of covariance (not `CovarianceReducerState`)
   ```
   """
 

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
@@ -1,0 +1,108 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Sample Discarding Kernel for Thinning and Burn-in"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python.experimental.mcmc import step_kernel
+from tensorflow_probability.python.mcmc import kernel as kernel_base
+from tensorflow_probability.python.mcmc.internal import util as mcmc_util
+
+
+__all__ = [
+    'SampleDiscardingKernel',
+]
+
+
+class SampleDiscardingKernelResults(
+    mcmc_util.PrettyNamedTupleMixin,
+    collections.namedtuple('SampleDiscardingKernelResults',
+                           ['call_counter',
+                            'inner_results'])):
+  __slots__ = ()
+
+class SampleDiscardingKernel(kernel_base.TransitionKernel):
+
+  def __init__(
+      self,
+      inner_kernel,
+      num_burnin_steps=0,
+      num_steps_between_results=0,
+      name=None):
+    self._parameters = dict(
+        inner_kernel=inner_kernel,
+        num_burnin_steps=num_burnin_steps,
+        num_steps_between_results=num_steps_between_results,
+        name=name or 'sample_discarding_kernel'
+    )
+
+  def _num_samples_to_skip(self, call_counter):
+    if self.num_burnin_steps == 0:
+      return self.num_steps_between_results
+    else:
+      return (tf.where(tf.equal(call_counter, 0), self.num_burnin_steps, 0) +
+              self.num_steps_between_results)
+
+  def one_step(self, current_state, previous_kernel_results=None, seed=None):
+    if previous_kernel_results is None:
+      previous_kernel_results = self.bootstrap_results(current_state)
+    new_sample, inner_kernel_results = step_kernel(
+        num_steps=self._num_samples_to_skip(
+            previous_kernel_results.call_counter
+        ) + 1,
+        current_state=current_state,
+        previous_kernel_results=previous_kernel_results.inner_results,
+        kernel=self.inner_kernel,
+        return_final_kernel_results=True,
+        seed=seed,
+        name=self.name)
+    new_kernel_results = SampleDiscardingKernelResults(
+        previous_kernel_results.call_counter + 1, inner_kernel_results
+    )
+    return new_sample, new_kernel_results
+
+  def bootstrap_results(self, init_state):
+    return SampleDiscardingKernelResults(
+        0, self.inner_kernel.bootstrap_results(init_state))
+
+  @property
+  def is_calibrated(self):
+    return self.inner_kernel.is_calibrated
+
+  @property
+  def inner_kernel(self):
+    return self._parameters['inner_kernel']
+
+  @property
+  def num_burnin_steps(self):
+    return self._parameters['num_burnin_steps']
+
+  @property
+  def num_steps_between_results(self):
+    return self._parameters['num_steps_between_results']
+
+  @property
+  def name(self):
+    return self._parameters['name']
+
+  @property
+  def parameters(self):
+    return self._parameters

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
@@ -83,7 +83,8 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
 
   def bootstrap_results(self, init_state):
     with tf.name_scope(
-        mcmc_util.make_name(self.name, 'with_reductions', 'bootstrap_results')):
+        mcmc_util.make_name(
+            self.name, 'sample_discarding_kernel', 'bootstrap_results')):
       return SampleDiscardingKernelResults(
           0, self.inner_kernel.bootstrap_results(init_state))
 

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
@@ -55,6 +55,10 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
     )
 
   def _num_samples_to_skip(self, call_counter):
+    # not using `tf.equal(self.num_burnin_steps, 0)` here is intentional.
+    # We are checking to see if `self.num_burnin_steps` is statically known.
+    # In the case where it's a `Tensor` holding 0, a `Tensor` will be
+    # returned in the else clause.
     if self.num_burnin_steps == 0:
       return self.num_steps_between_results
     else:

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
@@ -65,12 +65,13 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
     Args:
       inner_kernel: `TransitionKernel` whose `one_step` will generate
         MCMC sample(s).
-      num_burnin_steps: Integer number of chain steps to take before starting to
-        collect results. Defaults to 0 (i.e., no burn-in).
-      num_steps_between_results: Integer number of chain steps between
-        collecting a result. Only one out of every
-        `num_steps_between_samples + 1` steps is included in the returned
-        results. Defaults to 0 (i.e., no thinning).
+      num_burnin_steps: Integer or scalar `Tensor` representing the number
+        of chain steps to take before starting to collect results.
+        Defaults to 0 (i.e., no burn-in).
+      num_steps_between_results: Integer or scalar `Tensor` representing
+        the number of chain steps between collecting a result. Only one out
+        of every `num_steps_between_samples + 1` steps is included in the
+        returned results. Defaults to 0 (i.e., no thinning).
       name: Python `str` name prefixed to Ops created by this function.
         Default value: `None` (i.e., "sample_discarding_kernel").
     """
@@ -87,11 +88,9 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
     )
 
   def _num_samples_to_skip(self, call_counter):
-    """Calculates how many samples to skip based on the call number.
-
-    If `self.num_burnin_steps` is statically known to be 0,
-    `self.num_steps_between_results` will be returned outright.
-    """
+    """Calculates how many samples to skip based on the call number."""
+    # If `self.num_burnin_steps` is statically known to be 0,
+    # `self.num_steps_between_results` will be returned outright.
     if self.num_burnin_steps == 0:
       return self.num_steps_between_results
     else:

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
@@ -47,6 +47,7 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
       num_burnin_steps=0,
       num_steps_between_results=0,
       name=None):
+    # TODO(Ru): get static value
     self._parameters = dict(
         inner_kernel=inner_kernel,
         num_burnin_steps=num_burnin_steps,
@@ -55,15 +56,13 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
     )
 
   def _num_samples_to_skip(self, call_counter):
-    # not using `tf.equal(self.num_burnin_steps, 0)` here is intentional.
-    # We are checking to see if `self.num_burnin_steps` is statically known.
-    # In the case where it's a `Tensor` holding 0, a `Tensor` will be
-    # returned in the else clause.
-    if self.num_burnin_steps == 0:
-      return self.num_steps_between_results
+    if call_counter == 0:
+      return self.num_burnin_steps
     else:
-      return (tf.where(tf.equal(call_counter, 0), self.num_burnin_steps, 0) +
-              self.num_steps_between_results)
+      return tf.where(
+          tf.equal(call_counter, 0),
+          self.num_burnin_steps,
+          self.num_steps_between_results)
 
   def one_step(self, current_state, previous_kernel_results=None, seed=None):
     with tf.name_scope(

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel.py
@@ -105,7 +105,7 @@ class SampleDiscardingKernel(kernel_base.TransitionKernel):
       current_state: `Tensor` or Python `list` of `Tensor`s
         representing the current state(s) of the Markov chain(s),
       previous_kernel_results: `SampleDiscardingKernelResults` named tuple.
-        `SampleDiscardingKernelResults` contain the `call_counter`
+        `SampleDiscardingKernelResults` contains the `call_counter`
         and a reference to kernel results of nested `TransitionKernel`s.
       seed: Optional seed for reproducible sampling.
 

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
@@ -66,7 +66,8 @@ class SampleDiscardingTest(test_util.TestCase):
     discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
         fake_inner_kernel,
         num_steps_between_results=1,)
-    first_state, kernel_results = discarder.one_step(0.)
+    first_state, kernel_results = discarder.one_step(
+        0., discarder.bootstrap_results(0.))
     second_state, kernel_results = discarder.one_step(
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
@@ -82,7 +83,8 @@ class SampleDiscardingTest(test_util.TestCase):
     discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
         fake_inner_kernel,
         num_burnin_steps=5,)
-    sample, kernel_results = discarder.one_step(0.)
+    sample, kernel_results = discarder.one_step(
+        0., discarder.bootstrap_results(0.))
     sample, kernel_results = self.evaluate([
         sample, kernel_results])
     self.assertEqual(sample, 6)
@@ -94,7 +96,8 @@ class SampleDiscardingTest(test_util.TestCase):
     fake_inner_kernel = TestTransitionKernel()
     discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
         fake_inner_kernel,)
-    first_state, kernel_results = discarder.one_step(0.)
+    first_state, kernel_results = discarder.one_step(
+        0., discarder.bootstrap_results(0.))
     second_state, kernel_results = discarder.one_step(
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
@@ -111,7 +114,8 @@ class SampleDiscardingTest(test_util.TestCase):
         fake_inner_kernel,
         num_burnin_steps=10,
         num_steps_between_results=1,)
-    first_state, kernel_results = discarder.one_step(0.)
+    first_state, kernel_results = discarder.one_step(
+        0., discarder.bootstrap_results(0.))
     second_state, kernel_results = discarder.one_step(
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
@@ -128,8 +132,10 @@ class SampleDiscardingTest(test_util.TestCase):
         fake_inner_kernel,
         num_burnin_steps=10,
         num_steps_between_results=1,)
-    first_state, _ = discarder.one_step(0.)
-    second_state, kernel_results = discarder.one_step(first_state)
+    first_state, _ = discarder.one_step(
+        0., discarder.bootstrap_results(0.))
+    second_state, kernel_results = discarder.one_step(
+        first_state, discarder.bootstrap_results(first_state))
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
     self.assertEqual(first_state, 12)
@@ -158,7 +164,7 @@ class SampleDiscardingTest(test_util.TestCase):
             num_steps_between_results=2,),
         reducers=cov_reducer
     )
-    current_state, kernel_results = 0., None
+    current_state, kernel_results = 0., reducer_kernel.bootstrap_results(0.)
     for _ in range(2):
       current_state, kernel_results = reducer_kernel.one_step(
           current_state, kernel_results)

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
@@ -1,0 +1,203 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for SampleDiscardingKernel TransitionKernel (thinning and burn-in)."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.internal import test_util
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic Transition Kernel"""
+
+  def __init__(self, shape=(), target_log_prob_fn=None, is_calibrated=True):
+    self._is_calibrated = is_calibrated
+    self._shape = shape
+    # for composition purposes
+    self.parameters = dict(
+        target_log_prob_fn=target_log_prob_fn)
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    return (current_state + tf.ones(self._shape),
+            TestTransitionKernelResults(
+                counter_1=previous_kernel_results.counter_1 + 1,
+                counter_2=previous_kernel_results.counter_2 + 2))
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()),
+        counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+@test_util.test_all_tf_execution_regimes
+class SampleDiscardingTest(test_util.TestCase):
+
+  def test_thinning(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,
+        num_steps_between_results=1,)
+    first_state, kernel_results = discarder.one_step(0.)
+    second_state, kernel_results = discarder.one_step(
+        first_state, kernel_results)
+    first_state, second_state, inner_results = self.evaluate([
+        first_state, second_state, kernel_results.inner_results])
+    self.assertEqual(first_state, 2)
+    self.assertEqual(second_state, 4)
+    self.assertEqual(kernel_results.call_counter, 2)
+    self.assertEqual(inner_results.counter_1, 4)
+    self.assertEqual(inner_results.counter_2, 8)
+
+  def test_burnin(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,
+        num_burnin_steps=5,)
+    sample, kernel_results = discarder.one_step(0.)
+    sample, inner_results = self.evaluate([
+        sample, kernel_results.inner_results])
+    self.assertEqual(sample, 6)
+    self.assertEqual(kernel_results.call_counter, 1)
+    self.assertEqual(inner_results.counter_1, 6)
+    self.assertEqual(inner_results.counter_2, 12)
+
+  def test_no_thinning_or_burnin(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,)
+    first_state, kernel_results = discarder.one_step(0.)
+    second_state, kernel_results = discarder.one_step(
+        first_state, kernel_results)
+    first_state, second_state, inner_results = self.evaluate([
+        first_state, second_state, kernel_results.inner_results])
+    self.assertEqual(first_state, 1)
+    self.assertEqual(second_state, 2)
+    self.assertEqual(kernel_results.call_counter, 2)
+    self.assertEqual(inner_results.counter_1, 2)
+    self.assertEqual(inner_results.counter_2, 4)
+
+  def test_both_thinning_and_burnin(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,
+        num_burnin_steps=10,
+        num_steps_between_results=1,)
+    first_state, kernel_results = discarder.one_step(0.)
+    second_state, kernel_results = discarder.one_step(
+        first_state, kernel_results)
+    first_state, second_state, inner_results = self.evaluate([
+        first_state, second_state, kernel_results.inner_results])
+    self.assertEqual(first_state, 12)
+    self.assertEqual(second_state, 14)
+    self.assertEqual(kernel_results.call_counter, 2)
+    self.assertEqual(inner_results.counter_1, 14)
+    self.assertEqual(inner_results.counter_2, 28)
+
+  def test_cold_start(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,
+        num_burnin_steps=10,
+        num_steps_between_results=1,)
+    first_state, _ = discarder.one_step(0.)
+    second_state, kernel_results = discarder.one_step(first_state)
+    first_state, second_state, inner_results = self.evaluate([
+        first_state, second_state, kernel_results.inner_results])
+    self.assertEqual(first_state, 12)
+    self.assertEqual(second_state, 24)
+    self.assertEqual(kernel_results.call_counter, 1)
+    self.assertEqual(inner_results.counter_1, 12)
+    self.assertEqual(inner_results.counter_2, 24)
+
+  def test_is_calibrated(self):
+    calibrated_kernel = TestTransitionKernel()
+    uncalibrated_kernel = TestTransitionKernel(is_calibrated=False)
+    calibrated_discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        calibrated_kernel)
+    uncalibrated_discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        uncalibrated_kernel)
+    self.assertTrue(calibrated_discarder.is_calibrated)
+    self.assertFalse(uncalibrated_discarder.is_calibrated)
+
+  def test_with_composed_kernel(self):
+    fake_inner_kernel = TestTransitionKernel()
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reducer_kernel = tfp.experimental.mcmc.WithReductions(
+        inner_kernel=tfp.experimental.mcmc.SampleDiscardingKernel(
+            inner_kernel=fake_inner_kernel,
+            num_burnin_steps=10,
+            num_steps_between_results=2,),
+        reducers=cov_reducer
+    )
+    current_state, kernel_results = 0., None
+    for _ in range(2):
+      current_state, kernel_results = reducer_kernel.one_step(
+          current_state, kernel_results)
+    current_state, most_inner_results, cov = self.evaluate([
+        current_state,
+        kernel_results.inner_results.inner_results,
+        cov_reducer.finalize(kernel_results.streaming_calculations),
+    ])
+    self.assertEqual(current_state, 16)
+    self.assertEqual(kernel_results.inner_results.call_counter, 2)
+    self.assertEqual(most_inner_results.counter_1, 16)
+    self.assertEqual(most_inner_results.counter_2, 32)
+    self.assertEqual(cov, np.var([13, 16]))
+
+  def test_tf_while(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,
+        num_burnin_steps=10,
+        num_steps_between_results=1,)
+
+    def _loop_body(i, curr_state, pkr):
+      new_state, kernel_results = discarder.one_step(
+          curr_state, pkr,
+      )
+      return (i + 1, new_state, kernel_results)
+
+    pkr = discarder.bootstrap_results(0.)
+    _, final_sample, kernel_results = tf.while_loop(
+        lambda i, _, __: i < 2,
+        _loop_body,
+        (0., 0., pkr),
+    )
+    final_sample, kernel_results = self.evaluate([
+        final_sample, kernel_results])
+    self.assertEqual(final_sample, 14)
+    self.assertEqual(kernel_results.call_counter, 2)
+    self.assertEqual(kernel_results.inner_results.counter_1, 14)
+    self.assertEqual(kernel_results.inner_results.counter_2, 28)
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
@@ -69,13 +69,13 @@ class SampleDiscardingTest(test_util.TestCase):
     first_state, kernel_results = discarder.one_step(0.)
     second_state, kernel_results = discarder.one_step(
         first_state, kernel_results)
-    first_state, second_state, inner_results = self.evaluate([
-        first_state, second_state, kernel_results.inner_results])
-    self.assertEqual(first_state, 1)
-    self.assertEqual(second_state, 3)
+    first_state, second_state, kernel_results = self.evaluate([
+        first_state, second_state, kernel_results])
+    self.assertEqual(first_state, 2)
+    self.assertEqual(second_state, 4)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(inner_results.counter_1, 3)
-    self.assertEqual(inner_results.counter_2, 6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 4)
+    self.assertEqual(kernel_results.inner_results.counter_2, 8)
 
   def test_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -83,12 +83,12 @@ class SampleDiscardingTest(test_util.TestCase):
         fake_inner_kernel,
         num_burnin_steps=5,)
     sample, kernel_results = discarder.one_step(0.)
-    sample, inner_results = self.evaluate([
-        sample, kernel_results.inner_results])
+    sample, kernel_results = self.evaluate([
+        sample, kernel_results])
     self.assertEqual(sample, 6)
     self.assertEqual(kernel_results.call_counter, 1)
-    self.assertEqual(inner_results.counter_1, 6)
-    self.assertEqual(inner_results.counter_2, 12)
+    self.assertEqual(kernel_results.inner_results.counter_1, 6)
+    self.assertEqual(kernel_results.inner_results.counter_2, 12)
 
   def test_no_thinning_or_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -97,13 +97,13 @@ class SampleDiscardingTest(test_util.TestCase):
     first_state, kernel_results = discarder.one_step(0.)
     second_state, kernel_results = discarder.one_step(
         first_state, kernel_results)
-    first_state, second_state, inner_results = self.evaluate([
-        first_state, second_state, kernel_results.inner_results])
+    first_state, second_state, kernel_results = self.evaluate([
+        first_state, second_state, kernel_results])
     self.assertEqual(first_state, 1)
     self.assertEqual(second_state, 2)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(inner_results.counter_1, 2)
-    self.assertEqual(inner_results.counter_2, 4)
+    self.assertEqual(kernel_results.inner_results.counter_1, 2)
+    self.assertEqual(kernel_results.inner_results.counter_2, 4)
 
   def test_both_thinning_and_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -114,13 +114,13 @@ class SampleDiscardingTest(test_util.TestCase):
     first_state, kernel_results = discarder.one_step(0.)
     second_state, kernel_results = discarder.one_step(
         first_state, kernel_results)
-    first_state, second_state, inner_results = self.evaluate([
-        first_state, second_state, kernel_results.inner_results])
-    self.assertEqual(first_state, 11)
-    self.assertEqual(second_state, 13)
+    first_state, second_state, kernel_results = self.evaluate([
+        first_state, second_state, kernel_results])
+    self.assertEqual(first_state, 12)
+    self.assertEqual(second_state, 14)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(inner_results.counter_1, 13)
-    self.assertEqual(inner_results.counter_2, 26)
+    self.assertEqual(kernel_results.inner_results.counter_1, 14)
+    self.assertEqual(kernel_results.inner_results.counter_2, 28)
 
   def test_cold_start(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -130,13 +130,13 @@ class SampleDiscardingTest(test_util.TestCase):
         num_steps_between_results=1,)
     first_state, _ = discarder.one_step(0.)
     second_state, kernel_results = discarder.one_step(first_state)
-    first_state, second_state, inner_results = self.evaluate([
-        first_state, second_state, kernel_results.inner_results])
-    self.assertEqual(first_state, 11)
-    self.assertEqual(second_state, 22)
+    first_state, second_state, kernel_results = self.evaluate([
+        first_state, second_state, kernel_results])
+    self.assertEqual(first_state, 12)
+    self.assertEqual(second_state, 24)
     self.assertEqual(kernel_results.call_counter, 1)
-    self.assertEqual(inner_results.counter_1, 11)
-    self.assertEqual(inner_results.counter_2, 22)
+    self.assertEqual(kernel_results.inner_results.counter_1, 12)
+    self.assertEqual(kernel_results.inner_results.counter_2, 24)
 
   def test_is_calibrated(self):
     calibrated_kernel = TestTransitionKernel()
@@ -162,16 +162,18 @@ class SampleDiscardingTest(test_util.TestCase):
     for _ in range(2):
       current_state, kernel_results = reducer_kernel.one_step(
           current_state, kernel_results)
-    current_state, most_inner_results, cov = self.evaluate([
+    current_state, kernel_results, cov = self.evaluate([
         current_state,
-        kernel_results.inner_results.inner_results,
+        kernel_results,
         cov_reducer.finalize(kernel_results.streaming_calculations),
     ])
-    self.assertEqual(current_state, 14)
+    self.assertEqual(current_state, 16)
     self.assertEqual(kernel_results.inner_results.call_counter, 2)
-    self.assertEqual(most_inner_results.counter_1, 14)
-    self.assertEqual(most_inner_results.counter_2, 28)
-    self.assertEqual(cov, np.var([11, 14]))
+    self.assertEqual(
+        kernel_results.inner_results.inner_results.counter_1, 16)
+    self.assertEqual(
+        kernel_results.inner_results.inner_results.counter_2, 32)
+    self.assertEqual(cov, np.var([13, 16]))
 
   def test_tf_while(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -194,10 +196,10 @@ class SampleDiscardingTest(test_util.TestCase):
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 13)
+    self.assertEqual(final_sample, 14)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 13)
-    self.assertEqual(kernel_results.inner_results.counter_2, 26)
+    self.assertEqual(kernel_results.inner_results.counter_1, 14)
+    self.assertEqual(kernel_results.inner_results.counter_2, 28)
 
   def test_tensor_thinning_and_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -218,12 +220,13 @@ class SampleDiscardingTest(test_util.TestCase):
         _loop_body,
         (0., 0., pkr),
     )
+
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 13)
+    self.assertEqual(final_sample, 14)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 13)
-    self.assertEqual(kernel_results.inner_results.counter_2, 26)
+    self.assertEqual(kernel_results.inner_results.counter_1, 14)
+    self.assertEqual(kernel_results.inner_results.counter_2, 28)
 
   def test_tensor_no_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -246,11 +249,31 @@ class SampleDiscardingTest(test_util.TestCase):
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 3)
+    self.assertEqual(final_sample, 4)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 3)
-    self.assertEqual(kernel_results.inner_results.counter_2, 6)
+    self.assertEqual(kernel_results.inner_results.counter_1, 4)
+    self.assertEqual(kernel_results.inner_results.counter_2, 8)
 
+  def test_call_count_is_int32(self):
+    fake_inner_kernel = TestTransitionKernel()
+    discarder = tfp.experimental.mcmc.SampleDiscardingKernel(
+        fake_inner_kernel,
+        num_burnin_steps=10,
+        num_steps_between_results=1,)
+
+    def _loop_body(i, curr_state, pkr):
+      new_state, kernel_results = discarder.one_step(
+          curr_state, pkr,
+      )
+      return (i + 1, new_state, kernel_results)
+
+    pkr = discarder.bootstrap_results(0.)
+    _, _, kernel_results = tf.while_loop(
+        lambda i, *_: i < 2,
+        _loop_body,
+        (0., 0., pkr),
+    )
+    self.assertTrue(kernel_results.call_counter.dtype, tf.int32)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
@@ -71,11 +71,11 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, kernel_results)
     first_state, second_state, inner_results = self.evaluate([
         first_state, second_state, kernel_results.inner_results])
-    self.assertEqual(first_state, 2)
-    self.assertEqual(second_state, 4)
+    self.assertEqual(first_state, 1)
+    self.assertEqual(second_state, 3)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(inner_results.counter_1, 4)
-    self.assertEqual(inner_results.counter_2, 8)
+    self.assertEqual(inner_results.counter_1, 3)
+    self.assertEqual(inner_results.counter_2, 6)
 
   def test_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -116,11 +116,11 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, kernel_results)
     first_state, second_state, inner_results = self.evaluate([
         first_state, second_state, kernel_results.inner_results])
-    self.assertEqual(first_state, 12)
-    self.assertEqual(second_state, 14)
+    self.assertEqual(first_state, 11)
+    self.assertEqual(second_state, 13)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(inner_results.counter_1, 14)
-    self.assertEqual(inner_results.counter_2, 28)
+    self.assertEqual(inner_results.counter_1, 13)
+    self.assertEqual(inner_results.counter_2, 26)
 
   def test_cold_start(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -132,11 +132,11 @@ class SampleDiscardingTest(test_util.TestCase):
     second_state, kernel_results = discarder.one_step(first_state)
     first_state, second_state, inner_results = self.evaluate([
         first_state, second_state, kernel_results.inner_results])
-    self.assertEqual(first_state, 12)
-    self.assertEqual(second_state, 24)
+    self.assertEqual(first_state, 11)
+    self.assertEqual(second_state, 22)
     self.assertEqual(kernel_results.call_counter, 1)
-    self.assertEqual(inner_results.counter_1, 12)
-    self.assertEqual(inner_results.counter_2, 24)
+    self.assertEqual(inner_results.counter_1, 11)
+    self.assertEqual(inner_results.counter_2, 22)
 
   def test_is_calibrated(self):
     calibrated_kernel = TestTransitionKernel()
@@ -167,11 +167,11 @@ class SampleDiscardingTest(test_util.TestCase):
         kernel_results.inner_results.inner_results,
         cov_reducer.finalize(kernel_results.streaming_calculations),
     ])
-    self.assertEqual(current_state, 16)
+    self.assertEqual(current_state, 14)
     self.assertEqual(kernel_results.inner_results.call_counter, 2)
-    self.assertEqual(most_inner_results.counter_1, 16)
-    self.assertEqual(most_inner_results.counter_2, 32)
-    self.assertEqual(cov, np.var([13, 16]))
+    self.assertEqual(most_inner_results.counter_1, 14)
+    self.assertEqual(most_inner_results.counter_2, 28)
+    self.assertEqual(cov, np.var([11, 14]))
 
   def test_tf_while(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -188,16 +188,16 @@ class SampleDiscardingTest(test_util.TestCase):
 
     pkr = discarder.bootstrap_results(0.)
     _, final_sample, kernel_results = tf.while_loop(
-        lambda i, _, __: i < 2,
+        lambda i, *_: i < 2,
         _loop_body,
         (0., 0., pkr),
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 14)
+    self.assertEqual(final_sample, 13)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 14)
-    self.assertEqual(kernel_results.inner_results.counter_2, 28)
+    self.assertEqual(kernel_results.inner_results.counter_1, 13)
+    self.assertEqual(kernel_results.inner_results.counter_2, 26)
 
   def test_tensor_thinning_and_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -220,10 +220,10 @@ class SampleDiscardingTest(test_util.TestCase):
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 14)
+    self.assertEqual(final_sample, 13)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 14)
-    self.assertEqual(kernel_results.inner_results.counter_2, 28)
+    self.assertEqual(kernel_results.inner_results.counter_1, 13)
+    self.assertEqual(kernel_results.inner_results.counter_2, 26)
 
   def test_tensor_no_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -246,10 +246,10 @@ class SampleDiscardingTest(test_util.TestCase):
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 4)
+    self.assertEqual(final_sample, 3)
     self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 4)
-    self.assertEqual(kernel_results.inner_results.counter_2, 8)
+    self.assertEqual(kernel_results.inner_results.counter_1, 3)
+    self.assertEqual(kernel_results.inner_results.counter_2, 6)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
@@ -120,7 +120,10 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
+    # the first `one_step` performs burn-in and thinning to skip
+    # `num_burnin_steps` + `num_steps_between_results` samples
     self.assertEqual(12, first_state)
+    # subsequent `one_step` calls only perform thinning
     self.assertEqual(14, second_state)
     self.assertEqual(2, kernel_results.call_counter)
     self.assertEqual(14, kernel_results.inner_results.counter_1)
@@ -138,7 +141,12 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, discarder.bootstrap_results(first_state))
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
+    # the first `one_step` performs burn-in and thinning to skip
+    # `num_burnin_steps` + `num_steps_between_results` samples
     self.assertEqual(12, first_state)
+    # the step count is stored in the kernel results. Cold
+    # restarting resets the count back to 0 and hence, both
+    # thinning and burn-in are once again performed.
     self.assertEqual(24, second_state)
     self.assertEqual(1, kernel_results.call_counter)
     self.assertEqual(12, kernel_results.inner_results.counter_1)

--- a/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_discarding_kernel_test.py
@@ -72,11 +72,11 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
-    self.assertEqual(first_state, 2)
-    self.assertEqual(second_state, 4)
-    self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 4)
-    self.assertEqual(kernel_results.inner_results.counter_2, 8)
+    self.assertEqual(2, first_state)
+    self.assertEqual(4, second_state)
+    self.assertEqual(2, kernel_results.call_counter)
+    self.assertEqual(4, kernel_results.inner_results.counter_1)
+    self.assertEqual(8, kernel_results.inner_results.counter_2)
 
   def test_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -87,10 +87,10 @@ class SampleDiscardingTest(test_util.TestCase):
         0., discarder.bootstrap_results(0.))
     sample, kernel_results = self.evaluate([
         sample, kernel_results])
-    self.assertEqual(sample, 6)
-    self.assertEqual(kernel_results.call_counter, 1)
-    self.assertEqual(kernel_results.inner_results.counter_1, 6)
-    self.assertEqual(kernel_results.inner_results.counter_2, 12)
+    self.assertEqual(6, sample)
+    self.assertEqual(1, kernel_results.call_counter)
+    self.assertEqual(6, kernel_results.inner_results.counter_1)
+    self.assertEqual(12, kernel_results.inner_results.counter_2)
 
   def test_no_thinning_or_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -102,11 +102,11 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
-    self.assertEqual(first_state, 1)
-    self.assertEqual(second_state, 2)
-    self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 2)
-    self.assertEqual(kernel_results.inner_results.counter_2, 4)
+    self.assertEqual(1, first_state)
+    self.assertEqual(2, second_state)
+    self.assertEqual(2, kernel_results.call_counter)
+    self.assertEqual(2, kernel_results.inner_results.counter_1)
+    self.assertEqual(4, kernel_results.inner_results.counter_2)
 
   def test_both_thinning_and_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -120,11 +120,11 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, kernel_results)
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
-    self.assertEqual(first_state, 12)
-    self.assertEqual(second_state, 14)
-    self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 14)
-    self.assertEqual(kernel_results.inner_results.counter_2, 28)
+    self.assertEqual(12, first_state)
+    self.assertEqual(14, second_state)
+    self.assertEqual(2, kernel_results.call_counter)
+    self.assertEqual(14, kernel_results.inner_results.counter_1)
+    self.assertEqual(28, kernel_results.inner_results.counter_2)
 
   def test_cold_start(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -138,11 +138,11 @@ class SampleDiscardingTest(test_util.TestCase):
         first_state, discarder.bootstrap_results(first_state))
     first_state, second_state, kernel_results = self.evaluate([
         first_state, second_state, kernel_results])
-    self.assertEqual(first_state, 12)
-    self.assertEqual(second_state, 24)
-    self.assertEqual(kernel_results.call_counter, 1)
-    self.assertEqual(kernel_results.inner_results.counter_1, 12)
-    self.assertEqual(kernel_results.inner_results.counter_2, 24)
+    self.assertEqual(12, first_state)
+    self.assertEqual(24, second_state)
+    self.assertEqual(1, kernel_results.call_counter)
+    self.assertEqual(12, kernel_results.inner_results.counter_1)
+    self.assertEqual(24, kernel_results.inner_results.counter_2)
 
   def test_is_calibrated(self):
     calibrated_kernel = TestTransitionKernel()
@@ -173,13 +173,13 @@ class SampleDiscardingTest(test_util.TestCase):
         kernel_results,
         cov_reducer.finalize(kernel_results.streaming_calculations),
     ])
-    self.assertEqual(current_state, 16)
-    self.assertEqual(kernel_results.inner_results.call_counter, 2)
+    self.assertEqual(16, current_state)
+    self.assertEqual(2, kernel_results.inner_results.call_counter)
     self.assertEqual(
-        kernel_results.inner_results.inner_results.counter_1, 16)
+        16, kernel_results.inner_results.inner_results.counter_1)
     self.assertEqual(
-        kernel_results.inner_results.inner_results.counter_2, 32)
-    self.assertEqual(cov, np.var([13, 16]))
+        32, kernel_results.inner_results.inner_results.counter_2)
+    self.assertEqual(np.var([13, 16]), cov)
 
   def test_tf_while(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -202,10 +202,10 @@ class SampleDiscardingTest(test_util.TestCase):
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 14)
-    self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 14)
-    self.assertEqual(kernel_results.inner_results.counter_2, 28)
+    self.assertEqual(14, final_sample)
+    self.assertEqual(2, kernel_results.call_counter)
+    self.assertEqual(14, kernel_results.inner_results.counter_1)
+    self.assertEqual(28, kernel_results.inner_results.counter_2)
 
   def test_tensor_thinning_and_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -229,10 +229,10 @@ class SampleDiscardingTest(test_util.TestCase):
 
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 14)
-    self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 14)
-    self.assertEqual(kernel_results.inner_results.counter_2, 28)
+    self.assertEqual(14, final_sample)
+    self.assertEqual(2, kernel_results.call_counter)
+    self.assertEqual(14, kernel_results.inner_results.counter_1)
+    self.assertEqual(28, kernel_results.inner_results.counter_2)
 
   def test_tensor_no_burnin(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -255,10 +255,10 @@ class SampleDiscardingTest(test_util.TestCase):
     )
     final_sample, kernel_results = self.evaluate([
         final_sample, kernel_results])
-    self.assertEqual(final_sample, 4)
-    self.assertEqual(kernel_results.call_counter, 2)
-    self.assertEqual(kernel_results.inner_results.counter_1, 4)
-    self.assertEqual(kernel_results.inner_results.counter_2, 8)
+    self.assertEqual(4, final_sample)
+    self.assertEqual(2, kernel_results.call_counter)
+    self.assertEqual(4, kernel_results.inner_results.counter_1)
+    self.assertEqual(8, kernel_results.inner_results.counter_2)
 
   def test_call_count_is_int32(self):
     fake_inner_kernel = TestTransitionKernel()
@@ -279,7 +279,8 @@ class SampleDiscardingTest(test_util.TestCase):
         _loop_body,
         (0., 0., pkr),
     )
-    self.assertTrue(kernel_results.call_counter.dtype, tf.int32)
+    self.assertTrue(tf.int32, kernel_results.call_counter.dtype)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 # Dependency imports
 import tensorflow.compat.v2 as tf
 from tensorflow_probability.python.experimental import mcmc
-from tensorflow_probability.python.experimental.mcmc.with_reductions import WithReductionsKernelResults
 from tensorflow.python.util import nest
 
 
@@ -97,8 +96,10 @@ def sample_fold(
     current_state = tf.nest.map_structure(
         lambda x: tf.convert_to_tensor(x, name='current_state'),
         current_state)
+    reducers_was_none = False
     if reducers is None:
       reducers = []
+      reducers_was_none = True
     reduction_kernel = mcmc.WithReductions(
         inner_kernel=mcmc.SampleDiscardingKernel(
             inner_kernel=kernel,
@@ -122,9 +123,9 @@ def sample_fold(
         reducers,
         final_kernel_results.streaming_calculations,
         check_types=False)
-    if reduction_results == []:
+    if reduction_results == [] and reducers_was_none:
       reduction_results = None
-      final_kernel_results = WithReductionsKernelResults(
+      final_kernel_results = mcmc.WithReductionsKernelResults(
           None, final_kernel_results.inner_results
       )
     return reduction_results, end_state, final_kernel_results

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -43,13 +43,14 @@ def sample_fold(
     seed=None,
     name=None,
 ):
-  """Finalizes `num_steps` Reducer steps with samples provided by `kernel`.
+  """Finalizes `num_steps` Reducer steps with `kernel` samples.
 
-  This driver will appropriately apply `WithReductions` over the given `kernel`
-  and `reducers`. It will then update reducer states `num_steps` times (perform
-  `num_steps` calls to the `Reducer`'s `one_step` method). An arbitrary
-  collection of `reducers` can be provided, and the resulting finalized
-  statistics will be returned in an identical structure.
+  This driver will appropriately apply `WithReductions` and
+  `SampleDiscardingKernel` over the given `kernel` and `reducers`. It will
+  then update reducer states `num_steps` times (perform `num_steps` calls to
+  the `Reducer`'s `one_step` method). An arbitrary collection of `reducers`
+  can be provided, and the resulting finalized statistic(s) will be returned
+  in an identical structure.
 
   Args:
     num_steps: Integer number of `Reducer` steps.
@@ -62,7 +63,8 @@ def sample_fold(
     kernel: An instance of `tfp.mcmc.TransitionKernel` which implements one step
       of the Markov chain.
     reducers: A (possibly nested) structure of `Reducer`s to be evaluated
-      on the `kernel`'s samples.
+      on the `kernel`'s samples. If no reducers are given (`reducers=None`), an
+      empty list will be returned in place of streaming calculations.
     num_burnin_steps: Integer number of chain steps to take before starting to
       collect results. Defaults to 0 (i.e., no burn-in).
     num_steps_between_results: Integer number of chain steps between collecting
@@ -79,8 +81,7 @@ def sample_fold(
       statistics. The structure identically mimics that of `reducers`
     warm_restart_package: `Tuple` with the final state of the Markov chain(s)
       and kernel results, including those of applied wrapper kernels (i.e.
-      `WithReductions`). Can be used to warm restart future calls to
-      `sample_fold` or similar drivers.
+      `WithReductions`).
   """
   with tf.name_scope(name or 'mcmc_sample_fold'):
     num_steps = tf.convert_to_tensor(

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -67,8 +67,7 @@ def sample_fold(
       collect results. Defaults to 0 (i.e., no burn-in).
     num_steps_between_results: Integer number of chain steps between collecting
       a result. Only one out of every `num_steps_between_samples + 1` steps is
-      included in the returned results. The number of returned chain states is
-      still equal to `num_results`. Defaults to 0 (i.e., no thinning).
+      included in the returned results. Defaults to 0 (i.e., no thinning).
     parallel_iterations: The number of iterations allowed to run in parallel. It
       must be a positive integer. See `tf.while_loop` for more details.
     seed: Optional seed for reproducible sampling.

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -88,6 +88,8 @@ def sample_fold(
     current_state = tf.nest.map_structure(
         lambda x: tf.convert_to_tensor(x, name='current_state'),
         current_state)
+    if reducers is None:
+      reducers = []
     reduction_kernel = with_reductions.WithReductions(
         inner_kernel=SampleDiscardingKernel(
             inner_kernel=kernel,

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -20,9 +20,8 @@ from __future__ import print_function
 
 # Dependency imports
 import tensorflow.compat.v2 as tf
-from tensorflow_probability.python.experimental.mcmc import with_reductions
-from tensorflow_probability.python.experimental.mcmc import SampleDiscardingKernel
-from tensorflow_probability.python.experimental.mcmc import step_kernel
+from tensorflow_probability.python.experimental import mcmc
+from tensorflow_probability.python.experimental.mcmc.with_reductions import WithReductionsKernelResults
 from tensorflow.python.util import nest
 
 
@@ -100,14 +99,14 @@ def sample_fold(
         current_state)
     if reducers is None:
       reducers = []
-    reduction_kernel = with_reductions.WithReductions(
-        inner_kernel=SampleDiscardingKernel(
+    reduction_kernel = mcmc.WithReductions(
+        inner_kernel=mcmc.SampleDiscardingKernel(
             inner_kernel=kernel,
             num_burnin_steps=num_burnin_steps,
             num_steps_between_results=num_steps_between_results),
         reducers=reducers,
     )
-    end_state, final_kernel_results = step_kernel(
+    end_state, final_kernel_results = mcmc.step_kernel(
         num_steps=num_steps,
         current_state=current_state,
         previous_kernel_results=previous_kernel_results,
@@ -125,7 +124,7 @@ def sample_fold(
         check_types=False)
     if reduction_results == []:
       reduction_results = None
-      final_kernel_results = with_reductions.WithReductionsKernelResults(
+      final_kernel_results = WithReductionsKernelResults(
           None, final_kernel_results.inner_results
       )
     return reduction_results, end_state, final_kernel_results

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -43,12 +43,12 @@ def sample_fold(
     seed=None,
     name=None,
 ):
-  """Finalizes `num_steps` Reducer steps, with samples provided by `kernel`.
+  """Finalizes `num_steps` Reducer steps with samples provided by `kernel`.
 
   This driver will appropriately apply `WithReductions` over the given `kernel`
-  and `reducers`. It will then update reducer states `num_steps` times (each
-  update being a call to the `Reducer`'s `one_step` method). An arbitrary
-  collection of `reducers` can be provided. If so, the resulting finalized
+  and `reducers`. It will then update reducer states `num_steps` times (perform
+  `num_steps` calls to the `Reducer`'s `one_step` method). An arbitrary
+  collection of `reducers` can be provided, and the resulting finalized
   statistics will be returned in an identical structure.
 
   Args:
@@ -78,7 +78,7 @@ def sample_fold(
     reduction_results: A (possibly nested) structure of finalized reducer
       statistics. The structure identically mimics that of `reducers`
     warm_restart_package: `Tuple` with the final state of the Markov chain(s)
-      and its kernel results, including those of applied wrapper kernels (i.e.
+      and kernel results, including those of applied wrapper kernels (i.e.
       `WithReductions`). Can be used to warm restart future calls to
       `sample_fold` or similar drivers.
   """

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -106,7 +106,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=5,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
     reduction_rslt, last_sample, innermost_results = self.evaluate([
         reduction_rslt,
@@ -126,7 +126,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=5,
         current_state=curr_state,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
     reduction_rslt, last_sample, innermost_results = self.evaluate([
         reduction_rslt,
@@ -146,13 +146,13 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=5,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducer,)
-    # verify `warm_restart_pkg` works as intended
+        reducer=fake_reducer,)
+    # verify the warm restart package (last_sample and kr) works as intended
     reduction_rslt, last_sample, kr = tfp.experimental.mcmc.sample_fold(
         num_steps=5,
         current_state=last_sample,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
         previous_kernel_results=kr
     )
     reduction_rslt, last_sample, innermost_results = self.evaluate([
@@ -175,7 +175,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=3,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducers,
+        reducer=fake_reducers,
     )
     reduction_rslt, last_sample, innermost_results = self.evaluate([
         reduction_rslt,
@@ -200,7 +200,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=20,
         current_state=tf.convert_to_tensor([0., 0.]),
         kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
         seed=seed,)
     reduction_rslt = self.evaluate(reduction_rslt)
     self.assertAllClose(
@@ -216,7 +216,7 @@ class SampleFoldTest(test_util.TestCase):
         current_state=tf.convert_to_tensor(
             [[0., 0., 0.], [0., 0., 0.]]),
         kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
     reduction_rslt, streaming_calc = self.evaluate([
         reduction_rslt, kr.streaming_calculations
@@ -236,14 +236,14 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=3,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
         seed=seed
     )
     second_reduction_rslt, _, _ = tfp.experimental.mcmc.sample_fold(
         num_steps=3,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
         seed=seed
     )
     first_reduction_rslt, second_reduction_rslt = self.evaluate([
@@ -258,7 +258,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=5,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
         num_burnin_steps=10,
         num_steps_between_results=1,
     )
@@ -283,7 +283,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=tf.convert_to_tensor(5),
         current_state=0.,
         kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
         num_burnin_steps=tf.convert_to_tensor(10),
         num_steps_between_results=tf.convert_to_tensor(1),
     )
@@ -307,7 +307,7 @@ class SampleFoldTest(test_util.TestCase):
         num_steps=5,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=None,
+        reducer=None,
         num_burnin_steps=10,
         num_steps_between_results=1,
     )
@@ -321,13 +321,13 @@ class SampleFoldTest(test_util.TestCase):
     self.assertEqual(20, innermost_results.counter_1)
     self.assertEqual(40, innermost_results.counter_2)
 
-  def test_empty_reducers(self):
+  def test_empty_reducer(self):
     fake_kernel = TestTransitionKernel()
     reduction_rslt, last_sample, kr = tfp.experimental.mcmc.sample_fold(
         num_steps=5,
         current_state=0.,
         kernel=fake_kernel,
-        reducers=[],
+        reducer=[],
         num_burnin_steps=10,
         num_steps_between_results=1,
     )

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -1,0 +1,237 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for drivers in a Streaming Reductions Framework."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+from absl.testing import parameterized
+import collections
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.internal import samplers
+from tensorflow_probability.python.internal import test_util
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  "Deterministic Transition Kernel for testing purposes"
+
+  def __init__(self, shape=(), is_calibrated=True, accepts_seed=True):
+    self._shape = shape
+    self._is_calibrated = is_calibrated
+    self._accepts_seed = accepts_seed
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    if seed is not None and not self._accepts_seed:
+      raise TypeError('seed arg not accepted')
+    return current_state + tf.ones((self._shape)), TestTransitionKernelResults(
+        counter_1=previous_kernel_results.counter_1 + tf.ones(self._shape),
+        counter_2=previous_kernel_results.counter_2 + tf.ones(self._shape) * 2)
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(self._shape),
+        counter_2=tf.zeros(self._shape))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
+  "Outputs a random next state following a Rayleigh distribution."
+
+  def __init__(self, shape=(), is_calibrated=True, accepts_seed=True):
+    self._shape = shape
+    self._is_calibrated = is_calibrated
+    self._accepts_seed = accepts_seed
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    if seed is not None and not self._accepts_seed:
+      raise TypeError('seed arg not accepted')
+    new_state = tfp.random.rayleigh(self._shape, seed=seed)
+    return new_state, TestTransitionKernelResults(
+        counter_1=previous_kernel_results.counter_1 + 1,
+        counter_2=previous_kernel_results.counter_2 + 2)
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()), counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+class TestReducer(tfp.experimental.mcmc.Reducer):
+  """Simple Reducer that (naively) computes the mean"""
+
+  def initialize(self, initial_chain_state=None, initial_kernel_results=None):
+    return tf.zeros((2,))
+
+  def one_step(self, sample, current_state, previous_kernel_results, axis=None):
+    return current_state + tf.convert_to_tensor([1, sample])
+
+  def finalize(self, final_state):
+    return final_state[1] / final_state[0]
+
+
+@test_util.test_all_tf_execution_regimes
+class SampleFoldTest(test_util.TestCase):
+
+  def test_simple_operation(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    reduction_rslt, warm_restart_pkg = self.evaluate(
+        tfp.experimental.mcmc.sample_fold(
+            num_steps=5,
+            current_state=0.,
+            kernel=fake_kernel,
+            reducers=fake_reducer,
+        ))
+    self.assertEqual(reduction_rslt, 3)
+    self.assertEqual(warm_restart_pkg[0], 5)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_1, 5)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_2, 10)
+
+  @parameterized.parameters(1., 2.)
+  def test_current_state(self, curr_state):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    reduction_rslt, warm_restart_pkg = self.evaluate(
+        tfp.experimental.mcmc.sample_fold(
+            num_steps=5,
+            current_state=curr_state,
+            kernel=fake_kernel,
+            reducers=fake_reducer,
+        ))
+    self.assertEqual(reduction_rslt, np.mean(
+        np.arange(curr_state + 1, curr_state + 6)))
+    self.assertEqual(warm_restart_pkg[0], curr_state + 5)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_1, 5)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_2, 10)
+
+  def test_warm_restart(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducer = TestReducer()
+    _, warm_restart_pkg = tfp.experimental.mcmc.sample_fold(
+        num_steps=5,
+        current_state=0.,
+        kernel=fake_kernel,
+        reducers=fake_reducer,)
+    # verify `warm_restart_pkg` works as intended
+    reduction_rslt, warm_restart_pkg = self.evaluate(
+        tfp.experimental.mcmc.sample_fold(
+            num_steps=5,
+            current_state=warm_restart_pkg[0],
+            kernel=fake_kernel,
+            reducers=fake_reducer,
+            previous_kernel_results=warm_restart_pkg[1]
+        ))
+    self.assertEqual(reduction_rslt, 5.5)
+    self.assertEqual(warm_restart_pkg[0], 10)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_1, 10)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_2, 20)
+
+  def test_nested_reducers(self):
+    fake_kernel = TestTransitionKernel()
+    fake_reducers = [
+        [TestReducer(), tfp.experimental.mcmc.CovarianceReducer()],
+        [TestReducer()]
+    ]
+    reduction_rslt, warm_restart_pkg = self.evaluate(
+        tfp.experimental.mcmc.sample_fold(
+            num_steps=3,
+            current_state=0.,
+            kernel=fake_kernel,
+            reducers=fake_reducers,
+        ))
+    self.assertEqual(len(reduction_rslt), 2)
+    self.assertEqual(len(reduction_rslt[0]), 2)
+    self.assertEqual(len(reduction_rslt[1]), 1)
+
+    self.assertEqual(reduction_rslt[0][0], 2)
+    self.assertNear(reduction_rslt[0][1], 2/3, err=1e-6)
+    self.assertEqual(warm_restart_pkg[0], 3)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_1, 3)
+    self.assertEqual(warm_restart_pkg[1].inner_results.counter_2, 6)
+
+  def test_true_streaming_covariance(self):
+    seed = test_util.test_seed()
+    fake_kernel = TestTransitionKernel(())
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
+    reduction_rslt, _ = self.evaluate(tfp.experimental.mcmc.sample_fold(
+        num_steps=20,
+        current_state=tf.convert_to_tensor([0., 0.]),
+        kernel=fake_kernel,
+        reducers=cov_reducer,
+        seed=seed,))
+    self.assertAllClose(
+        np.cov(np.column_stack((np.arange(20), np.arange(20))).T, ddof=0),
+        reduction_rslt,
+        rtol=1e-5)
+
+  def test_batched_streaming_covariance(self):
+    fake_kernel = TestTransitionKernel((2, 3))
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer(event_ndims=1)
+    reduction_rslt, warm_restart_pkg = self.evaluate(
+        tfp.experimental.mcmc.sample_fold(
+            num_steps=5,
+            current_state=tf.convert_to_tensor(
+                [[0., 0., 0.], [0., 0., 0.]]),
+            kernel=fake_kernel,
+            reducers=cov_reducer,
+        ))
+    mean = warm_restart_pkg[1].streaming_calculations.mean
+    self.assertEqual(reduction_rslt.shape, (2, 3, 3))
+    self.assertAllEqual(reduction_rslt, np.ones(reduction_rslt.shape) * 2)
+    self.assertEqual(mean.shape, (2, 3))
+    self.assertAllEqual(mean, np.ones(mean.shape) * 3)
+    self.assertAllEqualNested(warm_restart_pkg[0], [[5., 5., 5.], [5., 5., 5.]])
+
+  def test_seed_reproducibility(self):
+    seed = samplers.sanitize_seed(test_util.test_seed())
+    fake_kernel = RandomTransitionKernel()
+    fake_reducer = TestReducer()
+    first_reduction_rslt, _ = tfp.experimental.mcmc.sample_fold(
+        num_steps=3,
+        current_state=0.,
+        kernel=fake_kernel,
+        reducers=fake_reducer,
+        seed=seed
+    )
+    second_reduction_rslt, _ = tfp.experimental.mcmc.sample_fold(
+        num_steps=3,
+        current_state=0.,
+        kernel=fake_kernel,
+        reducers=fake_reducer,
+        seed=seed
+    )
+    first_reduction_rslt, second_reduction_rslt = self.evaluate([
+        first_reduction_rslt, second_reduction_rslt
+    ])
+    self.assertEqual(first_reduction_rslt, second_reduction_rslt)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -301,12 +301,13 @@ class SampleFoldTest(test_util.TestCase):
     self.assertEqual(
         5, kernel_results.inner_results.call_counter)
 
-  def test_no_reducer(self):
+  def test_none_reducer(self):
     fake_kernel = TestTransitionKernel()
     reduction_rslt, last_sample, kr = tfp.experimental.mcmc.sample_fold(
         num_steps=5,
         current_state=0.,
         kernel=fake_kernel,
+        reducers=None,
         num_burnin_steps=10,
         num_steps_between_results=1,
     )
@@ -317,6 +318,26 @@ class SampleFoldTest(test_util.TestCase):
     self.assertEqual(None, reduction_rslt)
     self.assertEqual(20, last_sample)
     self.assertEqual(None, kr.streaming_calculations)
+    self.assertEqual(20, innermost_results.counter_1)
+    self.assertEqual(40, innermost_results.counter_2)
+
+  def test_empty_reducers(self):
+    fake_kernel = TestTransitionKernel()
+    reduction_rslt, last_sample, kr = tfp.experimental.mcmc.sample_fold(
+        num_steps=5,
+        current_state=0.,
+        kernel=fake_kernel,
+        reducers=[],
+        num_burnin_steps=10,
+        num_steps_between_results=1,
+    )
+    last_sample, innermost_results = self.evaluate([
+        last_sample,
+        kr.inner_results.inner_results
+    ])
+    self.assertEqual([], reduction_rslt)
+    self.assertEqual(20, last_sample)
+    self.assertEqual([], kr.streaming_calculations)
     self.assertEqual(20, innermost_results.counter_1)
     self.assertEqual(40, innermost_results.counter_2)
 

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -262,17 +262,19 @@ class SampleFoldTest(test_util.TestCase):
         num_burnin_steps=10,
         num_steps_between_results=1,
     )
-    reduction_rslt, last_sample, innermost_results = self.evaluate([
+    reduction_rslt, last_sample, kernel_results = self.evaluate([
         reduction_rslt,
         warm_restart_pkg[0],
-        warm_restart_pkg[1].inner_results.inner_results
+        warm_restart_pkg[1]
     ])
     self.assertEqual(reduction_rslt, 16)
     self.assertEqual(last_sample, 20)
-    self.assertEqual(innermost_results.counter_1, 20)
-    self.assertEqual(innermost_results.counter_2, 40)
     self.assertEqual(
-        warm_restart_pkg[1].inner_results.call_counter, 5)
+        kernel_results.inner_results.inner_results.counter_1, 20)
+    self.assertEqual(
+        kernel_results.inner_results.inner_results.counter_2, 40)
+    self.assertEqual(
+        kernel_results.inner_results.call_counter, 5)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -113,10 +113,10 @@ class SampleFoldTest(test_util.TestCase):
         warm_restart_pkg[0],
         warm_restart_pkg[1].inner_results.inner_results
     ])
-    self.assertEqual(reduction_rslt, 3)
-    self.assertEqual(last_sample, 5)
-    self.assertEqual(innermost_results.counter_1, 5)
-    self.assertEqual(innermost_results.counter_2, 10)
+    self.assertEqual(3, reduction_rslt)
+    self.assertEqual(5, last_sample)
+    self.assertEqual(5, innermost_results.counter_1)
+    self.assertEqual(10, innermost_results.counter_2)
 
   @parameterized.parameters(1., 2.)
   def test_current_state(self, curr_state):
@@ -133,11 +133,11 @@ class SampleFoldTest(test_util.TestCase):
         warm_restart_pkg[0],
         warm_restart_pkg[1].inner_results.inner_results
     ])
-    self.assertEqual(reduction_rslt, np.mean(
-        np.arange(curr_state + 1, curr_state + 6)))
-    self.assertEqual(last_sample, curr_state + 5)
-    self.assertEqual(innermost_results.counter_1, 5)
-    self.assertEqual(innermost_results.counter_2, 10)
+    self.assertEqual(
+        np.mean(np.arange(curr_state + 1, curr_state + 6)), reduction_rslt)
+    self.assertEqual(curr_state + 5, last_sample)
+    self.assertEqual(5, innermost_results.counter_1)
+    self.assertEqual(10, innermost_results.counter_2)
 
   def test_warm_restart(self):
     fake_kernel = TestTransitionKernel()
@@ -160,10 +160,10 @@ class SampleFoldTest(test_util.TestCase):
         warm_restart_pkg[0],
         warm_restart_pkg[1].inner_results.inner_results
     ])
-    self.assertEqual(reduction_rslt, 5.5)
-    self.assertEqual(last_sample, 10)
-    self.assertEqual(innermost_results.counter_1, 10)
-    self.assertEqual(innermost_results.counter_2, 20)
+    self.assertEqual(5.5, reduction_rslt)
+    self.assertEqual(10, last_sample)
+    self.assertEqual(10, innermost_results.counter_1)
+    self.assertEqual(20, innermost_results.counter_2)
 
   def test_nested_reducers(self):
     fake_kernel = TestTransitionKernel()
@@ -182,15 +182,15 @@ class SampleFoldTest(test_util.TestCase):
         warm_restart_pkg[0],
         warm_restart_pkg[1].inner_results.inner_results
     ])
-    self.assertEqual(len(reduction_rslt), 2)
-    self.assertEqual(len(reduction_rslt[0]), 2)
-    self.assertEqual(len(reduction_rslt[1]), 1)
+    self.assertEqual(2, len(reduction_rslt))
+    self.assertEqual(2, len(reduction_rslt[0]))
+    self.assertEqual(1, len(reduction_rslt[1]))
 
-    self.assertEqual(reduction_rslt[0][0], 2)
-    self.assertNear(reduction_rslt[0][1], 2/3, err=1e-6)
-    self.assertEqual(last_sample, 3)
-    self.assertEqual(innermost_results.counter_1, 3)
-    self.assertEqual(innermost_results.counter_2, 6)
+    self.assertEqual(2, reduction_rslt[0][0])
+    self.assertNear(2/3, reduction_rslt[0][1], err=1e-6)
+    self.assertEqual(3, last_sample)
+    self.assertEqual(3, innermost_results.counter_1)
+    self.assertEqual(6, innermost_results.counter_2)
 
   def test_true_streaming_covariance(self):
     seed = test_util.test_seed()
@@ -222,10 +222,10 @@ class SampleFoldTest(test_util.TestCase):
         reduction_rslt, warm_restart_pkg[1].streaming_calculations
     ])
     mean = streaming_calc.cov_state.mean
-    self.assertEqual(reduction_rslt.shape, (2, 3, 3))
-    self.assertAllEqual(reduction_rslt, np.ones(reduction_rslt.shape) * 2)
-    self.assertEqual(mean.shape, (2, 3))
-    self.assertAllEqual(mean, np.ones(mean.shape) * 3)
+    self.assertEqual((2, 3, 3), reduction_rslt.shape)
+    self.assertAllEqual(np.ones(reduction_rslt.shape) * 2, reduction_rslt)
+    self.assertEqual((2, 3), mean.shape)
+    self.assertAllEqual(np.ones(mean.shape) * 3, mean)
     self.assertAllEqualNested(warm_restart_pkg[0], [[5., 5., 5.], [5., 5., 5.]])
 
   def test_seed_reproducibility(self):
@@ -267,14 +267,14 @@ class SampleFoldTest(test_util.TestCase):
         warm_restart_pkg[0],
         warm_restart_pkg[1]
     ])
-    self.assertEqual(reduction_rslt, 16)
-    self.assertEqual(last_sample, 20)
+    self.assertEqual(16, reduction_rslt)
+    self.assertEqual(20, last_sample)
     self.assertEqual(
-        kernel_results.inner_results.inner_results.counter_1, 20)
+        20, kernel_results.inner_results.inner_results.counter_1)
     self.assertEqual(
-        kernel_results.inner_results.inner_results.counter_2, 40)
+        40, kernel_results.inner_results.inner_results.counter_2)
     self.assertEqual(
-        kernel_results.inner_results.call_counter, 5)
+        5, kernel_results.inner_results.call_counter)
 
   def test_no_reducer(self):
     fake_kernel = TestTransitionKernel()

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -276,6 +276,26 @@ class SampleFoldTest(test_util.TestCase):
     self.assertEqual(
         kernel_results.inner_results.call_counter, 5)
 
+  def test_no_reducer(self):
+    fake_kernel = TestTransitionKernel()
+    reduction_rslt, warm_restart_pkg = tfp.experimental.mcmc.sample_fold(
+        num_steps=5,
+        current_state=0.,
+        kernel=fake_kernel,
+        num_burnin_steps=10,
+        num_steps_between_results=1,
+    )
+    reduction_rslt, last_sample, kernel_results = self.evaluate([
+        reduction_rslt,
+        warm_restart_pkg[0],
+        warm_restart_pkg[1]
+    ])
+    self.assertEqual([], reduction_rslt)
+    self.assertEqual(20, last_sample)
+    self.assertEqual([], kernel_results.streaming_calculations)
+    self.assertEqual(20, kernel_results.inner_results.inner_results.counter_1)
+    self.assertEqual(40, kernel_results.inner_results.inner_results.counter_2)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/with_reductions_test.py
@@ -92,7 +92,7 @@ class WithReductionsTest(test_util.TestCase):
     fake_reducer = TestReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
     pkr = reducer_kernel.bootstrap_results(0.,)
     new_sample, kernel_results = reducer_kernel.one_step(0., pkr)
@@ -108,7 +108,7 @@ class WithReductionsTest(test_util.TestCase):
     fake_reducer = TestReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
     pkr = self.evaluate(reducer_kernel.bootstrap_results(9.))
     self.assertEqual(0, pkr.streaming_calculations, 0)
@@ -121,11 +121,11 @@ class WithReductionsTest(test_util.TestCase):
     fake_reducer = TestReducer()
     calibrated_reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_calibrated_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
     uncalibrated_reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_uncalibrated_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
     self.assertTrue(calibrated_reducer_kernel.is_calibrated)
     self.assertFalse(uncalibrated_reducer_kernel.is_calibrated)
@@ -135,7 +135,7 @@ class WithReductionsTest(test_util.TestCase):
     fake_reducer = TestReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=fake_reducer,
+        reducer=fake_reducer,
     )
 
     initial_state = 0.
@@ -161,10 +161,10 @@ class WithReductionsTest(test_util.TestCase):
 
   def test_nested_reducers(self):
     fake_kernel = TestTransitionKernel()
-    nested_reducers = [[TestReducer(), TestReducer()], [TestReducer()]]
+    nested_reducer = [[TestReducer(), TestReducer()], [TestReducer()]]
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=nested_reducers,
+        reducer=nested_reducer,
     )
     pkr = reducer_kernel.bootstrap_results(0.)
     new_sample, kernel_results = reducer_kernel.one_step(0., pkr)
@@ -188,10 +188,10 @@ class WithReductionsTest(test_util.TestCase):
 
   def test_nested_state_dependent_reducers(self):
     fake_kernel = TestTransitionKernel()
-    nested_reducers = [[MeanReducer(), MeanReducer()], [MeanReducer()]]
+    nested_reducer = [[MeanReducer(), MeanReducer()], [MeanReducer()]]
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=nested_reducers,
+        reducer=nested_reducer,
     )
     pkr = reducer_kernel.bootstrap_results(0.)
     new_sample, kernel_results = reducer_kernel.one_step(0., pkr)
@@ -226,7 +226,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer(ddof=ddof)
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
 
     chain_state, kernel_results = 0., reducer_kernel.bootstrap_results(0.)
@@ -251,7 +251,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer(event_ndims=1)
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
     state = tf.zeros((9, 3))
     kernel_results = reducer_kernel.bootstrap_results(state)
@@ -272,7 +272,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     reducer = tfp.experimental.mcmc.VarianceReducer(ddof=ddof)
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=reducer,
+        reducer=reducer,
     )
 
     chain_state, kernel_results = 0., reducer_kernel.bootstrap_results(0.)
@@ -308,7 +308,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
     samples, _, kernel_results = tfp.mcmc.sample_chain(
         num_results=20,
@@ -335,7 +335,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
     chain_state, kernel_results = tfp.experimental.mcmc.step_kernel(
         num_steps=6,
@@ -362,7 +362,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
     transformed_kernel = tfp.mcmc.TransformedTransitionKernel(
         inner_kernel=reducer_kernel,
@@ -397,7 +397,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=transformed_kernel,
-        reducers=cov_reducer,
+        reducer=cov_reducer,
     )
     samples, _, kernel_results = tfp.mcmc.sample_chain(
         num_results=10,
@@ -429,7 +429,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=hmc_kernel,
-        reducers=cov_reducer
+        reducer=cov_reducer
     )
     step_adapted_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
         inner_kernel=reducer_kernel,
@@ -463,7 +463,7 @@ class CovarianceWithReductionsTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
     reducer_kernel = tfp.experimental.mcmc.WithReductions(
         inner_kernel=fake_kernel,
-        reducers=[[mean_reducer, cov_reducer], [fake_reducer]],
+        reducer=[[mean_reducer, cov_reducer], [fake_reducer]],
     )
 
     chain_state, kernel_results = 0., reducer_kernel.bootstrap_results(0.)


### PR DESCRIPTION
`sample_fold` is a high-level driver that automatically applies reducers to stream over MCMC samples. It draws samples from the provided `kernel`, updates reducer states with those samples, and finalizes reducer computation. This piece makes it easy to conduct streaming MCMC without worrying about manually creating the Transition Kernel onion.

Thinning/burn-in semantics follow that proposed in https://github.com/tensorflow/probability/issues/1031