### PR TITLE
Adding a test fixtures internal file to `tfp.experimental.mcmc`

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/BUILD
@@ -356,6 +356,7 @@ py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/experimental/mcmc/internal:test_fixtures",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )
@@ -413,6 +414,7 @@ py_test(
     deps = [
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/experimental/mcmc/internal:test_fixtures",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )
@@ -442,6 +444,7 @@ py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/experimental/mcmc/internal:test_fixtures",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )
@@ -467,6 +470,7 @@ py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/experimental/mcmc/internal:test_fixtures",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )
@@ -491,6 +495,7 @@ py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/experimental/mcmc/internal:test_fixtures",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )
@@ -515,6 +520,7 @@ py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/experimental/mcmc/internal:test_fixtures",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )

--- a/tensorflow_probability/python/experimental/mcmc/expectations_reducer_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/expectations_reducer_test.py
@@ -23,6 +23,7 @@ import collections
 # Dependency imports
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
+from tensorflow_probability.python.experimental.mcmc.internal import test_fixtures
 from tensorflow_probability.python.internal import test_util
 
 
@@ -32,34 +33,6 @@ FakeKernelResults = collections.namedtuple(
 
 FakeInnerResults = collections.namedtuple(
     'FakeInnerResults', 'value')
-
-
-TestTransitionKernelResults = collections.namedtuple(
-    'TestTransitionKernelResults', 'counter_1, counter_2')
-
-
-class TestTransitionKernel(tfp.mcmc.TransitionKernel):
-  """Fake deterministic `TransitionKernel` for testing purposes."""
-
-  def __init__(self, is_calibrated=True, accepts_seed=True):
-    self._is_calibrated = is_calibrated
-    self._accepts_seed = accepts_seed
-
-  def one_step(self, current_state, previous_kernel_results, seed=None):
-    if seed is not None and not self._accepts_seed:
-      raise TypeError('seed arg not accepted')
-    return current_state + 1, TestTransitionKernelResults(
-        counter_1=previous_kernel_results.counter_1 + 1,
-        counter_2=previous_kernel_results.counter_2 + 2)
-
-  def bootstrap_results(self, current_state):
-    return TestTransitionKernelResults(
-        counter_1=tf.constant(0, dtype=tf.int32),
-        counter_2=tf.constant(0, dtype=tf.int32))
-
-  @property
-  def is_calibrated(self):
-    return self._is_calibrated
 
 
 @test_util.test_all_tf_execution_regimes
@@ -146,7 +119,7 @@ class ExpectationsReducerTest(test_util.TestCase):
     self.assertEqual(0, mean)
 
   def test_in_with_reductions(self):
-    fake_kernel = TestTransitionKernel()
+    fake_kernel = test_fixtures.TestTransitionKernel()
     mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
     reduced_kernel = tfp.experimental.mcmc.WithReductions(
         fake_kernel, mean_reducer,
@@ -158,7 +131,7 @@ class ExpectationsReducerTest(test_util.TestCase):
     self.assertEqual(9, streaming_calculations)
 
   def test_in_step_kernel(self):
-    fake_kernel = TestTransitionKernel()
+    fake_kernel = test_fixtures.TestTransitionKernel()
     mean_reducer = tfp.experimental.mcmc.ExpectationsReducer()
     reduced_kernel = tfp.experimental.mcmc.WithReductions(
         fake_kernel, mean_reducer,

--- a/tensorflow_probability/python/experimental/mcmc/internal/BUILD
+++ b/tensorflow_probability/python/experimental/mcmc/internal/BUILD
@@ -1,0 +1,53 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+# Description:
+#   Internal utilities for TensorFlow probability.
+
+# [internal] load python3.bzl
+load(
+    "//tensorflow_probability/python:build_defs.bzl",
+    "multi_substrate_py_test",
+    "multi_substrate_py_library",
+)
+
+licenses(["notice"])  # Apache 2.0
+
+package(
+    default_visibility = [
+        "//tensorflow_probability:__subpackages__",
+#         "//tensorflow_probability/google:friends",  # DisableOnExport
+    ],
+)
+
+exports_files(["LICENSE"])
+
+multi_substrate_py_library(
+    name = "internal",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":test_fixtures",
+    ]
+)
+
+py_library(
+    name = "test_fixtures",
+    srcs = ["test_fixtures.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        # tensorflow dep,
+        "//tensorflow_probability",
+    ],
+)

--- a/tensorflow_probability/python/experimental/mcmc/internal/__init__.py
+++ b/tensorflow_probability/python/experimental/mcmc/internal/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================

--- a/tensorflow_probability/python/experimental/mcmc/internal/test_fixtures.py
+++ b/tensorflow_probability/python/experimental/mcmc/internal/test_fixtures.py
@@ -1,0 +1,109 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Test Fixtures for the Streaming MCMC Framework."""
+
+import collections
+
+# Dependency imports
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+
+
+TestTransitionKernelResults = collections.namedtuple(
+    'TestTransitionKernelResults', 'counter_1, counter_2')
+
+
+class TestTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Fake deterministic Transition Kernel."""
+
+  def __init__(
+      self,
+      shape=(),
+      target_log_prob_fn=None,
+      is_calibrated=True,
+      accepts_seed=True):
+    self._is_calibrated = is_calibrated
+    self._shape = shape
+    # for composition purposes
+    self.parameters = dict(
+        target_log_prob_fn=target_log_prob_fn)
+    self._accepts_seed = accepts_seed
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    if seed is not None and not self._accepts_seed:
+      raise TypeError('seed arg not accepted')
+    current_state = tf.convert_to_tensor(current_state)
+    return (current_state + tf.ones(self._shape, dtype=current_state.dtype),
+            TestTransitionKernelResults(
+                counter_1=previous_kernel_results.counter_1 + 1,
+                counter_2=previous_kernel_results.counter_2 + 2))
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()),
+        counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+class RandomTransitionKernel(tfp.mcmc.TransitionKernel):
+  """Outputs a random next state following a Rayleigh distribution."""
+
+  def __init__(self, shape=(), is_calibrated=True, accepts_seed=True):
+    self._shape = shape
+    self._is_calibrated = is_calibrated
+    self._accepts_seed = accepts_seed
+
+  def one_step(self, current_state, previous_kernel_results, seed=None):
+    if seed is not None and not self._accepts_seed:
+      raise TypeError('seed arg not accepted')
+    new_state = tfp.random.rayleigh(self._shape, seed=seed)
+    return new_state, TestTransitionKernelResults(
+        counter_1=previous_kernel_results.counter_1 + 1,
+        counter_2=previous_kernel_results.counter_2 + 2)
+
+  def bootstrap_results(self, current_state):
+    return TestTransitionKernelResults(
+        counter_1=tf.zeros(()), counter_2=tf.zeros(()))
+
+  @property
+  def is_calibrated(self):
+    return self._is_calibrated
+
+
+class NaiveMeanReducer(tfp.experimental.mcmc.Reducer):
+  """Simple Reducer that (naively) computes the mean."""
+
+  def initialize(self, initial_chain_state=None, initial_kernel_results=None):
+    return tf.zeros((2,))
+
+  def one_step(self, sample, current_state, previous_kernel_results, axis=None):
+    return current_state + tf.convert_to_tensor([1, sample])
+
+  def finalize(self, final_state):
+    return final_state[1] / final_state[0]
+
+
+class TestReducer(tfp.experimental.mcmc.Reducer):
+  """Simple Reducer that just keeps track of the last sample."""
+
+  def initialize(self, initial_chain_state, initial_kernel_results=None):
+    return tf.zeros_like(initial_chain_state)
+
+  def one_step(
+      self, new_chain_state, current_reducer_state, previous_kernel_results):
+    return new_chain_state

--- a/tensorflow_probability/python/experimental/mcmc/tracing_reducer_test.py
+++ b/tensorflow_probability/python/experimental/mcmc/tracing_reducer_test.py
@@ -18,45 +18,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
-
 # Dependency imports
 import numpy as np
 
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
+from tensorflow_probability.python.experimental.mcmc.internal import test_fixtures
 from tensorflow_probability.python.internal import tensorshape_util
 from tensorflow_probability.python.internal import test_util
-
-
-TestTransitionKernelResults = collections.namedtuple(
-    'TestTransitionKernelResults', 'counter_1, counter_2')
-
-
-class TestTransitionKernel(tfp.mcmc.TransitionKernel):
-  """Fake deterministic Transition Kernel."""
-
-  def __init__(self, shape=(), target_log_prob_fn=None, is_calibrated=True):
-    self._is_calibrated = is_calibrated
-    self._shape = shape
-    # for composition purposes
-    self.parameters = dict(
-        target_log_prob_fn=target_log_prob_fn)
-
-  def one_step(self, current_state, previous_kernel_results, seed=None):
-    return (current_state + tf.ones(self._shape),
-            TestTransitionKernelResults(
-                counter_1=previous_kernel_results.counter_1 + 1,
-                counter_2=previous_kernel_results.counter_2 + 2))
-
-  def bootstrap_results(self, current_state):
-    return TestTransitionKernelResults(
-        counter_1=tf.zeros(()),
-        counter_2=tf.zeros(()))
-
-  @property
-  def is_calibrated(self):
-    return self._is_calibrated
 
 
 @test_util.test_all_tf_execution_regimes
@@ -131,7 +100,7 @@ class TracingReducerTest(test_util.TestCase):
 
   def test_in_sample_fold(self):
     tracer = tfp.experimental.mcmc.TracingReducer()
-    fake_kernel = TestTransitionKernel()
+    fake_kernel = test_fixtures.TestTransitionKernel()
     trace, final_state, kernel_results = tfp.experimental.mcmc.sample_fold(
         num_steps=3,
         current_state=0.,


### PR DESCRIPTION
In the Streaming MCMC Framework, a lot of tests rely on a dummy object to represent a TransitionKernel and/or Reducer. Rather than duplicating code for using (more or less) identical test objects, this PR creates a new internal file that holds all of them.