### PR TITLE
Specifying semantics for parallel sampling in `sample_chain` and friends

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/sample_fold.py
+++ b/tensorflow_probability/python/experimental/mcmc/sample_fold.py
@@ -55,6 +55,10 @@ def sample_fold(
   This runs in constant memory (unless a given `Reducer` builds a
   large structure).
 
+  If one desires to sample from multiple chains in parallel, the
+  `current_state` must be a `Tensor` with a leading batch dimension
+  representing the number of parallel chains.
+
   The driver internally composes the correct onion of `WithReductions`
   and `SampleDiscardingKernel` to implement the requested optionally
   thinned reduction; however, the kernel results of those applied
@@ -168,7 +172,10 @@ def sample_chain(
   there are multiple chains is dictated by the `kernel`.)
 
   The `current_state` can be represented as a single `Tensor` or a `list` of
-  `Tensors` which collectively represent the current state.
+  `Tensors` which collectively represent the current state. Note, if one desires
+  to sample from multiple chains in parallel, the `current_state` must be a
+  `Tensor` with a leading batch dimension representing the number of parallel
+  chains.
 
   Since MCMC states are correlated, it is sometimes desirable to produce
   additional intermediate states, and then discard them, ending up with a set of

--- a/tensorflow_probability/python/mcmc/sample.py
+++ b/tensorflow_probability/python/mcmc/sample.py
@@ -100,10 +100,13 @@ def sample_chain(
   instance (`kernel`).
 
   This function can sample from multiple chains, in parallel. (Whether or not
-  there are multiple chains is dictated by the `kernel`.)
+  there are multiple chains is dictated by the `kernel`).
 
   The `current_state` can be represented as a single `Tensor` or a `list` of
-  `Tensors` which collectively represent the current state.
+  `Tensors` which collectively represent the current state. Note, if one desires
+  to sample from multiple chains in parallel, the `current_state` must be a
+  `Tensor` with a leading batch dimension representing the number of parallel
+  chains.
 
   Since MCMC states are correlated, it is sometimes desirable to produce
   additional intermediate states, and then discard them, ending up with a set of


### PR DESCRIPTION
Current documentation doesn't explicitly specify that the `current_state` cannot be a `List` of `Tensor`s if parallel sampling is desired. Moreover, if one tries using a `List` of `Tensor`s, the error message is not really helpful. To make it more clear that the `current_state` should be a `Tensor` with a leading batch dimension, this PR simply explicitly states that in the Docstring of `sample_chain` and friends.