### PR TITLE
Make Replica Exchange / simple step size adaption work together

### DIFF
--- a/tensorflow_probability/python/mcmc/internal/util.py
+++ b/tensorflow_probability/python/mcmc/internal/util.py
@@ -741,11 +741,7 @@ def get_field(kernel_results, field_name):
   if accepted_results is None:
     raise TypeError('Cannot extract {} from {}'.format(
         field_name, kernel_results))
-  attr = getattr(accepted_results, field_name, None)
-  if attr is None:
-    raise TypeError('Cannot extract {} from {}'.format(
-        field_name, kernel_results))
-  return attr
+  return get_field(accepted_results, field_name)
 
 
 @make_innermost_setter
@@ -757,8 +753,5 @@ def update_field(kernel_results, field_name, value):
   if accepted_results is None:
     raise TypeError('Cannot set {} in {}'.format(
         field_name, kernel_results))
-  if not hasattr(accepted_results, field_name):
-    raise TypeError('Cannot set {} in {}'.format(
-        field_name, accepted_results))
   return kernel_results._replace(
-      accepted_results=accepted_results._replace(**{field_name: value}))
+      accepted_results=update_field(accepted_results, field_name, value))

--- a/tensorflow_probability/python/mcmc/internal/util.py
+++ b/tensorflow_probability/python/mcmc/internal/util.py
@@ -728,3 +728,37 @@ def index_remapping_gather(params,
     return dist_util.move_dimension(result_t,
                                     source_idx=broadcast_indices_ndims - 1,
                                     dest_idx=axis)
+
+
+# TODO(b/111801087): Use a standardized API, when available.
+@make_innermost_getter
+def get_field(kernel_results, field_name):
+  """Get field value from kernel_results or kernel_results.accepted_results."""
+  attr = getattr(kernel_results, field_name, None)
+  if attr is not None:
+    return attr
+  accepted_results = getattr(kernel_results, 'accepted_results', None)
+  if accepted_results is None:
+    raise TypeError('Cannot extract {} from {}'.format(
+        field_name, kernel_results))
+  attr = getattr(accepted_results, field_name, None)
+  if attr is None:
+    raise TypeError('Cannot extract {} from {}'.format(
+        field_name, kernel_results))
+  return attr
+
+
+@make_innermost_setter
+def update_field(kernel_results, field_name, value):
+  """Set field value in kernel_results or kernel_results.accepted_results."""
+  if hasattr(kernel_results, field_name):
+    return kernel_results._replace(**{field_name: value})
+  accepted_results = getattr(kernel_results, 'accepted_results', None)
+  if accepted_results is None:
+    raise TypeError('Cannot set {} in {}'.format(
+        field_name, kernel_results))
+  if not hasattr(accepted_results, field_name):
+    raise TypeError('Cannot set {} in {}'.format(
+        field_name, accepted_results))
+  return kernel_results._replace(
+      accepted_results=accepted_results._replace(**{field_name: value}))

--- a/tensorflow_probability/python/mcmc/internal/util_test.py
+++ b/tensorflow_probability/python/mcmc/internal/util_test.py
@@ -584,24 +584,24 @@ FakeKernelResults = collections.namedtuple('FakeKernelResults', 'some_field')
 
 
 FakeKernelAcceptedResults = collections.namedtuple(
-  'FakeKernelAcceptedResults',
-  'accepted_results')
+    'FakeKernelAcceptedResults',
+    'accepted_results')
 
 
 FakeAcceptedResults = collections.namedtuple(
-  'FakeAcceptedResults', 'some_field')
+    'FakeAcceptedResults', 'some_field')
 
 
 FakeIncompleteKernelResults = collections.namedtuple(
-  'FakeIncompleteKernelResults', 'some_field')
+    'FakeIncompleteKernelResults', 'some_field')
 
 
 class GetFieldTest(test_util.TestCase):
   @parameterized.parameters(
-    [FakeKernelResults(some_field='yak')],
-    [FakeKernelAcceptedResults(
-      accepted_results=FakeAcceptedResults(some_field='yak'))]
-    )
+      [FakeKernelResults(some_field='yak')],
+      [FakeKernelAcceptedResults(
+          accepted_results=FakeAcceptedResults(some_field='yak'))]
+  )
   def testValidKernelResults(self, kernel_results):
     self.assertEqual(util.get_field(kernel_results, 'some_field'), 'yak')
     with self.assertRaisesRegexp(TypeError, 'extract some_other_field'):
@@ -616,15 +616,16 @@ class GetFieldTest(test_util.TestCase):
 
 class UpdateFieldTest(test_util.TestCase):
   @parameterized.parameters(
-    [FakeKernelResults(some_field='yak')],
-    [FakeKernelAcceptedResults(
-      accepted_results=FakeAcceptedResults(some_field='yak'))]
+      [FakeKernelResults(some_field='yak')],
+      [FakeKernelAcceptedResults(
+          accepted_results=FakeAcceptedResults(some_field='yak'))]
     )
   def testValidKernelResults(self, kernel_results):
     updated_kernel_results = util.update_field(
         kernel_results, 'some_field', 'moose')
-    self.assertEqual(util.get_field(
-            updated_kernel_results, 'some_field'),'moose')
+    self.assertEqual(
+        util.get_field(
+            updated_kernel_results, 'some_field'), 'moose')
     with self.assertRaisesRegexp(TypeError, 'set some_other_field'):
       util.update_field(kernel_results, 'some_other_field', 'antelope')
 

--- a/tensorflow_probability/python/mcmc/internal/util_test.py
+++ b/tensorflow_probability/python/mcmc/internal/util_test.py
@@ -588,19 +588,11 @@ FakeKernelAcceptedResults = collections.namedtuple(
     'accepted_results')
 
 
-FakeAcceptedResults = collections.namedtuple(
-    'FakeAcceptedResults', 'some_field')
-
-
-FakeIncompleteKernelResults = collections.namedtuple(
-    'FakeIncompleteKernelResults', 'some_field')
-
-
 class GetFieldTest(test_util.TestCase):
   @parameterized.parameters(
       [FakeKernelResults(some_field='yak')],
       [FakeKernelAcceptedResults(
-          accepted_results=FakeAcceptedResults(some_field='yak'))]
+          accepted_results=FakeKernelResults(some_field='yak'))]
   )
   def testValidKernelResults(self, kernel_results):
     self.assertEqual(util.get_field(kernel_results, 'some_field'), 'yak')
@@ -608,8 +600,8 @@ class GetFieldTest(test_util.TestCase):
       util.get_field(kernel_results, 'some_other_field')
 
 
-  def testIncompletedKernelResults(self):
-    kernel_results = FakeIncompleteKernelResults(some_field='zebra')
+  def testIncompleteKernelResults(self):
+    kernel_results = FakeKernelResults(some_field='zebra')
     with self.assertRaisesRegexp(TypeError, 'extract some_other_field'):
       util.get_field(kernel_results, 'some_other_field')
 
@@ -618,7 +610,7 @@ class UpdateFieldTest(test_util.TestCase):
   @parameterized.parameters(
       [FakeKernelResults(some_field='yak')],
       [FakeKernelAcceptedResults(
-          accepted_results=FakeAcceptedResults(some_field='yak'))]
+          accepted_results=FakeKernelResults(some_field='yak'))]
     )
   def testValidKernelResults(self, kernel_results):
     updated_kernel_results = util.update_field(
@@ -631,7 +623,7 @@ class UpdateFieldTest(test_util.TestCase):
 
 
   def testIncompletedKernelResults(self):
-    kernel_results = FakeIncompleteKernelResults(some_field='ibex')
+    kernel_results = FakeKernelResults(some_field='ibex')
     with self.assertRaisesRegexp(TypeError, 'set some_other_field'):
       util.update_field(kernel_results, 'some_other_field', 'goat')
 

--- a/tensorflow_probability/python/mcmc/internal/util_test.py
+++ b/tensorflow_probability/python/mcmc/internal/util_test.py
@@ -580,5 +580,60 @@ class SimpleTensorWarningTest(test_util.TestCase):
             for warning in triggered))
 
 
+FakeKernelResults = collections.namedtuple('FakeKernelResults', 'some_field')
+
+
+FakeKernelAcceptedResults = collections.namedtuple(
+  'FakeKernelAcceptedResults',
+  'accepted_results')
+
+
+FakeAcceptedResults = collections.namedtuple(
+  'FakeAcceptedResults', 'some_field')
+
+
+FakeIncompleteKernelResults = collections.namedtuple(
+  'FakeIncompleteKernelResults', 'some_field')
+
+
+class GetFieldTest(test_util.TestCase):
+  @parameterized.parameters(
+    [FakeKernelResults(some_field='yak')],
+    [FakeKernelAcceptedResults(
+      accepted_results=FakeAcceptedResults(some_field='yak'))]
+    )
+  def testValidKernelResults(self, kernel_results):
+    self.assertEqual(util.get_field(kernel_results, 'some_field'), 'yak')
+    with self.assertRaisesRegexp(TypeError, 'extract some_other_field'):
+      util.get_field(kernel_results, 'some_other_field')
+
+
+  def testIncompletedKernelResults(self):
+    kernel_results = FakeIncompleteKernelResults(some_field='zebra')
+    with self.assertRaisesRegexp(TypeError, 'extract some_other_field'):
+      util.get_field(kernel_results, 'some_other_field')
+
+
+class UpdateFieldTest(test_util.TestCase):
+  @parameterized.parameters(
+    [FakeKernelResults(some_field='yak')],
+    [FakeKernelAcceptedResults(
+      accepted_results=FakeAcceptedResults(some_field='yak'))]
+    )
+  def testValidKernelResults(self, kernel_results):
+    updated_kernel_results = util.update_field(
+        kernel_results, 'some_field', 'moose')
+    self.assertEqual(util.get_field(
+            updated_kernel_results, 'some_field'),'moose')
+    with self.assertRaisesRegexp(TypeError, 'set some_other_field'):
+      util.update_field(kernel_results, 'some_other_field', 'antelope')
+
+
+  def testIncompletedKernelResults(self):
+    kernel_results = FakeIncompleteKernelResults(some_field='ibex')
+    with self.assertRaisesRegexp(TypeError, 'set some_other_field'):
+      util.update_field(kernel_results, 'some_other_field', 'goat')
+
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow_probability/python/mcmc/replica_exchange_mc.py
+++ b/tensorflow_probability/python/mcmc/replica_exchange_mc.py
@@ -29,10 +29,7 @@ from tensorflow_probability.python.internal import distribution_util
 from tensorflow_probability.python.internal import prefer_static as ps
 from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensorshape_util
-from tensorflow_probability.python.mcmc import hmc
 from tensorflow_probability.python.mcmc import kernel as kernel_base
-from tensorflow_probability.python.mcmc import metropolis_hastings
-from tensorflow_probability.python.mcmc import random_walk_metropolis
 from tensorflow_probability.python.mcmc.internal import util as mcmc_util
 from tensorflow_probability.python.util.seed_stream import SeedStream
 from tensorflow.python.util import deprecation  # pylint: disable=g-direct-tensorflow-import
@@ -969,11 +966,12 @@ def _make_post_swap_replica_results(pre_swap_replica_results,
       mcmc_util.get_field(kr, 'target_log_prob')))
   try:
     new_grads_target_log_prob = _swap_then_retemper(
-        mcmc_util.get_field(kr, 'grads_target_log_prob'))    
-    kr = mcmc_util.update_field(kr, 'grads_target_log_prob', new_grads_target_log_prob)
+        mcmc_util.get_field(kr, 'grads_target_log_prob'))
+    kr = mcmc_util.update_field(
+        kr, 'grads_target_log_prob', new_grads_target_log_prob)
   except TypeError:
     pass
-  
+
   return kr
 
 

--- a/tensorflow_probability/python/mcmc/replica_exchange_mc_test.py
+++ b/tensorflow_probability/python/mcmc/replica_exchange_mc_test.py
@@ -460,7 +460,7 @@ class REMCTest(test_util.TestCase):
       self.assertAllEqual(
           np.repeat([num_leapfrog_steps], axis=0, repeats=num_results),
           mcmc_util.get_field(
-            kr_.post_swap_replica_results, 'num_leapfrog_steps'))
+              kr_.post_swap_replica_results, 'num_leapfrog_steps'))
 
   @parameterized.named_parameters([
       # pylint: disable=line-too-long
@@ -516,7 +516,7 @@ class REMCTest(test_util.TestCase):
 
     def trace_fn(state, results):  # pylint: disable=unused-argument
       return mcmc_util.get_field(
-        results.post_swap_replica_results, 'log_accept_ratio')
+          results.post_swap_replica_results, 'log_accept_ratio')
 
     if state_includes_replicas:
       current_state = tf.ones((num_replica, 2), dtype=dtype)
@@ -730,7 +730,8 @@ class REMCTest(test_util.TestCase):
 
     def trace_fn(state, results):  # pylint: disable=unused-argument
       return [
-          mcmc_util.get_field(results.post_swap_replica_results, 'log_accept_ratio'),
+          mcmc_util.get_field(
+              results.post_swap_replica_results, 'log_accept_ratio'),
           results.post_swap_replica_states
       ]
 

--- a/tensorflow_probability/python/mcmc/replica_exchange_mc_test.py
+++ b/tensorflow_probability/python/mcmc/replica_exchange_mc_test.py
@@ -825,8 +825,8 @@ class REMCTest(test_util.TestCase):
       # z = matmul(inv(chol(true_cov)), [x, y] - true_mean)
       xy = tf.stack([x, y], axis=-1) - true_mean
       z = linop.solvevec(xy)
-
       return -0.5 * tf.reduce_sum(z**2., axis=-1)
+
     def make_kernel_fn(target_log_prob_fn):
       return tfp.mcmc.HamiltonianMonteCarlo(
           target_log_prob_fn=target_log_prob_fn,


### PR DESCRIPTION
Fixes #1032.
~~The changes in this PR are two-fold, but closely related (let me know if this merits two separate PRs):~~

1. ~~for the `SimpleStepSizeAdaption`, the `target_log_prob` field of the inner kernel results gets propagated to the `SimpleStepSizeAdaption` kernel results `namedtuple`~~
2. ~~while I'm not sure whether the `target_log_prob` field in results `namedtuple`s of existing kernels is used anywhere else other than in `ReplicaExchangeMC`, the change in 1.) allows, in principle, to embed the `SimpleStepSizeAdaption` kernel in the `ReplicaExchangeMC` kernel. For that to work, some further changes in the `ReplicaExchangeMC` code were necessary to propagate states to and from `SimpleStepSizeAdaption`'s inner kernel results~~

~~Currently, in `ReplicaExchangeMC`, there are distinctions via `if... else...` for two different kernels (HMC and RWMH) and kernel results. This PR just piles on with the necessary distinctions for the `SimpleStepSizeAdaption` kernel and HMC and RWMH as possible inner kernels. It gets somewhat unwieldy, but (and please correct me if I'm wrong) I feel that to improve that, there needs to be a better-defined interface of `tfp.mcmc.TransitionKernel` for recursive propagation of states and possibly other information.~~

This PR now implements @axch's [suggestion from the comments](https://github.com/tensorflow/probability/pull/1042#pullrequestreview-461931484). `ReplicaExchangeMC` _should_ now work with any nested kernel (as long as its kernel results `namedtuple` uses a `inner_results` / `accepted_results` field. At least it does with `SimpleStepSizeAdaptation`, which was the original issue.

I'm somewhat unsure about the tests. For the changes to `ReplicaExchangeMC`, I added a `SimpleStepSizeAdaptation` kernel parameter to the two existing functional tests of a 1- and 2D mixture of normal distributions, but did not test anything further apart from the `get_field()` / `update_field()` helper functions I moved to `tfp.mcmc.python.mcmc.internal.util` / wrote.
In case this is not sufficient, I'd appreciate some input on what additional tests are required and would be happy to implement them.