### PR TITLE
Adding `TracingReducer` and a recreated `sample_chain` to tfp.experimental

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -435,7 +435,6 @@ py_library(
 py_test(
     name = "sample_fold_test",
     size = "small",
-    timeout = "long",
     srcs = ["sample_fold_test.py"],
     shard_count = 5,
     deps = [

--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -46,6 +46,7 @@ py_library(
         ":sample_fold",
         ":sample_sequential_monte_carlo",
         ":sequential_monte_carlo_kernel",
+        ":tracing_reducer",
         ":weighted_resampling",
         ":with_reductions",
         # tensorflow dep,
@@ -422,9 +423,11 @@ py_library(
     deps = [
         ":sample",
         ":sample_discarding_kernel",
+        ":tracing_reducer",
         ":with_reductions",
         # numpy dep,
         # tensorflow dep,
+        "//tensorflow_probability/python/mcmc/internal:util",
     ],
 )
 
@@ -432,6 +435,7 @@ py_library(
 py_test(
     name = "sample_fold_test",
     size = "small",
+    timeout = "long",
     srcs = ["sample_fold_test.py"],
     shard_count = 5,
     deps = [
@@ -459,6 +463,30 @@ py_test(
     name = "sample_discarding_kernel_test",
     size = "small",
     srcs = ["sample_discarding_kernel_test.py"],
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
+    name = "tracing_reducer",
+    srcs = ["tracing_reducer.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        # tensorflow dep,
+        ":reducer",
+        "//tensorflow_probability/python/mcmc/internal:util",
+    ],
+)
+
+# py2and3
+py_test(
+    name = "tracing_reducer_test",
+    size = "small",
+    srcs = ["tracing_reducer_test.py"],
     deps = [
         # numpy dep,
         # tensorflow dep,

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -32,6 +32,7 @@ from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentatio
 from tensorflow_probability.python.experimental.mcmc.reducer import Reducer
 from tensorflow_probability.python.experimental.mcmc.sample import step_kernel
 from tensorflow_probability.python.experimental.mcmc.sample_discarding_kernel import SampleDiscardingKernel
+from tensorflow_probability.python.experimental.mcmc.sample_fold import sample_chain
 from tensorflow_probability.python.experimental.mcmc.sample_fold import sample_fold
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import default_make_hmc_kernel_fn
 from tensorflow_probability.python.experimental.mcmc.sample_sequential_monte_carlo import gen_make_hmc_kernel_fn
@@ -43,6 +44,7 @@ from tensorflow_probability.python.experimental.mcmc.sequential_monte_carlo_kern
 from tensorflow_probability.python.experimental.mcmc.sequential_monte_carlo_kernel import SequentialMonteCarlo
 from tensorflow_probability.python.experimental.mcmc.sequential_monte_carlo_kernel import SequentialMonteCarloResults
 from tensorflow_probability.python.experimental.mcmc.sequential_monte_carlo_kernel import WeightedParticles
+from tensorflow_probability.python.experimental.mcmc.tracing_reducer import TracingReducer
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_deterministic_minimum_error
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_independent
 from tensorflow_probability.python.experimental.mcmc.weighted_resampling import resample_stratified
@@ -76,10 +78,12 @@ __all__ = [
     'resample_stratified',
     'resample_systematic',
     'SampleDiscardingKernel',
+    'sample_chain',
     'sample_fold',
     'sample_sequential_monte_carlo',
     'simple_heuristic_tuning',
     'step_kernel',
+    'TracingReducer',
     'VarianceReducer',
     'WithReductions',
     'WithReductionsKernelResults',

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -22,7 +22,7 @@ import warnings
 
 # Dependency imports
 import tensorflow.compat.v2 as tf
-from tensorflow_probability.python.experimental.mcmc import sample as exp_sample
+from tensorflow_probability.python.experimental.mcmc import sample as exp_sample_lib
 from tensorflow_probability.python.experimental.mcmc import sample_discarding_kernel
 from tensorflow_probability.python.experimental.mcmc import with_reductions
 from tensorflow_probability.python.experimental.mcmc import tracing_reducer
@@ -117,7 +117,7 @@ def sample_fold(
             num_steps_between_results=num_steps_between_results),
         reducer=reducer,
     )
-    end_state, final_kernel_results = exp_sample.step_kernel(
+    end_state, final_kernel_results = exp_sample_lib.step_kernel(
         num_steps=num_steps,
         current_state=current_state,
         previous_kernel_results=previous_kernel_results,
@@ -247,7 +247,7 @@ def sample_chain(
                     'value) or an explicit callback that traces the values '
                     'you are interested in.')
 
-    # `WithReductions` assumes all its reducers want to reducer over the
+    # `WithReductions` assumes all its reducers want to reduce over the
     # immediate inner results of its kernel results. However,
     # We don't care about the kernel results of `SampleDiscardingKernel`; hence,
     # we evaluate the `trace_fn` on a deeper level of inner results.

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -319,16 +319,14 @@ class SampleChainTest(test_util.TestCase):
     self.assertAllClose(
         [2], tensorshape_util.as_list(samples.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_1.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_1.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_2.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_2.shape))
 
     samples, kernel_results = self.evaluate([samples, kernel_results])
     self.assertAllClose([1, 2], samples)
-    self.assertAllClose([1, 2], kernel_results.inner_results.counter_1)
-    self.assertAllClose([2, 4], kernel_results.inner_results.counter_2)
+    self.assertAllClose([1, 2], kernel_results.counter_1)
+    self.assertAllClose([2, 4], kernel_results.counter_2)
 
   def test_basic_operation_legacy(self):
     kernel = TestTransitionKernel(accepts_seed=False)
@@ -340,16 +338,14 @@ class SampleChainTest(test_util.TestCase):
     self.assertAllClose(
         [2], tensorshape_util.as_list(samples.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_1.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_1.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_2.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_2.shape))
 
     samples, kernel_results = self.evaluate([samples, kernel_results])
     self.assertAllClose([1, 2], samples)
-    self.assertAllClose([1, 2], kernel_results.inner_results.counter_1)
-    self.assertAllClose([2, 4], kernel_results.inner_results.counter_2)
+    self.assertAllClose([1, 2], kernel_results.counter_1)
+    self.assertAllClose([2, 4], kernel_results.counter_2)
 
   def test_burn_in(self):
     kernel = TestTransitionKernel()
@@ -360,19 +356,16 @@ class SampleChainTest(test_util.TestCase):
         num_burnin_steps=1,
         seed=test_util.test_seed())
 
+    self.assertAllClose([2], tensorshape_util.as_list(samples.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(samples.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_1.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_1.shape))
-    self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_2.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_2.shape))
 
     samples, kernel_results = self.evaluate([samples, kernel_results])
     self.assertAllClose([2, 3], samples)
-    self.assertAllClose([2, 3], kernel_results.inner_results.counter_1)
-    self.assertAllClose([4, 6], kernel_results.inner_results.counter_2)
+    self.assertAllClose([2, 3], kernel_results.counter_1)
+    self.assertAllClose([4, 6], kernel_results.counter_2)
 
   def test_thinning(self):
     kernel = TestTransitionKernel()
@@ -383,19 +376,16 @@ class SampleChainTest(test_util.TestCase):
         num_steps_between_results=2,
         seed=test_util.test_seed())
 
+    self.assertAllClose([2], tensorshape_util.as_list(samples.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(samples.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_1.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_1.shape))
-    self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            kernel_results.inner_results.counter_2.shape))
+        [2], tensorshape_util.as_list(kernel_results.counter_2.shape))
 
     samples, kernel_results = self.evaluate([samples, kernel_results])
     self.assertAllClose([3, 6], samples)
-    self.assertAllClose([3, 6], kernel_results.inner_results.counter_1)
-    self.assertAllClose([6, 12], kernel_results.inner_results.counter_2)
+    self.assertAllClose([3, 6], kernel_results.counter_1)
+    self.assertAllClose([6, 12], kernel_results.counter_2)
 
   def test_default_trace_named_tuple(self):
     kernel = TestTransitionKernel()
@@ -407,14 +397,14 @@ class SampleChainTest(test_util.TestCase):
 
     self.assertAllClose([2], tensorshape_util.as_list(res.all_states.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(res.trace.inner_results.counter_1.shape))
+        [2], tensorshape_util.as_list(res.trace.counter_1.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(res.trace.inner_results.counter_2.shape))
+        [2], tensorshape_util.as_list(res.trace.counter_2.shape))
 
     res = self.evaluate(res)
     self.assertAllClose([1, 2], res.all_states)
-    self.assertAllClose([1, 2], res.trace.inner_results.counter_1)
-    self.assertAllClose([2, 4], res.trace.inner_results.counter_2)
+    self.assertAllClose([1, 2], res.trace.counter_1)
+    self.assertAllClose([2, 4], res.trace.counter_2)
 
   def test_no_trace_fn(self):
     kernel = TestTransitionKernel()
@@ -440,17 +430,15 @@ class SampleChainTest(test_util.TestCase):
     self.assertAllClose([2], tensorshape_util.as_list(res.all_states.shape))
     self.assertAllClose([2], tensorshape_util.as_list(res.trace[0].shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            res.trace[1].inner_results.counter_1.shape))
+        [2], tensorshape_util.as_list(res.trace[1].counter_1.shape))
     self.assertAllClose(
-        [2], tensorshape_util.as_list(
-            res.trace[1].inner_results.counter_2.shape))
+        [2], tensorshape_util.as_list(res.trace[1].counter_2.shape))
 
     res = self.evaluate(res)
     self.assertAllClose([1, 2], res.all_states)
     self.assertAllClose([1, 2], res.trace[0])
-    self.assertAllClose([1, 2], res.trace[1].inner_results.counter_1)
-    self.assertAllClose([2, 4], res.trace[1].inner_results.counter_2)
+    self.assertAllClose([1, 2], res.trace[1].counter_1)
+    self.assertAllClose([2, 4], res.trace[1].counter_2)
 
   def test_checkpointing(self):
     kernel = TestTransitionKernel()
@@ -465,18 +453,14 @@ class SampleChainTest(test_util.TestCase):
     self.assertAllClose([2], tensorshape_util.as_list(res.all_states.shape))
     self.assertEqual((), res.trace)
     self.assertAllClose(
-        [], tensorshape_util.as_list(
-            res.final_kernel_results.counter_1.shape))
+        [], tensorshape_util.as_list(res.final_kernel_results.counter_1.shape))
     self.assertAllClose(
-        [], tensorshape_util.as_list(
-            res.final_kernel_results.counter_2.shape))
+        [], tensorshape_util.as_list(res.final_kernel_results.counter_2.shape))
 
-    all_states, kernel_results = self.evaluate([
-        res.all_states, res.final_kernel_results
-    ])
-    self.assertAllClose([1, 2], all_states)
-    self.assertAllClose(2, kernel_results.counter_1)
-    self.assertAllClose(4, kernel_results.counter_2)
+    res = self.evaluate(res)
+    self.assertAllClose([1, 2], res.all_states)
+    self.assertAllClose(2, res.final_kernel_results.counter_1)
+    self.assertAllClose(4, res.final_kernel_results.counter_2)
 
   def test_warnings_default(self):
     with warnings.catch_warnings(record=True) as triggered:

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -561,6 +561,10 @@ class SampleChainTest(test_util.TestCase):
     self.assertAllCloseNested(
         first_final_state, second_final_state, rtol=1e-6)
 
+
+@test_util.test_graph_mode_only
+class SampleChainGraphTest(test_util.TestCase):
+
   def test_chain_works_correlated_multivariate(self):
     dtype = np.float32
     true_mean = dtype([0, 0])
@@ -591,8 +595,7 @@ class SampleChainTest(test_util.TestCase):
         trace_fn=None,
         seed=test_util.test_seed())
 
-    if not tf.executing_eagerly():
-      self.assertAllEqual(dict(target_calls=1), counter)
+    self.assertAllEqual(dict(target_calls=1), counter)
     states = tf.stack(states, axis=-1)
     self.assertEqual(num_results, tf.compat.dimension_value(states.shape[0]))
     sample_mean = tf.reduce_mean(states, axis=0)

--- a/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold_test.py
@@ -19,13 +19,17 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import warnings
+
 # Dependency imports
 from absl.testing import parameterized
 import numpy as np
 
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
+
 from tensorflow_probability.python.internal import samplers
+from tensorflow_probability.python.internal import tensorshape_util
 from tensorflow_probability.python.internal import test_util
 
 
@@ -295,6 +299,310 @@ class SampleFoldTest(test_util.TestCase):
     self.assertEqual(20, last_sample)
     self.assertEqual(20, kernel_results.counter_1)
     self.assertEqual(40, kernel_results.counter_2)
+
+
+@test_util.test_all_tf_execution_regimes
+class SampleChainTest(test_util.TestCase):
+
+  def setUp(self):
+    self._shape_param = 5.
+    self._rate_param = 10.
+    super(SampleChainTest, self).setUp()
+
+  def test_basic_operation(self):
+    kernel = TestTransitionKernel()
+    samples, kernel_results = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        seed=test_util.test_seed())
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(samples.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_1.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_2.shape))
+
+    samples, kernel_results = self.evaluate([samples, kernel_results])
+    self.assertAllClose([1, 2], samples)
+    self.assertAllClose([1, 2], kernel_results.inner_results.counter_1)
+    self.assertAllClose([2, 4], kernel_results.inner_results.counter_2)
+
+  def test_basic_operation_legacy(self):
+    kernel = TestTransitionKernel(accepts_seed=False)
+    samples, kernel_results = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel)
+
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(samples.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_1.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_2.shape))
+
+    samples, kernel_results = self.evaluate([samples, kernel_results])
+    self.assertAllClose([1, 2], samples)
+    self.assertAllClose([1, 2], kernel_results.inner_results.counter_1)
+    self.assertAllClose([2, 4], kernel_results.inner_results.counter_2)
+
+  def test_burn_in(self):
+    kernel = TestTransitionKernel()
+    samples, kernel_results = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        num_burnin_steps=1,
+        seed=test_util.test_seed())
+
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(samples.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_1.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_2.shape))
+
+    samples, kernel_results = self.evaluate([samples, kernel_results])
+    self.assertAllClose([2, 3], samples)
+    self.assertAllClose([2, 3], kernel_results.inner_results.counter_1)
+    self.assertAllClose([4, 6], kernel_results.inner_results.counter_2)
+
+  def test_thinning(self):
+    kernel = TestTransitionKernel()
+    samples, kernel_results = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        num_steps_between_results=2,
+        seed=test_util.test_seed())
+
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(samples.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_1.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            kernel_results.inner_results.counter_2.shape))
+
+    samples, kernel_results = self.evaluate([samples, kernel_results])
+    self.assertAllClose([3, 6], samples)
+    self.assertAllClose([3, 6], kernel_results.inner_results.counter_1)
+    self.assertAllClose([6, 12], kernel_results.inner_results.counter_2)
+
+  def test_default_trace_named_tuple(self):
+    kernel = TestTransitionKernel()
+    res = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        seed=test_util.test_seed())
+
+    self.assertAllClose([2], tensorshape_util.as_list(res.all_states.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(res.trace.inner_results.counter_1.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(res.trace.inner_results.counter_2.shape))
+
+    res = self.evaluate(res)
+    self.assertAllClose([1, 2], res.all_states)
+    self.assertAllClose([1, 2], res.trace.inner_results.counter_1)
+    self.assertAllClose([2, 4], res.trace.inner_results.counter_2)
+
+  def test_no_trace_fn(self):
+    kernel = TestTransitionKernel()
+    samples = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        trace_fn=None,
+        seed=test_util.test_seed())
+    self.assertAllClose([2], tensorshape_util.as_list(samples.shape))
+    samples = self.evaluate(samples)
+    self.assertAllClose([1, 2], samples)
+
+  def test_custom_trace(self):
+    kernel = TestTransitionKernel()
+    res = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        trace_fn=lambda *args: args,
+        seed=test_util.test_seed())
+
+    self.assertAllClose([2], tensorshape_util.as_list(res.all_states.shape))
+    self.assertAllClose([2], tensorshape_util.as_list(res.trace[0].shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            res.trace[1].inner_results.counter_1.shape))
+    self.assertAllClose(
+        [2], tensorshape_util.as_list(
+            res.trace[1].inner_results.counter_2.shape))
+
+    res = self.evaluate(res)
+    self.assertAllClose([1, 2], res.all_states)
+    self.assertAllClose([1, 2], res.trace[0])
+    self.assertAllClose([1, 2], res.trace[1].inner_results.counter_1)
+    self.assertAllClose([2, 4], res.trace[1].inner_results.counter_2)
+
+  def test_checkpointing(self):
+    kernel = TestTransitionKernel()
+    res = tfp.experimental.mcmc.sample_chain(
+        num_results=2,
+        current_state=0.,
+        kernel=kernel,
+        trace_fn=None,
+        return_final_kernel_results=True,
+        seed=test_util.test_seed())
+
+    self.assertAllClose([2], tensorshape_util.as_list(res.all_states.shape))
+    self.assertEqual((), res.trace)
+    self.assertAllClose(
+        [], tensorshape_util.as_list(
+            res.final_kernel_results.counter_1.shape))
+    self.assertAllClose(
+        [], tensorshape_util.as_list(
+            res.final_kernel_results.counter_2.shape))
+
+    all_states, kernel_results = self.evaluate([
+        res.all_states, res.final_kernel_results
+    ])
+    self.assertAllClose([1, 2], all_states)
+    self.assertAllClose(2, kernel_results.counter_1)
+    self.assertAllClose(4, kernel_results.counter_2)
+
+  def test_warnings_default(self):
+    with warnings.catch_warnings(record=True) as triggered:
+      kernel = TestTransitionKernel()
+      tfp.experimental.mcmc.sample_chain(
+          num_results=2,
+          current_state=0.,
+          kernel=kernel,
+          seed=test_util.test_seed())
+    self.assertTrue(
+        any('Tracing all kernel results by default is deprecated' in str(
+            warning.message) for warning in triggered))
+
+  def test_no_warnings_explicit(self):
+    with warnings.catch_warnings(record=True) as triggered:
+      kernel = TestTransitionKernel()
+      tfp.experimental.mcmc.sample_chain(
+          num_results=2,
+          current_state=0.,
+          kernel=kernel,
+          trace_fn=lambda current_state, kernel_results: kernel_results,
+          seed=test_util.test_seed())
+    self.assertFalse(
+        any('Tracing all kernel results by default is deprecated' in str(
+            warning.message) for warning in triggered))
+
+  def test_is_calibrated(self):
+    with warnings.catch_warnings(record=True) as triggered:
+      kernel = TestTransitionKernel(is_calibrated=False)
+      tfp.experimental.mcmc.sample_chain(
+          num_results=2,
+          current_state=0.,
+          kernel=kernel,
+          trace_fn=lambda current_state, kernel_results: kernel_results,
+          seed=test_util.test_seed())
+    self.assertTrue(
+        any('supplied `TransitionKernel` is not calibrated.' in str(
+            warning.message) for warning in triggered))
+
+  def test_reproduce_bug159550941(self):
+    # Reproduction for b/159550941.
+    input_signature = [tf.TensorSpec([], tf.int32)]
+
+    @tf.function(input_signature=input_signature)
+    def sample(chains):
+      initial_state = tf.zeros([chains, 1])
+      def log_prob(x):
+        return tf.reduce_sum(tfp.distributions.Normal(0, 1).log_prob(x), -1)
+      kernel = tfp.mcmc.HamiltonianMonteCarlo(
+          target_log_prob_fn=log_prob,
+          num_leapfrog_steps=3,
+          step_size=1e-3)
+      return tfp.experimental.mcmc.sample_chain(
+          num_results=5,
+          num_burnin_steps=4,
+          current_state=initial_state,
+          kernel=kernel,
+          trace_fn=None)
+
+    # Checking that shape inference doesn't fail.
+    sample(2)
+
+  def test_seed_reproducibility(self):
+    first_fake_kernel = RandomTransitionKernel()
+    second_fake_kernel = RandomTransitionKernel()
+    seed = samplers.sanitize_seed(test_util.test_seed())
+    first_final_state = tfp.experimental.mcmc.sample_chain(
+        num_results=5,
+        current_state=0.,
+        kernel=first_fake_kernel,
+        seed=seed,
+    )
+    second_final_state = tfp.experimental.mcmc.sample_chain(
+        num_results=5,
+        current_state=1.,  # difference should be irrelevant
+        kernel=second_fake_kernel,
+        seed=seed,
+    )
+    first_final_state, second_final_state = self.evaluate([
+        first_final_state, second_final_state
+    ])
+    self.assertAllCloseNested(
+        first_final_state, second_final_state, rtol=1e-6)
+
+  def test_chain_works_correlated_multivariate(self):
+    dtype = np.float32
+    true_mean = dtype([0, 0])
+    true_cov = dtype([[1, 0.5],
+                      [0.5, 1]])
+    true_cov_chol = np.linalg.cholesky(true_cov)
+    num_results = 3000
+    counter = collections.Counter()
+
+    @tf.function
+    def target_log_prob(x, y):
+      counter['target_calls'] += 1
+      # Corresponds to unnormalized MVN.
+      # z = matmul(inv(chol(true_cov)), [x, y] - true_mean)
+      z = tf.stack([x, y], axis=-1) - true_mean
+      z = tf.linalg.triangular_solve(true_cov_chol, z[..., tf.newaxis])[..., 0]
+      return -0.5 * tf.reduce_sum(z**2., axis=-1)
+
+    states = tfp.experimental.mcmc.sample_chain(
+        num_results=num_results,
+        current_state=[dtype(-2), dtype(2)],
+        kernel=tfp.mcmc.HamiltonianMonteCarlo(
+            target_log_prob_fn=target_log_prob,
+            step_size=[0.5, 0.5],
+            num_leapfrog_steps=2),
+        num_burnin_steps=20,
+        num_steps_between_results=1,
+        trace_fn=None,
+        seed=test_util.test_seed())
+
+    if not tf.executing_eagerly():
+      self.assertAllEqual(dict(target_calls=1), counter)
+    states = tf.stack(states, axis=-1)
+    self.assertEqual(num_results, tf.compat.dimension_value(states.shape[0]))
+    sample_mean = tf.reduce_mean(states, axis=0)
+    x = states - sample_mean
+    sample_cov = tf.matmul(x, x, transpose_a=True) / dtype(num_results)
+    sample_mean_, sample_cov_ = self.evaluate([sample_mean, sample_cov])
+    self.assertAllClose(true_mean, sample_mean_,
+                        atol=0.1, rtol=0.)
+    self.assertAllClose(true_cov, sample_cov_,
+                        atol=0., rtol=0.175)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
@@ -64,7 +64,6 @@ class TracingReducer(reducer_base.Reducer):
   `one_step` method calls.
   """
 
-  # TODO(Ru): bring the lambda fn out
   def __init__(
       self,
       trace_fn=_trace_state_and_kernel_results,

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
@@ -60,6 +60,7 @@ class TracingReducer(reducer_base.Reducer):
   `one_step` method calls.
   """
 
+  # TODO(Ru): bring the lambda fn out
   def __init__(
       self,
       trace_fn=lambda current_state, kernel_results:

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
@@ -1,0 +1,201 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""TracingReducer for pre-packaged accumulation of samples."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.experimental.mcmc import reducer as reducer_base
+from tensorflow_probability.python.mcmc.internal import util as mcmc_util
+
+
+__all__ = [
+    'TracingReducer',
+]
+
+
+class TracingState(
+    mcmc_util.PrettyNamedTupleMixin,
+    collections.namedtuple(
+        'TracingState', ['num_samples', 'trace_state'])):
+  __slots__ = ()
+
+
+class TracingReducer(reducer_base.Reducer):
+  """`Reducer` that accumulates trace results at each sample.
+
+  Trace results are defined by an appropriate `trace_fn`, which accepts the
+  current chain state and kernel results, and returns the desired result.
+  At each sample, the traced values are added to a `TensorArray` which
+  accumulates all results. By default, all kernel results are traced but in the
+  future the default will be changed to no results being traced, so plan
+  accordingly.
+
+  If wrapped in a `tfp.experimental.mcmc.WithReductions` Transition Kernel,
+  TracingReducer will not accumulate the kernel results of `WithReductions`.
+  Rather, the top level kernel results will be that of `WithReductions`' inner
+  kernel.
+
+  As with all reducers, TracingReducer does not hold state information;
+  rather, it stores supplied metadata. Intermediate calculations are held in
+  a `TracingState` named tuple, which is returned via `initialize` and
+  `one_step` method calls.
+  """
+
+  def __init__(
+      self,
+      trace_fn=lambda current_state, kernel_results:
+      (current_state, kernel_results),
+      size=None,
+      name=None):
+    """Instantiates this object.
+
+    TracingReducer can accumulate samples in a dynamic or static shape
+    `TensorArray`. Specifying the `size` at instantiation will cause all
+    subsequent state objects to hold a `TensorArray` of the same static size.
+    If `size` is `None`, all `TensorArray`s will have dynamic size.
+
+    Args:
+      trace_fn: A callable that takes in the current chain state and the
+        previous kernel results and return a `Tensor` or a nested collection
+        of `Tensor`s that is accumulated across samples.
+      size: Integer or scalar `Tensor` denoting the size of the accumulated
+        `TensorArray`.
+      name: Python `str` name prefixed to Ops created by this function.
+        Default value: `None` (i.e., 'tracing_reducer').
+    """
+    self._parameters = dict(
+        trace_fn=trace_fn,
+        size=size,
+        name=name or 'tracing_reducer',
+    )
+
+  def initialize(self, initial_chain_state, initial_kernel_results=None):
+    """Initializes a `TracingState` using previously defined metadata.
+
+    Both the `initial_chain_state` and `initial_kernel_results` do not count
+    as a sample, and hence, will not be traced. This is a deliberate decision
+    that ensures consistency across sampling procedures.
+
+    Args:
+      initial_chain_state: A (possibly nested) structure of `Tensor`s or Python
+        `list`s of `Tensor`s representing the current state(s) of the Markov
+        chain(s). It is used to infer the structure of future trace results.
+      initial_kernel_results: A (possibly nested) structure of `Tensor`s
+        representing internal calculations made in a related `TransitionKernel`.
+        It is used to infer the structure of future trace results.
+
+    Returns:
+      state: `TracingState` with an empty `TensorArray` in its `trace_state`
+        field.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'tracing_reducer', 'initialize')):
+      initial_chain_state = tf.nest.map_structure(
+          tf.convert_to_tensor,
+          initial_chain_state)
+      trace_result = self.trace_fn(initial_chain_state, initial_kernel_results)
+      if self.size is None:
+        size = 0
+        dynamic_size = True
+      else:
+        size = self.size
+        dynamic_size = False
+
+      def _map_body(trace_state):
+        if not tf.is_tensor(trace_state):
+          trace_state = tf.convert_to_tensor(trace_state)
+        return tf.TensorArray(
+            dtype=trace_state.dtype,
+            size=size,
+            dynamic_size=dynamic_size,
+            element_shape=trace_state.shape,
+            clear_after_read=False)
+
+      trace_state = tf.nest.map_structure(
+          _map_body,
+          trace_result)
+      return TracingState(0, trace_state)
+
+  def one_step(
+      self, new_chain_state, current_reducer_state, previous_kernel_results):
+    """Update the `current_reducer_state` with a new trace result.
+
+    The trace result will be computed by evaluating the `trace_fn` provided
+    at instantiation with the `new_chain_state` and `previous_kernel_results`.
+
+    Args:
+      new_chain_state: A (possibly nested) structure of incoming chain state(s)
+        with shape and dtype compatible with those used to initialize the
+        `TracingState`.
+      current_reducer_state: `TracingState`s representing all previously traced
+        results.
+      previous_kernel_results: A (possibly nested) structure of `Tensor`s
+        representing internal calculations made in a related
+        `TransitionKernel`.
+
+    Returns:
+      new_reducer_state: `TracingState` with updated trace. Its 'trace_state'
+        field holds a `TensorArray` that includes the newly computed trace
+        result.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'tracing_reducer', 'one_step')):
+      num_samples, trace_state = current_reducer_state
+      new_trace_results = self.trace_fn(
+          new_chain_state, previous_kernel_results)
+      new_trace_state = tf.nest.map_structure(
+          lambda state, new_trace: state.write(num_samples, new_trace),
+          trace_state, new_trace_results)
+      return TracingState(
+          num_samples + 1,
+          new_trace_state)
+
+  def finalize(self, final_reducer_state):
+    """Finalizes tracing by stacking the accumulated `TensorArray`.
+
+    Args:
+      final_reducer_state: `TracingState` that holds all desired traced results.
+
+    Returns:
+      trace: `Tensor` that represents stacked tracing results.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'tracing_reducer', 'finalize')):
+      return tf.nest.map_structure(
+          lambda state: state.stack(),
+          final_reducer_state.trace_state)
+
+  @property
+  def name(self):
+    return self._parameters['name']
+
+  @property
+  def trace_fn(self):
+    return self._parameters['trace_fn']
+
+  @property
+  def size(self):
+    return self._parameters['size']
+
+  @property
+  def parameters(self):
+    return self._parameters

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
@@ -54,7 +54,7 @@ class TracingReducer(reducer_base.Reducer):
   Rather, the top level kernel results will be that of `WithReductions`' inner
   kernel.
 
-  As with all reducers, TracingReducer does not hold state information;
+  As with all reducers, `TracingReducer` does not hold state information;
   rather, it stores supplied metadata. Intermediate calculations are held in
   a `TracingState` named tuple, which is returned via `initialize` and
   `one_step` method calls.
@@ -153,7 +153,7 @@ class TracingReducer(reducer_base.Reducer):
         `TransitionKernel`.
 
     Returns:
-      new_reducer_state: `TracingState` with updated trace. Its 'trace_state'
+      new_reducer_state: `TracingState` with updated trace. Its `trace_state`
         field holds a `TensorArray` that includes the newly computed trace
         result.
     """

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer.py
@@ -39,6 +39,10 @@ class TracingState(
   __slots__ = ()
 
 
+def _trace_state_and_kernel_results(current_state, kernel_results):
+  return current_state, kernel_results
+
+
 class TracingReducer(reducer_base.Reducer):
   """`Reducer` that accumulates trace results at each sample.
 
@@ -63,8 +67,7 @@ class TracingReducer(reducer_base.Reducer):
   # TODO(Ru): bring the lambda fn out
   def __init__(
       self,
-      trace_fn=lambda current_state, kernel_results:
-      (current_state, kernel_results),
+      trace_fn=_trace_state_and_kernel_results,
       size=None,
       name=None):
     """Instantiates this object.

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer_test.py
@@ -1,0 +1,174 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for TracingReducer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.internal import tensorshape_util
+from tensorflow_probability.python.internal import test_util
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic Transition Kernel"""
+
+  def __init__(self, shape=(), target_log_prob_fn=None, is_calibrated=True):
+    self._is_calibrated = is_calibrated
+    self._shape = shape
+    # for composition purposes
+    self.parameters = dict(
+        target_log_prob_fn=target_log_prob_fn)
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    return (current_state + tf.ones(self._shape),
+            TestTransitionKernelResults(
+                counter_1=previous_kernel_results.counter_1 + 1,
+                counter_2=previous_kernel_results.counter_2 + 2))
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()),
+        counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+@test_util.test_all_tf_execution_regimes
+class TracingReducerTest(test_util.TestCase):
+
+  def test_simple_operation(self):
+    tracer = tfp.experimental.mcmc.TracingReducer()
+    state = tracer.initialize(tf.zeros(()), tf.zeros(()))
+    for sample in range(1, 6):
+      # kernel results is simply the last sample
+      state = tracer.one_step(sample, state, sample)
+    all_states, final_trace = self.evaluate(tracer.finalize(state))
+    self.assertAllEqual([1, 2, 3, 4, 5], all_states)
+    self.assertAllEqual([1, 2, 3, 4, 5], final_trace)
+
+  def test_custom_tracing(self):
+    tracer = tfp.experimental.mcmc.TracingReducer(
+        trace_fn=lambda sample, pkr: (sample + pkr,))
+    state = tracer.initialize(tf.zeros(()), tf.zeros(()))
+    for sample in range(1, 6):
+      state = tracer.one_step(sample, state, sample * 2)
+    final_trace = self.evaluate(tracer.finalize(state))
+    self.assertAllEqual(([3, 6, 9, 12, 15],), final_trace)
+
+  def test_latent_chain_state(self):
+    tracer = tfp.experimental.mcmc.TracingReducer(
+        trace_fn=lambda current_state, _: current_state
+    )
+    chain_state = ({'one': np.ones((2, 3)), 'zero': np.zeros((2, 3))},
+                   {'two': np.ones((2, 3)) * 2})
+    state = tracer.initialize(chain_state)
+    for _ in range(3):
+      state = tracer.one_step(chain_state, state, None)
+    final_trace = self.evaluate(tracer.finalize(state))
+    self.assertEqual(2, len(final_trace[0]))
+    self.assertAllEqualNested(chain_state, tf.nest.map_structure(
+        lambda trace_state: trace_state[0], final_trace))
+
+  def test_differently_structured_trace_results(self):
+    tracer = tfp.experimental.mcmc.TracingReducer(
+        trace_fn=lambda sample, pkr: (sample,
+                                      (sample, pkr),
+                                      ({"one": sample, "two": pkr})))
+    state = tracer.initialize(tf.zeros(()), tf.zeros(()))
+    for sample in range(1, 3):
+      state = tracer.one_step(sample, state, sample * 2)
+    final_trace = self.evaluate(tracer.finalize(state))
+    self.assertEqual(3, len(final_trace))
+    self.assertAllEqual([1, 2], final_trace[0])
+    self.assertAllEqual(([1, 2], [2, 4]), final_trace[1])
+    self.assertAllEqualNested(final_trace[2], ({"one": [1, 2],
+                                                "two": [2, 4]}))
+
+  def test_tf_while(self):
+    tracer = tfp.experimental.mcmc.TracingReducer(
+        trace_fn=lambda sample, pkr: (sample,
+                                      (sample, pkr),
+                                      ({"one": sample, "two": pkr})))
+    state = tracer.initialize(tf.zeros(()), tf.zeros(()))
+    def _body(sample, pkr, state):
+      new_state = tracer.one_step(sample, state, pkr)
+      return (sample + 1, pkr + 2, new_state)
+    _, _, state = tf.while_loop(
+        cond=lambda i, _, __: i < 3,
+        body=_body,
+        loop_vars=(1., 2., state)
+    )
+    final_trace = self.evaluate(tracer.finalize(state))
+    self.assertEqual(3, len(final_trace))
+    self.assertAllEqual([1, 2], final_trace[0])
+    self.assertAllEqual(([1, 2], [2, 4]), final_trace[1])
+    self.assertAllEqualNested(final_trace[2], ({"one": [1, 2],
+                                                "two": [2, 4]}))
+
+  def test_in_sample_fold(self):
+    tracer = tfp.experimental.mcmc.TracingReducer()
+    fake_kernel = TestTransitionKernel()
+    trace, final_state, kernel_results = tfp.experimental.mcmc.sample_fold(
+        num_steps=3,
+        current_state=0.,
+        kernel=fake_kernel,
+        reducer=tracer,
+    )
+    trace, final_state, kernel_results = self.evaluate([
+        trace,
+        final_state,
+        kernel_results
+    ])
+    self.assertAllEqual([1, 2, 3], trace[0])
+    self.assertAllEqual([1, 2, 3], trace[1].inner_results.counter_1)
+    self.assertAllEqual([2, 4, 6], trace[1].inner_results.counter_2)
+    self.assertEqual(3, final_state)
+    self.assertEqual(3, kernel_results.counter_1)
+    self.assertEqual(6, kernel_results.counter_2)
+
+  def test_known_size(self):
+    tracer = tfp.experimental.mcmc.TracingReducer(size=3)
+    self.assertEqual(tracer.size, 3)
+    state = tracer.initialize(tf.zeros(()), tf.zeros(()))
+    for sample in range(3):
+      state = tracer.one_step(sample, state, sample)
+    all_states, final_trace = tracer.finalize(state)
+    self.assertAllClose(
+        [3], tensorshape_util.as_list(all_states.shape))
+    self.assertAllClose(
+        [3], tensorshape_util.as_list(final_trace.shape))
+    all_states, final_trace = self.evaluate([
+        all_states, final_trace
+    ])
+    self.assertAllEqual([0, 1, 2], all_states)
+    self.assertAllEqual([0, 1, 2], final_trace)
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
`TracingReducer` allows for accumulating arbitrary functions of samples and kernel results in the streaming MCMC framework. We can now also rewrite `sample_chain` in terms of `TracingReducer` and `sample_fold`, which is also included.