### PR TITLE
Adding an Expectations Reducer to tfp.experimental.mcmc

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -37,6 +37,7 @@ py_library(
     deps = [
         ":covariance_reducer",
         ":elliptical_slice_sampler",
+        ":expectations_reducer",
         ":nuts_autobatching",
         ":particle_filter",
         ":particle_filter_augmentation",
@@ -486,6 +487,30 @@ py_test(
     name = "tracing_reducer_test",
     size = "small",
     srcs = ["tracing_reducer_test.py"],
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
+    name = "expectations_reducer",
+    srcs = ["expectations_reducer.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":reducer",
+        # tensorflow dep,
+        "//tensorflow_probability/python/mcmc/internal:util",
+    ],
+)
+
+# py2and3
+py_test(
+    name = "expectations_reducer_test",
+    shard_count = 5,
+    srcs = ["expectations_reducer_test.py"],
     deps = [
         # numpy dep,
         # tensorflow dep,

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from tensorflow_probability.python.experimental.mcmc.covariance_reducer import CovarianceReducer
 from tensorflow_probability.python.experimental.mcmc.covariance_reducer import VarianceReducer
 from tensorflow_probability.python.experimental.mcmc.elliptical_slice_sampler import EllipticalSliceSampler
+from tensorflow_probability.python.experimental.mcmc.expectations_reducer import ExpectationsReducer
 from tensorflow_probability.python.experimental.mcmc.nuts import NoUTurnSampler
 from tensorflow_probability.python.experimental.mcmc.particle_filter import infer_trajectories
 from tensorflow_probability.python.experimental.mcmc.particle_filter import particle_filter
@@ -56,6 +57,7 @@ from tensorflow_probability.python.experimental.mcmc.with_reductions import With
 __all__ = [
     'CovarianceReducer',
     'EllipticalSliceSampler',
+    'ExpectationsReducer',
     'NoUTurnSampler',
     'SequentialMonteCarlo',
     'SequentialMonteCarloResults',

--- a/tensorflow_probability/python/experimental/mcmc/expectations_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/expectations_reducer.py
@@ -1,0 +1,227 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""ExpectationsReducer for pre-packaged streaming expectations."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.experimental.mcmc import reducer as reducer_base
+from tensorflow_probability.python.internal import nest_util
+from tensorflow_probability.python.internal import prefer_static as ps
+from tensorflow_probability.python.mcmc.internal import util as mcmc_util
+from tensorflow.python.util import nest  # pylint: disable=g-direct-tensorflow-import
+
+
+__all__ = [
+    'ExpectationsReducer',
+]
+
+
+ExpectationsReducerState = collections.namedtuple(
+    'ExpectationsReducerState', 'num_samples, running_total')
+
+
+class ExpectationsReducer(reducer_base.Reducer):
+  """`Reducer` that computes a running expectation.
+
+  `ExpectationsReducer` calculates expectation over some arbitrary structure
+  of `callables`. A callable is a function that accepts a Markov chain sample
+  and kernel results, and outputs the relevant value for expectation
+  calculation. In other words, if we denote a callable as f(x,y),
+  `ExpectationsReducer` computes E[f(x,y)] for all provided functions. The
+  finalized expectation will also identically mimic the structure of
+  `callables`.
+
+  As with all reducers, ExpectationsReducer does not hold state information;
+  rather, it stores supplied metadata. Intermediate calculations are held in
+  a state object, which is returned via `initialize` and `one_step` method
+  calls.
+  """
+
+  def __init__(self, callables=lambda sample, kr: sample, name=None):
+    """Instantiates this object.
+
+    Args:
+      callables: A (possibly nested) structure of functions that accept a
+        chain state and kernel results. Defaults to simply returning the
+        incoming chain state.
+      name: Python `str` name prefixed to Ops created by this function.
+        Default value: `None` (i.e., 'expectations_reducer').
+    """
+    self._parameters = dict(
+        callables=callables,
+        name=name or 'expectations_reducer'
+    )
+
+  def initialize(self, initial_chain_state, initial_kernel_results=None):
+    """Initializes an empty `ExpectationsReducerState`.
+
+    Args:
+      initial_chain_state: A (possibly nested) structure of `Tensor`s or Python
+        `list`s of `Tensor`s representing the current state(s) of the Markov
+        chain(s).
+      initial_kernel_results: A (possibly nested) structure of `Tensor`s
+        representing internal calculations made in a related `TransitionKernel`.
+
+    Returns:
+      state: `ExpectationsReducerState` representing a stream of no inputs.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'expectations_reducer', 'initialize')):
+      initial_chain_state = tf.nest.map_structure(
+          tf.convert_to_tensor,
+          initial_chain_state)
+      return ExpectationsReducerState(
+          num_samples=tf.zeros((), dtype=tf.int32),
+          running_total=tf.nest.map_structure(
+              lambda _: tf.zeros(
+                  initial_chain_state.shape, initial_chain_state.dtype),
+              self.callables
+          )
+      )
+
+  def one_step(
+      self,
+      new_chain_state,
+      current_reducer_state,
+      previous_kernel_results=None,
+      axis=None):
+    """Update the `current_reducer_state` with a new chain state.
+
+    Chunking semantics are specified by the `axis` parameter. If chunking is
+    enabled (axis is not `None`), all elements along the specified `axis` will
+    be treated as separate samples. If a single scalar value is provided for a
+    non-scalar sample structure, that value will be used for all elements in the
+    structure. If not, an identical structure must be provided.
+
+    Args:
+      new_chain_state: A (possibly nested) structure of incoming chain state(s)
+        with shape and dtype compatible with those used to initialize the
+        `current_reducer_state`.
+      current_reducer_state: `ExpectationsReducerState` representing the current
+        reducer state.
+      previous_kernel_results: A (possibly nested) structure of `Tensor`s
+        representing internal calculations made in a related
+        `TransitionKernel`.
+      axis: If chunking is desired, this is a (possibly nested) structure of
+        integers that specifies the axis with chunked samples. For individual
+        samples, set this to `None`. By default, samples are not chunked
+        (`axis` is None).
+
+    Returns:
+      new_reducer_state: `ExpectationsReducerState` with updated running
+        statistics. It tracks a running total and the number of processed
+        samples.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'expectations_reducer', 'one_step')):
+      new_chain_state = tf.nest.map_structure(
+          tf.convert_to_tensor,
+          new_chain_state)
+      axis, new_chain_state, previous_kernel_results = _prepare_args(
+          self.callables, axis, new_chain_state, previous_kernel_results)
+      num_new_samples = 1
+
+      def _update_running_total(
+          running_total, new_chain_state, pkr, fn, axis):
+        """Updates the running total and facilitates chunking (if enabled)."""
+        nonlocal num_new_samples
+        if axis is None:
+          chunked_new_chain_state = new_chain_state
+          chunked_result = fn(chunked_new_chain_state, pkr)
+        else:
+          rank = ps.rank(new_chain_state)
+          num_new_samples = ps.shape(new_chain_state)[axis]
+          chunked_new_chain_state = tf.transpose(
+              new_chain_state,
+              [axis] + list(range(0, axis)) + list(range(axis + 1, rank)))
+          chunked_result = tf.reduce_sum(
+              tf.map_fn(lambda chain_state: fn(chain_state, pkr),
+                        chunked_new_chain_state),
+              axis=0)
+        return running_total + chunked_result
+
+      new_running_total = nest.map_structure_up_to(
+          current_reducer_state.running_total,
+          _update_running_total,
+          current_reducer_state.running_total,
+          new_chain_state,
+          previous_kernel_results,
+          self.callables,
+          axis,
+          check_types=False,
+      )
+      return ExpectationsReducerState(
+          num_samples=current_reducer_state.num_samples + num_new_samples,
+          running_total=new_running_total)
+
+  def finalize(self, final_reducer_state):
+    """Finalizes expectation calculation from the `final_reducer_state`.
+
+    Args:
+      final_reducer_state: `ExpectationsReducerState` that represents the
+        final reducer state.
+
+    Returns:
+      expectation: an estimate of the expectation with identical structure to
+        `final_reducer_state.running_total`.
+    """
+    if final_reducer_state.num_samples == 0:
+      finalize_fn = lambda x, y: None
+    else:
+      finalize_fn = lambda num_samples, total: total / tf.cast(
+          num_samples, total.dtype)
+    return tf.nest.map_structure(
+        finalize_fn,
+        nest_util.broadcast_structure(
+            final_reducer_state.running_total,
+            final_reducer_state.num_samples),
+        final_reducer_state.running_total,
+        check_types=False,
+    )
+
+  @property
+  def callables(self):
+    return self._parameters['callables']
+
+  @property
+  def name(self):
+    return self._parameters['name']
+
+  @property
+  def parameters(self):
+    return self._parameters
+
+
+def _prepare_args(target, axis, chain_state, pkr):
+  """Broadcasts arguments to match the structure of `target`."""
+  axis = nest_util.broadcast_structure(target, axis)
+  # using `nest_util.broadcast_structure` for the following arguments
+  # isn't robust as they may already be in some nested structure.
+  chain_state = tf.nest.map_structure(
+      lambda _: chain_state,
+      target
+  )
+  pkr = tf.nest.map_structure(
+      lambda _: pkr,
+      target
+  )
+  return axis, chain_state, pkr

--- a/tensorflow_probability/python/experimental/mcmc/expectations_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/expectations_reducer.py
@@ -46,7 +46,7 @@ ExpectationsReducerState = collections.namedtuple(
 class ExpectationsReducer(reducer_base.Reducer):
   """`Reducer` that computes a running expectation.
 
-  `ExpectationsReducer` calculates expectation over some arbitrary structure
+  `ExpectationsReducer` calculates expectations over some arbitrary structure
   of `transform_fn`s. A `transform_fn` is a function that accepts a Markov
   chain sample and kernel results, and outputs the relevant value for
   expectation calculation. In other words, if we denote a `transform_fn`

--- a/tensorflow_probability/python/experimental/mcmc/expectations_reducer_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/expectations_reducer_test.py
@@ -1,0 +1,175 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for ExpectationsReducer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import numpy as np
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.internal import test_util
+
+
+FakeKernelResults = collections.namedtuple(
+        'FakeKernelResults', 'value, inner_results')
+
+
+FakeInnerResults = collections.namedtuple(
+    'FakeInnerResults', 'value')
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic `TransitionKernel` for testing purposes."""
+
+  def __init__(self, is_calibrated=True, accepts_seed=True):
+    self._is_calibrated = is_calibrated
+    self._accepts_seed = accepts_seed
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    if seed is not None and not self._accepts_seed:
+      raise TypeError('seed arg not accepted')
+    return current_state + 1, TestTransitionKernelResults(
+        counter_1=previous_kernel_results.counter_1 + 1,
+        counter_2=previous_kernel_results.counter_2 + 2)
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.constant(0, dtype=tf.int32),
+        counter_2=tf.constant(0, dtype=tf.int32))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+@test_util.test_all_tf_execution_regimes
+class ExpectationsReducerTest(test_util.TestCase):
+
+  def test_simple_operation(self):
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
+    state = mean_reducer.initialize(0)
+    for sample in range(6):
+      state = mean_reducer.one_step(sample, state)
+    mean = self.evaluate(mean_reducer.finalize(state))
+    self.assertEqual(2.5, mean)
+
+  def test_with_callables(self):
+    callables = [lambda x, y: x + 1, lambda x, y: x + 2]
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer(
+        callables=callables
+    )
+    state = mean_reducer.initialize(0)
+    for sample in range(6):
+      state = mean_reducer.one_step(sample, state)
+    mean = self.evaluate(mean_reducer.finalize(state))
+    self.assertEqual([3.5, 4.5], mean)
+
+  def test_with_nested_callables(self):
+    callables = [
+        {'add_one': lambda x, y: x + 1},
+        {'add_two': lambda x, y: x + 2, 'zero': lambda x, y: 0}
+    ]
+    expectations_reducer = tfp.experimental.mcmc.ExpectationsReducer(
+        callables=callables
+    )
+    state = expectations_reducer.initialize(0)
+    for sample in range(6):
+      state = expectations_reducer.one_step(sample, state)
+    mean = self.evaluate(expectations_reducer.finalize(state))
+    self.assertEqual([
+        {'add_one': 3.5},
+        {'add_two': 4.5, 'zero': 0}
+    ], mean)
+
+  def test_with_kernel_results(self):
+    def kernel_average(sample, kr):
+      return kr.value
+    def inner_average(sample, kr):
+      return kr.inner_results.value
+
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer(
+        callables=[kernel_average, inner_average]
+    )
+    kernel_results = FakeKernelResults(
+        0, FakeInnerResults(1))
+    state = mean_reducer.initialize(0, kernel_results)
+    for sample in range(6):
+      kernel_results = FakeKernelResults(
+          sample, FakeInnerResults(sample + 1))
+      state = mean_reducer.one_step(sample, state, kernel_results)
+    mean = self.evaluate(mean_reducer.finalize(state))
+    self.assertEqual([2.5, 3.5], mean)
+
+  def test_chunking(self):
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
+    state = mean_reducer.initialize(tf.ones((3,)))
+    kernel_results = FakeKernelResults(
+        0, FakeInnerResults(1))
+    for sample in range(6):
+      state = mean_reducer.one_step(
+          tf.ones((3, 9)) * sample, state, kernel_results, axis=1)
+    mean = self.evaluate(mean_reducer.finalize(state))
+    self.assertEqual((3,), mean.shape)
+    self.assertAllEqual([2.5, 2.5, 2.5], mean)
+
+  def test_no_steps(self):
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
+    state = mean_reducer.initialize(0)
+    mean = self.evaluate(mean_reducer.finalize(state))
+    if tf.executing_eagerly():
+      self.assertEqual(None, mean)
+    else:
+      self.assertTrue(np.isnan(mean))
+
+  def test_in_with_reductions(self):
+    fake_kernel = TestTransitionKernel()
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
+    reduced_kernel = tfp.experimental.mcmc.WithReductions(
+        fake_kernel, mean_reducer,
+    )
+    pkr = reduced_kernel.bootstrap_results(8)
+    _, kernel_results = reduced_kernel.one_step(8, pkr)
+    streaming_calculations = self.evaluate(
+        mean_reducer.finalize(kernel_results.streaming_calculations))
+    self.assertEqual(9, streaming_calculations)
+
+  def test_in_step_kernel(self):
+    fake_kernel = TestTransitionKernel()
+    mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
+    reduced_kernel = tfp.experimental.mcmc.WithReductions(
+        fake_kernel, mean_reducer,
+    )
+    _, kernel_results = tfp.experimental.mcmc.step_kernel(
+        num_steps=5,
+        current_state=8,
+        kernel=reduced_kernel,
+        return_final_kernel_results=True,
+    )
+    streaming_calculations = self.evaluate(
+        mean_reducer.finalize(kernel_results.streaming_calculations))
+    self.assertEqual(11, streaming_calculations)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/experimental/stats/__init__.py
+++ b/tensorflow_probability/python/experimental/stats/__init__.py
@@ -18,16 +18,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_probability.python.experimental.stats.sample_stats import RunningExpectations
-from tensorflow_probability.python.experimental.stats.sample_stats import RunningExpectationsState
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningMean
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningMeanState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovariance
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovarianceState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningVariance
 
 
 __all__ = [
-    'RunningExpectations',
-    'RunningExpectationsState',
+    'RunningMean',
+    'RunningMeanState',
     'RunningCovariance',
     'RunningCovarianceState',
     'RunningVariance',

--- a/tensorflow_probability/python/experimental/stats/__init__.py
+++ b/tensorflow_probability/python/experimental/stats/__init__.py
@@ -18,13 +18,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningExpectations
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningExpectationsState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovariance
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovarianceState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningVariance
 
+
 __all__ = [
+    'RunningExpectations',
+    'RunningExpectationsState',
     'RunningCovariance',
     'RunningCovarianceState',
     'RunningVariance',
 ]
-

--- a/tensorflow_probability/python/experimental/stats/sample_stats.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats.py
@@ -23,7 +23,6 @@ import collections
 
 import tensorflow.compat.v2 as tf
 
-from tensorflow_probability.python.internal import nest_util
 from tensorflow_probability.python.internal import prefer_static as ps
 
 

--- a/tensorflow_probability/python/experimental/stats/sample_stats.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats.py
@@ -144,8 +144,10 @@ class RunningCovariance(object):
         the inner-most dimensions.  Specifying `None` returns all cross
         product terms (no batching) and is the default.
       dtype: Dtype of incoming samples and the resulting statistics.
-        By default, the dtype is `tf.float32`. Any integer dtypes will also
-        be treated as `tf.float32` (to not lose significant precision).
+        By default, the dtype is `tf.float32`. Any integer dtypes will be
+        cast to corresponding floats (i.e. `tf.int32` will be cast to
+        `tf.float32`), as intermediate calculations should be performing
+        floating-point division.
 
     Raises:
       ValueError: if `event_ndims` is greater than the rank of the intended
@@ -160,7 +162,9 @@ class RunningCovariance(object):
       raise ValueError('`event_ndims` over 13 not supported')
     self.shape = shape
     self.event_ndims = event_ndims
-    if dtype.is_integer:
+    if dtype is tf.int64:
+      dtype = tf.float64
+    elif dtype.is_integer:
       dtype = tf.float32
     self.dtype = dtype
 
@@ -271,8 +275,10 @@ class RunningVariance(RunningCovariance):
       shape: Python `Tuple` or `TensorShape` representing the shape of
         incoming samples. By default, the shape is assumed to be scalar.
       dtype: Dtype of incoming samples and the resulting statistics.
-        By default, the dtype is `tf.float32`. Any integer dtypes will also
-        be treated as `tf.float32` (to not lose significant precision).
+        By default, the dtype is `tf.float32`. Any integer dtypes will be
+        cast to corresponding floats (i.e. `tf.int32` will be cast to
+        `tf.float32`), as intermediate calculations should be performing
+        floating-point division.
     """
     super(RunningVariance, self).__init__(shape, event_ndims=0, dtype=dtype)
 
@@ -287,8 +293,8 @@ class RunningMean(object):
   In computation, samples can be provided individually or in chunks. A
   "chunk" of size M implies incorporating M samples into a single expectation
   computation at once, which is more efficient than one by one. If more than one
-  callable is accepted and chunking is enabled, the chunked `axis` will define
-  chunking semantics for all callables.
+  sample is accepted and chunking is enabled, the chunked `axis` will define
+  chunking semantics for all samples.
 
   `RunningMean` objects do not hold state information. That information,
   which includes intermediate calculations, are held in a
@@ -307,11 +313,15 @@ class RunningMean(object):
       shape: Python `Tuple` or `TensorShape` representing the shape of
         incoming samples.
       dtype: Dtype of incoming samples and the resulting statistics.
-        By default, the dtype is `tf.float32`. Any integer dtypes will also
-        be treated as `tf.float32` (to not lose significant precision).
+        By default, the dtype is `tf.float32`. Any integer dtypes will be
+        cast to corresponding floats (i.e. `tf.int32` will be cast to
+        `tf.float32`), as intermediate calculations should be performing
+        floating-point division.
     """
     self.shape = shape
-    if dtype.is_integer:
+    if dtype is tf.int64:
+      dtype = tf.float64
+    elif dtype.is_integer:
       dtype = tf.float32
     self.dtype = dtype
 

--- a/tensorflow_probability/python/experimental/stats/sample_stats.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats.py
@@ -23,10 +23,14 @@ import collections
 
 import tensorflow.compat.v2 as tf
 
+from tensorflow_probability.python.internal import nest_util
 from tensorflow_probability.python.internal import prefer_static as ps
+from tensorflow.python.util import nest  # pylint: disable=g-direct-tensorflow-import
 
 
 __all__ = [
+    'RunningExpectations',
+    'RunningExpectationsState',
     'RunningCovariance',
     'RunningCovarianceState',
     'RunningVariance',
@@ -110,30 +114,30 @@ class RunningCovariance(object):
   `RunningCovarianceState` as returned via `initialize` and `update` method
   calls.
 
+  The running covariance computation supports batching. The `event_ndims`
+  parameter indicates the number of trailing dimensions to treat as part of
+  the event, and to compute covariance across. The leading dimensions, if
+  any, are treated as batch shape, and no cross terms are computed.
+
+  For example, if the incoming samples have shape `[5, 7]`, the `event_ndims`
+  selects among three different covariance computations:
+  - `event_ndims=0` treats the samples as a `[5, 7]` batch of scalar random
+    variables, and computes their variances in batch.  The shape of the result
+    is `[5, 7]`.
+  - `event_ndims=1` treats the samples as a `[5]` batch of vector random
+    variables of shape `[7]`, and computes their covariances in batch.  The
+    shape of the result is `[5, 7, 7]`.
+  - `event_ndims=2` treats the samples as a single random variable of
+    shape `[5, 7]` and computes its covariance.  The shape of the result
+    is `[5, 7, 5, 7]`.
+
   `RunningCovariance` is meant to serve general streaming covariance needs.
   For a specialized version that fits streaming over MCMC samples, see
   `CovarianceReducer` in `tfp.experimental.mcmc`.
   """
 
   def __init__(self, shape, event_ndims=None, dtype=tf.float32):
-    """A `RunningCovariance` object holds metadata for covariance computation.
-
-    The running covariance computation supports batching. The `event_ndims`
-    parameter indicates the number of trailing dimensions to treat as part of
-    the event, and to compute covariance across. The leading dimensions, if
-    any, are treated as batch shape, and no cross terms are computed.
-
-    For example, if the incoming samples have shape `[5, 7]`, the `event_ndims`
-    selects among three different covariance computations:
-    - `event_ndims=0` treats the samples as a `[5, 7]` batch of scalar random
-      variables, and computes their variances in batch.  The shape of the result
-      is `[5, 7]`.
-    - `event_ndims=1` treats the samples as a `[5]` batch of vector random
-      variables of shape `[7]`, and computes their covariances in batch.  The
-      shape of the result is `[5, 7, 7]`.
-    - `event_ndims=2` treats the samples as a single random variable of
-      shape `[5, 7]` and computes its covariance.  The shape of the result
-      is `[5, 7, 5, 7]`.
+    """Instantiates this object.
 
     Args:
       shape: Python `Tuple` or `TensorShape` representing the shape of
@@ -269,3 +273,169 @@ class RunningVariance(RunningCovariance):
         By default, the dtype is `tf.float32`.
     """
     super(RunningVariance, self).__init__(shape, event_ndims=0, dtype=dtype)
+
+
+RunningExpectationsState = collections.namedtuple(
+    'RunningExpectationsState', 'num_samples, expectation')
+
+
+class RunningExpectations(object):
+  """Computes expectations over arbitrary functions evaluated at samples.
+
+  To elaborate, any function that outputs a singular `Tensor` is accepted. If
+  one wishes to compute multiple expectations over the same samples, a
+  (possibly nested) collection of callables can be provided upon instantiation
+  (instead of only one). The resulting expectation calculations will mimic the
+  exact structure of the given callabes.
+
+  In computation, samples can be provided individually or in chunks. A
+  "chunk" of size M implies incorporating M samples into a single expectation
+  computation at once, which is more efficient than one by one. If more than one
+  callable is accepted and chunking is enabled, the chunked `axis` will define
+  chunking semantics for all callables.
+
+  `RunningExpectations` objects do not hold state information. That information,
+  which includes intermediate calculations, are held in a
+  `RunningExpectationsState` as returned via `initialize` and `update` method
+  calls.
+
+  `RunningExpectations` is meant to serve general streaming expectations.
+  For a specialized version that fits streaming over MCMC samples, see
+  `ExpectationsReducer` in `tfp.experimental.mcmc`.
+  """
+
+  def __init__(self, shape, callables, dtype=tf.float32):
+    """Instantiates this object.
+
+    Args:
+      shape: Python `Tuple` or `TensorShape` representing the shape of
+        incoming samples.
+      callables: A (possibly nested) collection of callables to evaluate
+        samples at before expectation calculation.
+      dtype: Dtype of incoming samples and the resulting statistics.
+        By default, the dtype is `tf.float32`. Any integer dtypes will also
+        be treated as `tf.float32` (to not lose significant precision).
+    """
+    self.shape = shape
+    self.callables = callables
+    if dtype.is_integer:
+      dtype = tf.float32
+    self.dtype = dtype
+
+  def initialize(self):
+    """Initializes an empty `RunningExpectationsState`.
+
+    Returns:
+      state: `RunningExpectationsState` representing a stream of no inputs.
+    """
+    return RunningExpectationsState(
+        num_samples=tf.zeros((), dtype=self.dtype),
+        expectation=tf.nest.map_structure(
+            lambda _: tf.zeros(self.shape, self.dtype),
+            self.callables)
+    )
+
+  def update(self, state, new_sample, axis=None):
+    """Update the `RunningExpectationsState` with a new sample.
+
+    The update formula is from Philippe Pebay (2008) [1] and is identical to
+    that used to calculate the intermediate mean in
+    `tfp.experimental.stats.RunningCovariance` and
+    `tfp.experimental.stats.RunningVariance`.
+
+    Args:
+      state: `RunningExpectationsState` that represents the current state of
+        running statistics.
+      new_sample: Incoming sample with shape and dtype compatible with those
+        used to form the `RunningExpectationsState`.
+      axis: If chunking is desired, this is an integer that specifies the axis
+        with chunked samples. For individual samples, set this to `None`. By
+        default, samples are not chunked (`axis` is None).
+
+    Returns:
+      state: `RunningExpectationsState` with updated calculations.
+
+    #### References
+    [1]: Philippe Pebay. Formulas for Robust, One-Pass Parallel Computation of
+         Covariances and Arbitrary-Order Statistical Moments. _Technical Report
+         SAND2008-6212_, 2008.
+         https://prod-ng.sandia.gov/techlib-noauth/access-control.cgi/2008/086212.pdf
+    """
+    new_sample = tf.nest.map_structure(
+        lambda new_sample: tf.cast(new_sample, dtype=self.dtype),
+        new_sample)
+    if axis is None:
+      chunk_n = tf.cast(1, dtype=self.dtype)
+    elif tf.nest.is_nested(new_sample):
+      chunk_n = tf.cast(ps.shape(new_sample[0])[axis], dtype=self.dtype)
+    else:
+      chunk_n = tf.cast(ps.shape(new_sample)[axis], dtype=self.dtype)
+    new_n = state.num_samples + chunk_n
+
+    def _update_for_one_fn(old_mean, new_sample, axis, fn, rank):
+      """Update the expectation state for one callable function."""
+      if axis is None:
+        chunk_mean = fn(new_sample)
+      else:
+        def _transpose_if_needed(sample, sample_rank):
+          # make the chunking `axis` as the first for `tf.map_fn`
+          if sample_rank < 2:
+            return sample
+          perm = [axis] + list(
+              range(0, axis)) + list(range(axis + 1, sample_rank))
+          return tf.transpose(sample, perm)
+        chunked_new_chain_state = tf.nest.map_structure(
+            _transpose_if_needed,
+            new_sample, rank)
+        chunk_mean = tf.math.reduce_mean(
+            tf.map_fn(
+                fn, chunked_new_chain_state, fn_output_signature=self.dtype),
+            axis=0)
+      delta_mean = chunk_mean - old_mean
+      new_mean_component = chunk_n * delta_mean / new_n
+      new_mean = tf.cast(
+          old_mean, dtype=new_mean_component.dtype) + new_mean_component
+      return tf.cast(new_mean, dtype=self.dtype)
+
+    axis, new_sample, rank = self._prepare_args(
+        target=self.callables,
+        axis=axis,
+        sample=new_sample,
+    )
+    new_expectation = nest.map_structure_up_to(
+        self.callables,
+        _update_for_one_fn,
+        state.expectation, new_sample, axis, self.callables, rank
+    )
+    return RunningExpectationsState(new_n, new_expectation)
+
+  def finalize(self, state):
+    """Finalizes expectation computation for the `state`.
+
+    If the `finalized` method is invoked on a running state of no inputs,
+    `RunningExpectations` will return a corresponding structure of `tf.zeros`.
+
+    Args:
+      state: `RunningExpectationsState` that represents the current state of
+        running statistics.
+
+    Returns:
+      expectation: An estimate of the expectation.
+    """
+    return state.expectation
+
+  def _prepare_args(self, target, axis, sample):
+    """Broadcasts arguments to match the structure of `target`."""
+    axis = nest_util.broadcast_structure(target, axis)
+    # using `nest_util.broadcast_structure` for the `sample`
+    # isn't robust as they may already be in some nested structure.
+    sample = tf.nest.map_structure(
+        lambda _: sample,
+        target
+    )
+    sample_rank = tf.nest.map_structure(
+        ps.rank,
+        sample
+    )
+    rank = nest_util.broadcast_structure(target, sample_rank)
+    return axis, sample, rank


### PR DESCRIPTION
Bulking the suite of reducers with one that computes arbitrary expectations over a series of callable functions (that accept the incoming sample and kernel results).