### PR TITLE
Adding transform_fn capabilities to `tfp.experimental.mcmc.CovarianceReducer`

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
+++ b/tensorflow_probability/python/experimental/mcmc/covariance_reducer.py
@@ -41,8 +41,22 @@ CovarianceReducerState = collections.namedtuple(
     'CovarianceReducerState', 'init_structure, cov_state')
 
 
+def _get_sample(current_state, kernel_results):
+  del kernel_results
+  return current_state
+
+
 class CovarianceReducer(reducer_base.Reducer):
   """`Reducer` that computes a running covariance.
+
+  `CovarianceReducer` computes a running covariance on samples evaluated on
+  some arbitrary structure of `transform_fn`s. A `trasform_fn` is defined as
+  any function that accepts the chain state and kernel results, and ouptuts
+  a `Tensor` or nested structure of `Tensor`s to compute the covariance over.
+  To be explicit, if we denote a `transform_fn` as f(x, y), then
+  `CovarianceReducer` will compute Cov(f(x, y)). If some structure of
+  `transform_fn`s are given, the final statistic (as returned by the
+  `finalize` method) will mimic that exact structure.
 
   As with all reducers, CovarianceReducer does not hold state information;
   rather, it stores supplied metadata. Intermediate calculations are held in
@@ -81,7 +95,8 @@ class CovarianceReducer(reducer_base.Reducer):
   ```
   """
 
-  def __init__(self, event_ndims=None, ddof=0, name=None):
+  def __init__(
+      self, event_ndims=None, transform_fn=_get_sample, ddof=0, name=None):
     """Instantiates this object.
 
     The running covariance computation supports batching. The `event_ndims`
@@ -114,6 +129,8 @@ class CovarianceReducer(reducer_base.Reducer):
         the number of inner-most dimensions that represent the event shape.
         Specifying `None` returns all cross product terms (no batching)
         and is the default.
+      transform_fn: A (possibly nested) structure of functions to evaluate the
+        incoming chain states on before covariance calculation.
       ddof: A (possibly nested) structure of integers that represent the
         requested dynamic degrees of freedom. For example, use `ddof=0`
         for population covariance and `ddof=1` for sample covariance. Defaults
@@ -123,11 +140,12 @@ class CovarianceReducer(reducer_base.Reducer):
     """
     self._parameters = dict(
         event_ndims=event_ndims,
+        transform_fn=transform_fn,
         ddof=ddof,
         name=name or 'covariance_reducer'
     )
 
-  def initialize(self, initial_chain_state, initial_kernel_results=None):
+  def initialize(self, initial_chain_state, initial_kernel_results):
     """Initializes a `CovarianceReducerState` using previously defined metadata.
 
     For calculation purposes, the `initial_chain_state` does not count as a
@@ -141,9 +159,6 @@ class CovarianceReducer(reducer_base.Reducer):
         chain(s). It is used to infer the shape and dtype of future samples.
       initial_kernel_results: A (possibly nested) structure of `Tensor`s
         representing internal calculations made in a related `TransitionKernel`.
-        For streaming covariance, this argument has no influence on the
-        computation; hence, it is `None` by default. However, it's
-        still accepted to fit the `Reducer` base class.
 
     Returns:
       state: `CovarianceReducerState` with `cov_state` field representing
@@ -155,19 +170,27 @@ class CovarianceReducer(reducer_base.Reducer):
       initial_chain_state = tf.nest.map_structure(
           tf.convert_to_tensor,
           initial_chain_state)
+      initial_kernel_results = tf.nest.map_structure(
+          tf.convert_to_tensor,
+          initial_kernel_results,
+      )
+      initial_fn_result = tf.nest.map_structure(
+          lambda fn: fn(initial_chain_state, initial_kernel_results),
+          self.transform_fn,
+      )
       cov_streams = _prepare_args(
-          initial_chain_state, self.event_ndims)
+          initial_fn_result, self.event_ndims)
       running_covariance_states = tf.nest.map_structure(
           lambda strm: strm.initialize(),
           cov_streams)
       return CovarianceReducerState(
-          initial_chain_state, running_covariance_states)
+          initial_fn_result, running_covariance_states)
 
   def one_step(
       self,
       new_chain_state,
       current_reducer_state,
-      previous_kernel_results=None,
+      previous_kernel_results,
       axis=None):
     """Update the `current_reducer_state` with a new chain state.
 
@@ -186,9 +209,7 @@ class CovarianceReducer(reducer_base.Reducer):
         state of the running covariance.
       previous_kernel_results: A (possibly nested) structure of `Tensor`s
         representing internal calculations made in a related
-        `TransitionKernel`. For streaming covariance, this argument has no
-        influence on computation; hence, it is `None` by default. However, it's
-        still accepted to fit the `Reducer` base class.
+        `TransitionKernel`.
       axis: If chunking is desired, this is a (possibly nested) structure of
         integers that specifies the axis with chunked samples. For individual
         samples, set this to `None`. By default, samples are not chunked
@@ -196,8 +217,9 @@ class CovarianceReducer(reducer_base.Reducer):
 
     Returns:
       new_reducer_state: `CovarianceReducerState` with updated running
-        statistics. Its `cov_state` field has an identical structure to the
-        `current_reducer_state`.
+        statistics. Its `cov_state` field has an identical structure to
+        `self.transform_fn`. Each of the individual values in that structure
+        subsequently mimics the structure of `current_reducer_state`.
     """
     with tf.name_scope(
         mcmc_util.make_name(self.name, 'covariance_reducer', 'one_step')):
@@ -206,14 +228,21 @@ class CovarianceReducer(reducer_base.Reducer):
       new_chain_state = tf.nest.map_structure(
           tf.convert_to_tensor,
           new_chain_state)
+      previous_kernel_results = tf.nest.map_structure(
+          tf.convert_to_tensor,
+          previous_kernel_results)
+      fn_results = tf.nest.map_structure(
+          lambda fn: fn(new_chain_state, previous_kernel_results),
+          self.transform_fn,
+      )
       if not nest.is_nested(axis):
-        axis = nest_util.broadcast_structure(new_chain_state, axis)
+        axis = nest_util.broadcast_structure(fn_results, axis)
       running_cov_state = nest.map_structure_up_to(
           current_reducer_state.init_structure,
           lambda strm, *args: strm.update(*args),
           cov_streams,
           current_reducer_state.cov_state,
-          new_chain_state,
+          fn_results,
           axis,
           check_types=False,
       )
@@ -229,7 +258,7 @@ class CovarianceReducer(reducer_base.Reducer):
 
     Returns:
       covariance: an estimate of the covariance with identical structure to
-        `final_reducer_state.cov_state`.
+        `self.transform_fn`.
     """
     with tf.name_scope(
         mcmc_util.make_name(self.name, 'covariance_reducer', 'finalize')):
@@ -244,6 +273,10 @@ class CovarianceReducer(reducer_base.Reducer):
   @property
   def event_ndims(self):
     return self._parameters['event_ndims']
+
+  @property
+  def transform_fn(self):
+    return self._parameters['transform_fn']
 
   @property
   def ddof(self):
@@ -269,9 +302,10 @@ class VarianceReducer(CovarianceReducer):
   `RunningVariance` in `tfp.experimental.stats`.
   """
 
-  def __init__(self, ddof=0, name=None):
+  def __init__(self, transform_fn=_get_sample, ddof=0, name=None):
     super(VarianceReducer, self).__init__(
         event_ndims=0,
+        transform_fn=transform_fn,
         ddof=ddof,
         name=name or 'variance_reducer',
     )

--- a/tensorflow_probability/python/experimental/mcmc/covariance_reducer_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/covariance_reducer_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
+
 # Dependency imports
 
 import numpy as np
@@ -27,14 +29,23 @@ import tensorflow_probability as tfp
 from tensorflow_probability.python.internal import test_util
 
 
+FakeKernelResults = collections.namedtuple(
+        'FakeKernelResults', 'value, inner_results')
+
+
+FakeInnerResults = collections.namedtuple(
+    'FakeInnerResults', 'value')
+
+
 @test_util.test_all_tf_execution_regimes
 class CovarianceReducersTest(test_util.TestCase):
 
   def test_zero_covariance(self):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
-    state = cov_reducer.initialize(0.)
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(0., fake_kr)
     for _ in range(2):
-      state = cov_reducer.one_step(0., state)
+      state = cov_reducer.one_step(0., state, fake_kr)
     final_num_samples, final_mean, final_cov = self.evaluate([
         state.cov_state.num_samples,
         state.cov_state.mean,
@@ -47,9 +58,10 @@ class CovarianceReducersTest(test_util.TestCase):
     rng = test_util.test_np_rng()
     x = rng.rand(100)
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
-    state = cov_reducer.initialize(0.)
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(0., fake_kr)
     for sample in x:
-      state = cov_reducer.one_step(sample, state)
+      state = cov_reducer.one_step(sample, state, fake_kr)
     final_mean, final_cov = self.evaluate([
         state.cov_state.mean,
         cov_reducer.finalize(state)])
@@ -58,10 +70,11 @@ class CovarianceReducersTest(test_util.TestCase):
 
   def test_covariance_shape(self):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer(event_ndims=1)
-    state = cov_reducer.initialize(tf.ones((9, 3)))
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(tf.ones((9, 3)), fake_kr)
     for _ in range(2):
       state = cov_reducer.one_step(
-          tf.zeros((5, 9, 3)), state, axis=0)
+          tf.zeros((5, 9, 3)), state, fake_kr, axis=0)
     final_mean, final_cov = self.evaluate([
         state.cov_state.mean,
         cov_reducer.finalize(state)])
@@ -70,10 +83,11 @@ class CovarianceReducersTest(test_util.TestCase):
 
   def test_variance_shape(self):
     var_reducer = tfp.experimental.mcmc.VarianceReducer()
-    state = var_reducer.initialize(tf.ones((9, 3)))
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = var_reducer.initialize(tf.ones((9, 3)), fake_kr)
     for _ in range(2):
       state = var_reducer.one_step(
-          tf.zeros((5, 9, 3)), state, axis=0)
+          tf.zeros((5, 9, 3)), state, fake_kr, axis=0)
     final_mean, final_var = self.evaluate([
         state.cov_state.mean,
         var_reducer.finalize(state)])
@@ -83,30 +97,29 @@ class CovarianceReducersTest(test_util.TestCase):
   def test_attributes(self):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer(
         event_ndims=1, ddof=1)
-    state = cov_reducer.initialize(tf.ones((2, 3), dtype=tf.float64))
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(
+        tf.ones((2, 3), dtype=tf.float64), fake_kr)
 
     # check attributes are correct right after initialization
-    parameters = dict(
-        event_ndims=1, ddof=1, name='covariance_reducer'
-    )
     self.assertEqual(1, cov_reducer.event_ndims)
     self.assertEqual(1, cov_reducer.ddof)
-    self.assertEqual(parameters, cov_reducer.parameters)
     for _ in range(2):
       state = cov_reducer.one_step(
-          tf.zeros((2, 3), dtype=tf.float64), state)
+          tf.zeros((2, 3), dtype=tf.float64), state, fake_kr)
 
     # check attributes don't change after stepping through
     self.assertEqual(1, cov_reducer.event_ndims)
     self.assertEqual(1, cov_reducer.ddof)
-    self.assertEqual(parameters, cov_reducer.parameters)
 
   def test_tf_while(self):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer()
-    state = cov_reducer.initialize(tf.ones((2, 3)))
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(tf.ones((2, 3)), fake_kr)
     _, state = tf.while_loop(
         lambda i, _: i < 100,
-        lambda i, state: (i + 1, cov_reducer.one_step(tf.ones((2, 3)), state)),
+        lambda i, state: (i + 1, cov_reducer.one_step(
+            tf.ones((2, 3)), state, fake_kr)),
         (0., state)
     )
     final_cov = self.evaluate(cov_reducer.finalize(state))
@@ -116,10 +129,12 @@ class CovarianceReducersTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer(event_ndims=0)
     chain_state = ({'one': tf.ones((2, 3)), 'zero': tf.zeros((2, 3))},
                    {'two': tf.ones((2, 3)) * 2})
-    state = cov_reducer.initialize(chain_state)
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(chain_state, fake_kr)
     _, state = tf.while_loop(
         lambda i, _: i < 10,
-        lambda i, state: (i + 1, cov_reducer.one_step(chain_state, state)),
+        lambda i, state: (i + 1, cov_reducer.one_step(
+            chain_state, state, fake_kr)),
         (0., state)
     )
     final_cov = self.evaluate(cov_reducer.finalize(state))
@@ -131,16 +146,87 @@ class CovarianceReducersTest(test_util.TestCase):
     cov_reducer = tfp.experimental.mcmc.CovarianceReducer(event_ndims=1)
     chain_state = ({'one': tf.ones((3, 4)), 'zero': tf.zeros((3, 4))},
                    {'two': tf.ones((3, 4)) * 2})
-    state = cov_reducer.initialize(chain_state)
+    fake_kr = FakeKernelResults(0, FakeInnerResults(0))
+    state = cov_reducer.initialize(chain_state, fake_kr)
     _, state = tf.while_loop(
         lambda i, _: i < 10,
-        lambda i, state: (i + 1, cov_reducer.one_step(chain_state, state, 0)),
+        lambda i, state: (i + 1, cov_reducer.one_step(
+            chain_state, state, fake_kr, 0)),
         (0., state)
     )
     final_cov = self.evaluate(cov_reducer.finalize(state))
     self.assertAllEqualNested(
         final_cov, ({'one': tf.zeros((3, 4, 4)), 'zero': tf.zeros((3, 4, 4))},
                     {'two': tf.zeros((3, 4, 4))}))
+
+  def test_manual_variance_transform_fn(self):
+    var_reducer = tfp.experimental.mcmc.VarianceReducer(
+        transform_fn=lambda _, kr: kr.inner_results.value)
+    fake_kr = FakeKernelResults(0., FakeInnerResults(
+        tf.zeros((2, 3))))
+    # chain state should be irrelevant
+    state = var_reducer.initialize(0., fake_kr)
+    for sample in range(5):
+      fake_kr = FakeKernelResults(
+          sample, FakeInnerResults(tf.ones((2, 3)) * sample))
+      state = var_reducer.one_step(sample, state, fake_kr)
+    final_mean, final_var = self.evaluate([
+        state.cov_state.mean,
+        var_reducer.finalize(state)])
+    self.assertEqual((2, 3), final_mean.shape)
+    self.assertAllEqual(np.ones((2, 3)) * 2, final_mean)
+    self.assertEqual((2, 3), final_var.shape)
+    self.assertAllEqual(np.ones((2, 3)) * 2, final_var)
+
+  def test_manual_covariance_transform_fn_with_random_states(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 5, 2)
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer(
+        transform_fn=lambda _, kr: kr.inner_results.value)
+    fake_kr = FakeKernelResults(0., FakeInnerResults(
+        tf.zeros((5, 2))))
+    state = cov_reducer.initialize(0., fake_kr)
+    for sample in x:
+      fake_kr = FakeKernelResults(0., FakeInnerResults(sample))
+      state = cov_reducer.one_step(0., state, fake_kr)
+    final_mean, final_cov = self.evaluate([
+        state.cov_state.mean,
+        cov_reducer.finalize(state)])
+
+    # reshaping to be compatible with a check against numpy
+    x_reshaped = x.reshape(100, 10)
+    final_cov_reshaped = tf.reshape(final_cov, (10, 10))
+    self.assertEqual((5, 2), final_mean.shape)
+    self.assertAllClose(np.mean(x, axis=0), final_mean, rtol=1e-5)
+    self.assertEqual((5, 2, 5, 2), final_cov.shape)
+    self.assertAllClose(np.cov(x_reshaped.T, ddof=0),
+                        final_cov_reshaped,
+                        rtol=1e-5)
+
+  def test_latent_state_with_multiple_transform_fn(self):
+    cov_reducer = tfp.experimental.mcmc.CovarianceReducer(
+        event_ndims=1,
+        transform_fn=[
+            lambda _, kr: kr.value,
+            lambda _, kr: kr.inner_results.value
+        ])
+    latent_state = ({'one': tf.ones((3, 4)), 'zero': tf.zeros((3, 4))},
+                    {'two': tf.ones((3, 4)) * 2})
+    fake_kr = FakeKernelResults(latent_state, FakeInnerResults(latent_state))
+    state = cov_reducer.initialize(latent_state, fake_kr)
+    _, state = tf.while_loop(
+        lambda i, _: i < 10,
+        lambda i, state: (i + 1, cov_reducer.one_step(
+            0., state, fake_kr)),
+        (0., state)
+    )
+    final_cov = self.evaluate(cov_reducer.finalize(state))
+    cov_latent = ({'one': tf.zeros((3, 4, 4)), 'zero': tf.zeros((3, 4, 4))},
+                  {'two': tf.zeros((3, 4, 4))})
+    self.assertAllEqualNested(
+        final_cov[0], cov_latent)
+    self.assertAllEqualNested(
+        final_cov[1], cov_latent)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Like with `tfp.experimental.mcmc.ExpectationsReducer`, I'm adding a kwarg to CovarianceReducer to allow the user to specify an arbitrary structure of functions to evaluate on the chain state and kernel results for covariance computation. This makes it much easier to compute covariance over the kernel results.