### PR TITLE
Adding `RhatReducer` and streaming rhat to tfp.experimental

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -42,6 +42,7 @@ py_library(
         ":particle_filter",
         ":particle_filter_augmentation",
         ":reducer",
+        ":rhat_reducer",
         ":sample",
         ":sample_discarding_kernel",
         ":sample_fold",
@@ -511,6 +512,31 @@ py_test(
     name = "expectations_reducer_test",
     srcs = ["expectations_reducer_test.py"],
     shard_count = 5,
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
+    name = "rhat_reducer",
+    srcs = ["rhat_reducer.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":reducer",
+        # tensorflow dep,
+        "//tensorflow_probability/python/experimental/stats",
+    ],
+)
+
+# py2and3
+py_test(
+    name = "rhat_reducer_test",
+    size = "small",
+    shard_count = 5,
+    srcs = ["rhat_reducer_test.py"],
     deps = [
         # numpy dep,
         # tensorflow dep,

--- a/tensorflow_probability/python/experimental/mcmc/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/__init__.py
@@ -31,6 +31,7 @@ from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentatio
 from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentation import augment_with_state_history
 from tensorflow_probability.python.experimental.mcmc.particle_filter_augmentation import StateWithHistory
 from tensorflow_probability.python.experimental.mcmc.reducer import Reducer
+from tensorflow_probability.python.experimental.mcmc.rhat_reducer import RhatReducer
 from tensorflow_probability.python.experimental.mcmc.sample import step_kernel
 from tensorflow_probability.python.experimental.mcmc.sample_discarding_kernel import SampleDiscardingKernel
 from tensorflow_probability.python.experimental.mcmc.sample_fold import sample_chain
@@ -79,6 +80,7 @@ __all__ = [
     'resample_independent',
     'resample_stratified',
     'resample_systematic',
+    'RhatReducer',
     'SampleDiscardingKernel',
     'sample_chain',
     'sample_fold',

--- a/tensorflow_probability/python/experimental/mcmc/rhat_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/rhat_reducer.py
@@ -1,0 +1,203 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""RhatReducer for calculating streaming potential scale reduction."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.experimental.mcmc import reducer as reducer_base
+from tensorflow_probability.python.experimental.stats import sample_stats
+from tensorflow_probability.python.internal import prefer_static as ps
+from tensorflow_probability.python.mcmc.internal import util as mcmc_util
+
+
+__all__ = [
+    'RhatReducer',
+]
+
+
+RhatReducerState = collections.namedtuple(
+    'RhatReducerState', 'sample_shape, rhat_state')
+
+
+class RhatReducer(reducer_base.Reducer):
+  """`Reducer` that computes a running rhat diagnostic statistic.
+
+  `RhatReducer` assumes that all provided chain states include samples from
+  multiple independent Markov chains, and that all of these chains are to
+  be included in the same calculation. `RhatReducer` also assumes that
+  incoming samples have shape `[Ni, Ci1, Ci2,...,CiD]`. Dimension `0` indexes
+  the `Ni > 1` result steps of the Markov Chain. Dimensions `1` through `D`
+  index the `Ci1 x ... x CiD` independent chains to be tested for convergence
+  to the same target. A possible chunking dimension can also be specified via
+  the `axis` parameter of the `one_step` method. This dimension indexes multiple
+  dependent samples from the same Markov chain, but disregards the first sample
+  dimension.
+
+  To illustrate, with no chunking enabled, a chain state of shape `[5, 2, 3, 4]`
+  can be inferred as shape `[2, 3, 4]` samples drawn from 5 independent Markov
+  chains. If chunking is enabled and `axis=1` then the same chain state can be
+  inferred as 3 samples of shape `[2, 4]` from 5 independent Markov chains. Note
+  how the chunking dimension indexes into only the event dimensions, and not the
+  batch dimension.
+
+  As with all reducers, RhatReducer does not hold state information;
+  rather, it stores supplied metadata. Intermediate calculations are held in
+  a state object, which is returned via `initialize` and `one_step` method
+  calls.
+
+  `RhatReducer` is meant to fit into the larger Streaming MCMC framework.
+  `RunningPotentialScaleReduction` in `tfp.experimental.stats` is
+  better suited for more generic streaming covariance needs. More precise
+  algorithmic details can also be found by referencing
+  `RunningPotentialScaleReduction`.
+  """
+
+  def __init__(self, num_parallel_chains, name=None):
+    """Instantiates this object.
+
+    Args:
+      num_parallel_chains: Integer number of independent Markov chains
+        ran in parallel.
+      name: Python `str` name prefixed to Ops created by this function.
+        Default value: `None` (i.e., 'rhat_reducer').
+
+    Raises:
+      ValueError: if `num_parallel_chains < 2`. This results in undefined
+        intermediate variance calculations.
+    """
+    if num_parallel_chains < 2:
+      raise ValueError('At least 2 parallel chains are required for '
+                       'well-defined between_chain variances')
+    self._parameters = dict(
+        num_parallel_chains=num_parallel_chains,
+        name=name or 'rhat_reducer'
+    )
+
+  def initialize(self, initial_chain_state, initial_kernel_results=None):
+    """Initializes a `RhatReducerState` using previously defined metadata.
+
+    For calculation purposes, the `initial_chain_state` does not count as a
+    sample. This is a deliberate decision that ensures consistency across
+    sampling procedures (i.e. `tfp.mcmc.sample_chain` follows similar
+    semantics).
+
+    Args:
+      initial_chain_state: A (possibly nested) structure of `Tensor`s or Python
+        `list`s of `Tensor`s representing the current state(s) of the Markov
+        chain(s). It is used to infer the shape and dtype of future samples.
+      initial_kernel_results: A (possibly nested) structure of `Tensor`s
+        representing internal calculations made in a related `TransitionKernel`.
+        For streaming rhat, this argument has no influence on the
+        computation; hence, it is `None` by default. However, it's
+        still accepted to fit the `Reducer` base class.
+
+    Returns:
+      state: `RhatReducerState` with `rhat_state` field representing
+        a stream of no inputs.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'rhat_reducer', 'initialize')):
+      initial_chain_state = tf.convert_to_tensor(initial_chain_state)
+      if ps.rank(initial_chain_state) == 1:
+        sample_shape = ()
+      else:
+        sample_shape = ps.shape(initial_chain_state)[1:]
+      running_rhat = sample_stats.RunningPotentialScaleReduction(
+          shape=sample_shape,
+          num_chains=self.num_parallel_chains,
+          dtype=initial_chain_state.dtype
+      )
+      return RhatReducerState(sample_shape, running_rhat.initialize())
+
+  def one_step(
+      self,
+      new_chain_state,
+      current_reducer_state,
+      previous_kernel_results=None,
+      axis=None):
+    """Update the `current_reducer_state` with a new chain state.
+
+    Args:
+      new_chain_state: A (possibly nested) structure of incoming chain state(s)
+        with shape and dtype compatible with those used to initialize the
+        `current_reducer_state`.
+      current_reducer_state: `RhatReducerState` representing the current
+        state of the running rhat statistic.
+      previous_kernel_results: A (possibly nested) structure of `Tensor`s
+        representing internal calculations made in a related
+        `TransitionKernel`. For streaming rhat, this argument has no
+        influence on computation; hence, it is `None` by default. However, it's
+        still accepted to fit the `Reducer` base class.
+      axis: If chunking is desired, this is a (possibly nested) structure of
+        integers that specifies the axis with chunked samples. For individual
+        samples, set this to `None`. By default, samples are not chunked
+        (`axis` is None).
+
+    Returns:
+      new_reducer_state: `RhatReducerState` with updated running
+        statistics.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'rhat_reducer', 'one_step')):
+      new_chain_state = tf.convert_to_tensor(new_chain_state)
+      running_rhat = sample_stats.RunningPotentialScaleReduction(
+          shape=current_reducer_state.sample_shape,
+          num_chains=self.num_parallel_chains,
+          dtype=new_chain_state.dtype
+      )
+      new_rhat_state = running_rhat.update(
+          current_reducer_state.rhat_state,
+          new_chain_state,
+          chunk_axis=axis)
+      return RhatReducerState(
+          current_reducer_state.sample_shape, new_rhat_state)
+
+  def finalize(self, final_reducer_state):
+    """Finalizes covariance calculation from the `final_reducer_state`.
+
+    Args:
+      final_reducer_state: `RhatReducerState` that represents the
+        final state of the running rhat statistic.
+
+    Returns:
+      rhat: an estimate of the rhat.
+    """
+    with tf.name_scope(
+        mcmc_util.make_name(self.name, 'rhat_reducer', 'finalize')):
+      running_rhat = sample_stats.RunningPotentialScaleReduction(
+          shape=final_reducer_state.sample_shape,
+          num_chains=self.num_parallel_chains,
+          dtype=final_reducer_state.rhat_state.chain_var[0].mean.dtype
+      )
+      return running_rhat.finalize(final_reducer_state.rhat_state)
+
+  @property
+  def parameters(self):
+    return self._parameters
+
+  @property
+  def num_parallel_chains(self):
+    return self._parameters['num_parallel_chains']
+
+  @property
+  def name(self):
+    return self._parameters['name']

--- a/tensorflow_probability/python/experimental/mcmc/rhat_reducer_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/rhat_reducer_test.py
@@ -1,0 +1,206 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for RhatReducer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Dependency imports
+
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.internal import test_util
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic Transition Kernel."""
+
+  def __init__(self, shape=(), target_log_prob_fn=None, is_calibrated=True):
+    self._is_calibrated = is_calibrated
+    self._shape = shape
+    # for composition purposes
+    self.parameters = dict(
+        target_log_prob_fn=target_log_prob_fn)
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    return (current_state + tf.ones(self._shape),
+            TestTransitionKernelResults(
+                counter_1=previous_kernel_results.counter_1 + 1,
+                counter_2=previous_kernel_results.counter_2 + 2))
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()),
+        counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+@test_util.test_all_tf_execution_regimes
+class RhatReducerTest(test_util.TestCase):
+
+  def test_simple_operation(self):
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=5,
+    )
+    state = rhat_reducer.initialize(tf.zeros(5,))
+    chain_state = np.arange(20, dtype=np.float32).reshape((4, 5))
+    for sample in chain_state:
+      state = rhat_reducer.one_step(sample, state)
+    rhat = rhat_reducer.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=chain_state,
+        independent_chain_ndims=1,
+    )
+    rhat, true_rhat = self.evaluate([rhat, true_rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_non_scalar_sample(self):
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=5,
+    )
+    state = rhat_reducer.initialize(tf.zeros(5,))
+    chain_state = np.arange(60, dtype=np.float32).reshape((4, 5, 3))
+    for sample in chain_state:
+      state = rhat_reducer.one_step(sample, state)
+    rhat = rhat_reducer.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=chain_state,
+        independent_chain_ndims=1,
+    )
+    rhat, true_rhat = self.evaluate([rhat, true_rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_int_samples(self):
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=5,
+    )
+    state = rhat_reducer.initialize(tf.zeros((5,), dtype=tf.int64))
+    chain_state = np.arange(60).reshape((4, 5, 3))
+    for sample in chain_state:
+      state = rhat_reducer.one_step(sample, state)
+    rhat = rhat_reducer.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=chain_state,
+        independent_chain_ndims=1,
+    )
+    self.assertEqual(tf.float64, rhat.dtype)
+    rhat, true_rhat = self.evaluate([rhat, true_rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_chunking(self):
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=5,
+    )
+    state = rhat_reducer.initialize(tf.zeros(()))
+    chain_state = np.arange(60, dtype=np.float32).reshape((4, 5, 3))
+    for sample in chain_state:
+      state = rhat_reducer.one_step(sample, state, axis=0)
+    rhat = rhat_reducer.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=np.swapaxes(chain_state, 1, 2).reshape((12, 5)),
+        independent_chain_ndims=1,
+    )
+    rhat, true_rhat = self.evaluate([rhat, true_rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_in_with_reductions(self):
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=5,
+    )
+    fake_kernel = TestTransitionKernel(shape=(5,))
+    reduced_kernel = tfp.experimental.mcmc.WithReductions(
+        inner_kernel=fake_kernel,
+        reducer=rhat_reducer,
+    )
+    chain_state = tf.zeros(5,)
+    pkr = reduced_kernel.bootstrap_results(chain_state)
+    for _ in range(2):
+      chain_state, pkr = reduced_kernel.one_step(
+          chain_state, pkr)
+    rhat = self.evaluate(
+        rhat_reducer.finalize(pkr.streaming_calculations))
+    self.assertEqual(0.5, rhat)
+
+  def test_iid_normal_passes(self):
+    n_samples = 500
+    # two scalar chains taken from iid Normal(0, 1)
+    rng = test_util.test_np_rng()
+    iid_normal_samples = rng.randn(n_samples, 2)
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=2,
+    )
+    state = rhat_reducer.initialize(iid_normal_samples[0])
+    for sample in iid_normal_samples:
+      state = rhat_reducer.one_step(sample, state)
+    rhat = self.evaluate(rhat_reducer.finalize(state))
+    self.assertAllEqual((), rhat.shape)
+    self.assertAllClose(1., rhat, rtol=0.02)
+
+  def test_offset_normal_fails(self):
+    n_samples = 500
+    # three 4-variate chains taken from Normal(0, 1) that have been
+    # shifted. Since every chain is shifted, they are not the same, and the
+    # test should fail.
+    offset = np.array([1., -1., 2.]).reshape(3, 1)
+    rng = test_util.test_np_rng()
+    offset_samples = rng.randn(n_samples, 3, 4) + offset
+    rhat_reducer = tfp.experimental.mcmc.RhatReducer(
+        num_parallel_chains=3,
+    )
+    state = rhat_reducer.initialize(offset_samples[0])
+    for sample in offset_samples:
+      state = rhat_reducer.one_step(sample, state)
+    rhat = self.evaluate(rhat_reducer.finalize(state))
+    self.assertAllEqual((4,), rhat.shape)
+    self.assertAllEqual(np.ones_like(rhat).astype(bool), rhat > 1.2)
+
+  def test_with_hmc(self):
+    target_dist = tfp.distributions.Normal(loc=0., scale=1.)
+    hmc_kernel = tfp.mcmc.HamiltonianMonteCarlo(
+        target_log_prob_fn=target_dist.log_prob,
+        num_leapfrog_steps=27,
+        step_size=1/3)
+    reduced_stats, _, _ = tfp.experimental.mcmc.sample_fold(
+        num_steps=50,
+        current_state=tf.zeros((2,)),
+        kernel=hmc_kernel,
+        reducer=[
+            tfp.experimental.mcmc.TracingReducer(),
+            tfp.experimental.mcmc.RhatReducer(num_parallel_chains=2)
+        ]
+    )
+    rhat = reduced_stats[1]
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=reduced_stats[0][0],
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/experimental/stats/__init__.py
+++ b/tensorflow_probability/python/experimental/stats/__init__.py
@@ -22,13 +22,17 @@ from tensorflow_probability.python.experimental.stats.sample_stats import Runnin
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovarianceState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningMean
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningMeanState
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningPotentialScaleReduction
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningPotentialScaleReductionState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningVariance
 
 
 __all__ = [
-    'RunningMean',
-    'RunningMeanState',
     'RunningCovariance',
     'RunningCovarianceState',
+    'RunningMean',
+    'RunningMeanState',
+    'RunningPotentialScaleReduction',
+    'RunningPotentialScaleReductionState',
     'RunningVariance',
 ]

--- a/tensorflow_probability/python/experimental/stats/sample_stats_test.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats_test.py
@@ -449,6 +449,147 @@ class RunningCovarianceTest(test_util.TestCase):
 
 
 @test_util.test_all_tf_execution_regimes
+class RunningRhatTest(test_util.TestCase):
+
+  def test_simple_operation(self):
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=(),
+        num_chains=3,
+    )
+    state = running_rhat.initialize()
+    # 5 samples from 3 independent Markov chains
+    x = np.arange(15, dtype=np.float32).reshape((5, 3))
+    for sample in x:
+      state = running_rhat.update(state, sample)
+    rhat = running_rhat.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=x,
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertNear(true_rhat, rhat, err=1e-6)
+
+  def test_random_scalar_computation(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 10) * 100
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=(),
+        num_chains=10,
+    )
+    state = running_rhat.initialize()
+    for sample in x:
+      state = running_rhat.update(state, sample)
+    rhat = running_rhat.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=x,
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertNear(true_rhat, rhat, err=1e-6)
+
+  def test_chain_axis(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 2, 5) * 100
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=(),
+        num_chains=5,
+    )
+    state = running_rhat.initialize()
+    for sample in x:
+      state = running_rhat.update(state, sample, chain_axis=1)
+    rhat = running_rhat.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=np.swapaxes(x, 2, 1),
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_non_scalar_samples(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 2, 2, 3, 5) * 100
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=(2, 3, 5),
+        num_chains=2,
+    )
+    state = running_rhat.initialize()
+    for sample in x:
+      state = running_rhat.update(state, sample)
+    rhat = running_rhat.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=x,
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_chunking(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 10, 2, 5) * 100
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=(5,),
+        num_chains=2,
+    )
+    state = running_rhat.initialize()
+    for sample in x:
+      state = running_rhat.update(
+          state, sample, chain_axis=1, chunk_axis=0)
+    rhat = running_rhat.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=x.reshape(1000, 2, 5),
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_batching(self):
+    n_samples = 100
+    # state_0 is two scalar chains taken from iid Normal(0, 1).
+    state_0 = np.random.randn(n_samples, 2)
+
+    # state_1 is three 4-variate chains taken from Normal(0, 1) that have been
+    # shifted.
+    offset = np.array([1., -1., 2.]).reshape(3, 1)
+    state_1 = np.random.randn(n_samples, 3, 4) + offset
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=[(), (4,)],
+        num_chains=[2, 3]
+    )
+    state = running_rhat.initialize()
+    for sample in zip(state_0, state_1):
+      state = running_rhat.update(state, sample)
+    rhat = self.evaluate(running_rhat.finalize(state))
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=[state_0, state_1], independent_chain_ndims=1)
+    self.assertAllClose(true_rhat, rhat, rtol=1e-6)
+
+  def test_tf_while(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 10) * 100
+    tensor_x = tf.convert_to_tensor(x)
+    running_rhat = tfp.experimental.stats.RunningPotentialScaleReduction(
+        shape=(),
+        num_chains=10,
+    )
+    state = running_rhat.initialize()
+    def _loop_body(i, state):
+      new_state = running_rhat.update(state, tensor_x[i])
+      return i + 1, new_state
+    _, state = tf.while_loop(
+        lambda i, _: i < 100,
+        _loop_body,
+        (0, state)
+    )
+    rhat = running_rhat.finalize(state)
+    true_rhat = tfp.mcmc.potential_scale_reduction(
+        chains_states=x,
+        independent_chain_ndims=1,
+    )
+    true_rhat, rhat = self.evaluate([true_rhat, rhat])
+    self.assertNear(true_rhat, rhat, err=1e-6)
+
+
+@test_util.test_all_tf_execution_regimes
 class RunningMeanTest(test_util.TestCase):
 
   def test_zero_mean(self):

--- a/tensorflow_probability/python/mcmc/diagnostic.py
+++ b/tensorflow_probability/python/mcmc/diagnostic.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
 import tensorflow.compat.v2 as tf
 
 from tensorflow_probability.python import stats
@@ -492,6 +493,18 @@ def potential_scale_reduction(chains_states,
 def _potential_scale_reduction_single_state(state, independent_chain_ndims,
                                             split_chains, validate_args):
   """potential_scale_reduction for one single state `Tensor`."""
+  # casting integers to floats for floating-point division
+  # check to see if the `state` is a numpy object for the numpy test suite
+  if type(state).__module__ == np.__name__:
+    if state.dtype is np.int64:
+      state = state.astype(np.float64)
+    elif np.issubdtype(state.dtype, np.integer):
+      state = state.astype(np.float32)
+  else:
+    if state.dtype is tf.int64:
+      state = tf.cast(state, tf.float64)
+    elif state.dtype.is_integer:
+      state = tf.cast(state, tf.float32)
   with tf.name_scope('potential_scale_reduction_single_state'):
     # We assume exactly one leading dimension indexes e.g. correlated samples
     # from each Markov chain.
@@ -568,13 +581,12 @@ def _potential_scale_reduction_single_state(state, independent_chain_ndims,
         sample_and_chain_axis,
         biased=False)
     w = tf.reduce_mean(
-        _reduce_variance(state, sample_axis, keepdims=True, biased=True),
+        _reduce_variance(state, sample_axis, keepdims=True, biased=False),
         axis=sample_and_chain_axis)
 
     # sigma^2_+ is an estimate of the true variance, which would be unbiased if
     # each chain was drawn from the target.  c.f. "law of total variance."
-    sigma_2_plus = w + b_div_n
-
+    sigma_2_plus = ((n - 1) / n) * w + b_div_n
     return ((m + 1.) / m) * sigma_2_plus / w - (n - 1.) / (m * n)
 
 

--- a/tensorflow_probability/python/mcmc/diagnostic_test.py
+++ b/tensorflow_probability/python/mcmc/diagnostic_test.py
@@ -410,6 +410,36 @@ class _PotentialScaleReductionTest(object):
     raise NotImplementedError(
         "Subclass failed to implement `use_static_shape`.")
 
+  def testWithManualComputation(self):
+    # 5 samples from 3 independent Markov chains
+    chain_state = np.arange(15, dtype=np.float32).reshape((5, 3))
+    rhat = self.evaluate(tfp.mcmc.potential_scale_reduction(
+        chains_states=chain_state,
+        independent_chain_ndims=1,
+    ))
+    # manual computation with numpy operations
+    b_div_n = np.var(np.mean(chain_state, axis=0), ddof=1)
+    w = np.mean(np.var(chain_state, axis=0, ddof=1))
+    sigma_2_plus = 0.8 * w + b_div_n
+    n = 5
+    m = 3
+    manual_rhat = ((m + 1.) / m) * sigma_2_plus / w - (n - 1.) / (m * n)
+    self.assertNear(manual_rhat, rhat, err=1e-6)
+
+  def testIntegerSamples(self):
+    # 5 samples from 3 independent Markov chains
+    int_chain_state = np.arange(15, dtype=np.int64).reshape((5, 3))
+    int_rhat = self.evaluate(tfp.mcmc.potential_scale_reduction(
+        chains_states=int_chain_state,
+        independent_chain_ndims=1,
+    ))
+    float_chain_state = np.arange(15, dtype=np.float64).reshape((5, 3))
+    float_rhat = self.evaluate(tfp.mcmc.potential_scale_reduction(
+        chains_states=float_chain_state,
+        independent_chain_ndims=1,
+    ))
+    self.assertNear(float_rhat, int_rhat, err=1e-6)
+
   def testListOfStatesWhereFirstPassesSecondFails(self):
     """Simple test showing API with two states.  Read first!."""
     n_samples = 1000


### PR DESCRIPTION
This PR accomplishes three things:

1. Add a base implementation of Gelman and Rubin (1992)'s potential scale reduction (or rhat) in streaming fashion to `tfp.experimental.stats` in fashion similar to `tfp.mcmc.potential_scale_reduction`, but without the use of certain flags.
2. Add a RhatReducer to `tfp.experimental.mcmc`
3. Update `tfp.mcmc.potential_scale_reduction` to correctly implement Gelman and Rubin (1992)'s formula. This addresses and fixes https://github.com/tensorflow/probability/issues/1054