### PR TITLE
Add streaming arbitrary central moments to `tfp.experimental.stats`

### DIFF
--- a/tensorflow_probability/python/experimental/stats/BUILD
+++ b/tensorflow_probability/python/experimental/stats/BUILD
@@ -53,7 +53,7 @@ py_test(
     name = "sample_stats_test",
     size = "small",
     srcs = ["sample_stats_test.py"],
-    shard_count = 5,
+    shard_count = 10,
     deps = [
         ":sample_stats",
         # numpy dep,

--- a/tensorflow_probability/python/experimental/stats/BUILD
+++ b/tensorflow_probability/python/experimental/stats/BUILD
@@ -57,6 +57,7 @@ py_test(
     deps = [
         ":sample_stats",
         # numpy dep,
+        # scipy dep,
         # tensorflow dep,
         "//tensorflow_probability",
         "//tensorflow_probability/python/internal:test_util",

--- a/tensorflow_probability/python/experimental/stats/__init__.py
+++ b/tensorflow_probability/python/experimental/stats/__init__.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningCentralMoments
+from tensorflow_probability.python.experimental.stats.sample_stats import RunningCentralMomentsState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovariance
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningCovarianceState
 from tensorflow_probability.python.experimental.stats.sample_stats import RunningMean
@@ -26,9 +28,11 @@ from tensorflow_probability.python.experimental.stats.sample_stats import Runnin
 
 
 __all__ = [
-    'RunningMean',
-    'RunningMeanState',
+    'RunningCentralMoments',
+    'RunningCentralMomentsState',
     'RunningCovariance',
     'RunningCovarianceState',
+    'RunningMean',
+    'RunningMeanState',
     'RunningVariance',
 ]

--- a/tensorflow_probability/python/experimental/stats/sample_stats.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats.py
@@ -431,7 +431,7 @@ class RunningCentralMoments(object):
     Args:
       shape: Python `Tuple` or `TensorShape` representing the shape of
         incoming samples.
-      moment: Integer or shallow collection of integers that represent the
+      moment: Integer or iterable of integers that represent the
         desired moments to return.
       dtype: Dtype of incoming samples and the resulting statistics.
         By default, the dtype is `tf.float32`. Any integer dtypes will be

--- a/tensorflow_probability/python/experimental/stats/sample_stats.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats.py
@@ -451,6 +451,14 @@ class RunningCentralMoments(object):
   def initialize(self):
     """Initializes an empty `RunningCentralMomentsState`.
 
+    The `RunningCentralMomentsState` contains a `RunningMeanState` and
+    a `Tensor` representing the sum of exponentiated residuals. The sum
+    of exponentiated residuals is a `Tensor` of shape
+    (`self.max_moment`, `self.shape`) which contains the sum of
+    residuals raised to the nth power, for all `2 <= n <= self.max_moment`.
+    In the case of `n == 1`, the value is a corresponding structure of
+    `tf.zeros`.
+
     Returns:
       state: `RunningCentralMomentsState` representing a stream of no
         inputs.

--- a/tensorflow_probability/python/experimental/stats/sample_stats_test.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats_test.py
@@ -573,7 +573,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_first_five_moments(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        moment=5
+        max_moment=5
     )
     state = running_moments.initialize()
     for sample in range(5):
@@ -586,22 +586,10 @@ class RunningCentralMomentsTest(test_util.TestCase):
     self.assertNear(6.8, kur, err=1e-6)
     self.assertNear(0, fifth_moment, err=1e-6)
 
-  def test_return_all_moments_flag(self):
-    running_moments = tfp.experimental.stats.RunningCentralMoments(
-        shape=(),
-        moment=4
-    )
-    state = running_moments.initialize()
-    for sample in range(5):
-      state = running_moments.update(state, sample)
-    moment = self.evaluate(
-        running_moments.finalize(state, return_all_moments=False))
-    self.assertNear(6.8, moment, err=1e-6)
-
   def test_very_high_moments(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        moment=15
+        max_moment=15
     )
     state = running_moments.initialize()
     for sample in range(5):
@@ -616,7 +604,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_higher_rank_samples(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(2, 2),
-        moment=5
+        max_moment=5
     )
     state = running_moments.initialize()
     for sample in range(5):
@@ -634,7 +622,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
     x = rng.rand(100)
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        moment=5
+        max_moment=5
     )
     state = running_moments.initialize()
     for sample in x:
@@ -648,7 +636,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
     x = rng.rand(100, 10)
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(10,),
-        moment=5
+        max_moment=5
     )
     state = running_moments.initialize()
     for sample in x:
@@ -660,7 +648,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_manual_dtype(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        moment=1,
+        max_moment=1,
         dtype=tf.float64
     )
     state = running_moments.initialize()
@@ -671,7 +659,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_int_dtype_casts(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        moment=1,
+        max_moment=1,
         dtype=tf.int32
     )
     state = running_moments.initialize()
@@ -682,7 +670,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_in_tf_while(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        moment=4
+        max_moment=4
     )
     state = running_moments.initialize()
     _, state = tf.while_loop(
@@ -691,9 +679,12 @@ class RunningCentralMomentsTest(test_util.TestCase):
             state, tf.ones(()) * i)),
         (0., state)
     )
-    kur = self.evaluate(
-        running_moments.finalize(state, return_all_moments=False))
-    self.assertNear(6.8, kur, err=1e-6)
+    moments = self.evaluate(
+        running_moments.finalize(state))
+    self.assertAllClose(
+        stats.moment(np.arange(5), moment=np.arange(4) + 1),
+        moments,
+        rtol=1e-6)
 
 
 if __name__ == '__main__':

--- a/tensorflow_probability/python/experimental/stats/sample_stats_test.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats_test.py
@@ -573,7 +573,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_first_five_moments(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        max_moment=5
+        moment=np.arange(5) + 1
     )
     state = running_moments.initialize()
     for sample in range(5):
@@ -586,10 +586,23 @@ class RunningCentralMomentsTest(test_util.TestCase):
     self.assertNear(6.8, kur, err=1e-6)
     self.assertNear(0, fifth_moment, err=1e-6)
 
+  def test_specific_moments(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=[5, 3]
+    )
+    state = running_moments.initialize()
+    for sample in range(5):
+      state = running_moments.update(state, sample)
+    fifth_moment, skew = self.evaluate(
+        running_moments.finalize(state))
+    self.assertNear(0, skew, err=1e-6)
+    self.assertNear(0, fifth_moment, err=1e-6)
+
   def test_very_high_moments(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        max_moment=15
+        moment=np.arange(15) + 1
     )
     state = running_moments.initialize()
     for sample in range(5):
@@ -604,7 +617,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_higher_rank_samples(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(2, 2),
-        max_moment=5
+        moment=np.arange(5) + 1
     )
     state = running_moments.initialize()
     for sample in range(5):
@@ -622,7 +635,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
     x = rng.rand(100)
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        max_moment=5
+        moment=np.arange(5) + 1
     )
     state = running_moments.initialize()
     for sample in x:
@@ -636,7 +649,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
     x = rng.rand(100, 10)
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(10,),
-        max_moment=5
+        moment=np.arange(5) + 1
     )
     state = running_moments.initialize()
     for sample in x:
@@ -648,7 +661,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_manual_dtype(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        max_moment=1,
+        moment=1,
         dtype=tf.float64
     )
     state = running_moments.initialize()
@@ -659,7 +672,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_int_dtype_casts(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        max_moment=1,
+        moment=1,
         dtype=tf.int32
     )
     state = running_moments.initialize()
@@ -670,7 +683,7 @@ class RunningCentralMomentsTest(test_util.TestCase):
   def test_in_tf_while(self):
     running_moments = tfp.experimental.stats.RunningCentralMoments(
         shape=(),
-        max_moment=4
+        moment=np.arange(4) + 1
     )
     state = running_moments.initialize()
     _, state = tf.while_loop(

--- a/tensorflow_probability/python/experimental/stats/sample_stats_test.py
+++ b/tensorflow_probability/python/experimental/stats/sample_stats_test.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 import numpy as np
+import scipy.stats as stats
 
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
@@ -565,6 +566,134 @@ class RunningMeanTest(test_util.TestCase):
     state = running_mean.initialize()
     mean = self.evaluate(running_mean.finalize(state))
     self.assertEqual(0, mean)
+
+@test_util.test_all_tf_execution_regimes
+class RunningCentralMomentsTest(test_util.TestCase):
+
+  def test_first_five_moments(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=5
+    )
+    state = running_moments.initialize()
+    for sample in range(5):
+      state = running_moments.update(state, sample)
+    zeroth_moment, var, skew, kur, fifth_moment = self.evaluate(
+        running_moments.finalize(state))
+    self.assertNear(0, zeroth_moment, err=1e-6)
+    self.assertNear(2, var, err=1e-6)
+    self.assertNear(0, skew, err=1e-6)
+    self.assertNear(6.8, kur, err=1e-6)
+    self.assertNear(0, fifth_moment, err=1e-6)
+
+  def test_return_all_moments_flag(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=4
+    )
+    state = running_moments.initialize()
+    for sample in range(5):
+      state = running_moments.update(state, sample)
+    moment = self.evaluate(
+        running_moments.finalize(state, return_all_moments=False))
+    self.assertNear(6.8, moment, err=1e-6)
+
+  def test_very_high_moments(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=15
+    )
+    state = running_moments.initialize()
+    for sample in range(5):
+      state = running_moments.update(state, sample)
+    moments = self.evaluate(
+        running_moments.finalize(state))
+    self.assertAllClose(
+        stats.moment(np.arange(5), moment=np.arange(15) + 1),
+        moments,
+        rtol=1e-6)
+
+  def test_higher_rank_samples(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(2, 2),
+        moment=5
+    )
+    state = running_moments.initialize()
+    for sample in range(5):
+      state = running_moments.update(state, tf.ones((2, 2)) * sample)
+    zeroth_moment, var, skew, kur, fifth_moment = self.evaluate(
+        running_moments.finalize(state))
+    self.assertAllClose(tf.zeros((2, 2)), zeroth_moment, rtol=1e-6)
+    self.assertAllClose(tf.ones((2, 2)) * 2, var, rtol=1e-6)
+    self.assertAllClose(tf.zeros((2, 2)), skew, rtol=1e-6)
+    self.assertAllClose(tf.ones((2, 2)) * 6.8, kur, rtol=1e-6)
+    self.assertAllClose(tf.zeros((2, 2)), fifth_moment, rtol=1e-6)
+
+  def test_random_scalar_samples(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100)
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=5
+    )
+    state = running_moments.initialize()
+    for sample in x:
+      state = running_moments.update(state, sample)
+    moments = self.evaluate(running_moments.finalize(state))
+    self.assertAllClose(
+        stats.moment(x, moment=[1, 2, 3, 4, 5]), moments, rtol=1e-6)
+
+  def test_random_higher_rank_samples(self):
+    rng = test_util.test_np_rng()
+    x = rng.rand(100, 10)
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(10,),
+        moment=5
+    )
+    state = running_moments.initialize()
+    for sample in x:
+      state = running_moments.update(state, sample)
+    moments = self.evaluate(running_moments.finalize(state))
+    self.assertAllClose(
+        stats.moment(x, moment=[1, 2, 3, 4, 5]), moments, rtol=1e-6)
+
+  def test_manual_dtype(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=1,
+        dtype=tf.float64
+    )
+    state = running_moments.initialize()
+    state = running_moments.update(state, 0)
+    moment = running_moments.finalize(state)
+    self.assertEqual(tf.float64, moment.dtype)
+
+  def test_int_dtype_casts(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=1,
+        dtype=tf.int32
+    )
+    state = running_moments.initialize()
+    state = running_moments.update(state, 0)
+    moment = running_moments.finalize(state)
+    self.assertEqual(tf.float32, moment.dtype)
+
+  def test_in_tf_while(self):
+    running_moments = tfp.experimental.stats.RunningCentralMoments(
+        shape=(),
+        moment=4
+    )
+    state = running_moments.initialize()
+    _, state = tf.while_loop(
+        lambda i, _: i < 5,
+        lambda i, state: (i + 1, running_moments.update(
+            state, tf.ones(()) * i)),
+        (0., state)
+    )
+    kur = self.evaluate(
+        running_moments.finalize(state, return_all_moments=False))
+    self.assertNear(6.8, kur, err=1e-6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds an object that facilitates the computation of arbitrary central moments to `tfp.experimental.stats`. All intermediate moments (i.e. lower moments) are required for computation, and hence, the user has the choice to define if they want to receive all moments or simply their moment of choice via the `finalize` method.