### PR TITLE
add example of conditional density estimation to docs

### DIFF
--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -684,20 +684,21 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
 
   ```python
   # Generate data as the mixture of two distributions.
-  n = 2000
+  n = 10000
   c = np.r_[
     np.zeros(n//2),
     np.ones(n//2)
   ]
+  mean_0, mean_1 = 0, 5
   x = np.r_[
-    np.random.randn(n//2).astype(dtype=np.float32) * 2,
-    np.random.randn(n//2).astype(dtype=np.float32) + 5
+    np.random.randn(n//2).astype(dtype=np.float32) + mean_0,
+    np.random.randn(n//2).astype(dtype=np.float32) + mean_1
   ]
 
   # Density estimation with MADE.
   made = tfb.AutoregressiveNetwork(
     params=2, 
-    hidden_units=[10, 10],
+    hidden_units=[2, 2],
     event_shape=(1,),
     conditional=True, 
     conditional_event_shape=(1,)
@@ -714,19 +715,21 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   model = tfk.Model([x_, c_], log_prob_)
 
   model.compile(optimizer=tf.optimizers.Adam(),
-                 loss=lambda _, log_prob: -log_prob)
+                loss=lambda _, log_prob: -log_prob)
 
   batch_size = 25
   model.fit(x=[x, c],
             y=np.zeros((n, 0), dtype=np.float32),
             batch_size=batch_size,
-            epochs=1,
-            steps_per_epoch=1,  # Usually `n // batch_size`.
+            epochs=2,
+            steps_per_epoch=n // batch_size,  
             shuffle=True,
             verbose=True)
 
   # Use the fitted distribution to sample condition on c = 1
-  distribution.sample((3,), bijector_kwargs={'conditional_input': np.ones((3, 1))})
+  n_samples = 1000
+  cond = 1
+  samples = distribution.sample((n_samples,), bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
   ```
 
   #### Examples: Handling Rank-2+ Tensors

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -686,16 +686,22 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   # Generate data as the mixture of two distributions.
   n = 2000
   c = np.r_[
-  np.zeros(n//2),
-  np.ones(n//2)
+		np.zeros(n//2),
+		np.ones(n//2)
   ]
   x = np.r_[
-  np.random.randn(n//2).astype(dtype=np.float32) * 2,
-  np.random.randn(n//2).astype(dtype=np.float32) + 5
+		np.random.randn(n//2).astype(dtype=np.float32) * 2,
+		np.random.randn(n//2).astype(dtype=np.float32) + 5
   ]
 
   # Density estimation with MADE.
-  made = tfb.AutoregressiveNetwork(params=2, hidden_units=[10, 10])
+  made = tfb.AutoregressiveNetwork(
+		params=2, 
+		hidden_units=[10, 10],
+		event_shape=(1,),
+    conditional=True, 
+		conditional_event_shape=(1,)
+	)
 
   distribution = tfd.TransformedDistribution(
     distribution=tfd.Sample(tfd.Normal(loc=0., scale=1.), sample_shape=[1]),
@@ -707,8 +713,10 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   log_prob_ = distribution.log_prob(x_, bijector_kwargs={'conditional_input': c_})
   model = tfk.Model([x_, c_], log_prob_)
 
-  model.compile(optimizer=tf.optimizers.Adam(),
-              loss=lambda _, log_prob: -log_prob)
+  model.compile(
+		optimizer=tf.optimizers.Adam(),
+ 	  loss=lambda _, log_prob: -log_prob
+	)
 
   batch_size = 25
   model.fit(x=[x, c],

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -679,7 +679,7 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   distribution.log_prob(np.ones((3, 2), dtype=np.float32))
   ```
 
-  The `conditional` argument can be used to instead build a conditional density.  
+  The `conditional` argument can be used to instead build a conditional density.
   estimator. To do this the conditioning variable must be passed as a `kwarg`:
 
   ```python
@@ -697,10 +697,10 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
 
   # Density estimation with MADE.
   made = tfb.AutoregressiveNetwork(
-    params=2, 
+    params=2,
     hidden_units=[2, 2],
     event_shape=(1,),
-    conditional=True, 
+    conditional=True,
     conditional_event_shape=(1,)
   )
 
@@ -711,7 +711,8 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   # Construct and fit model.
   x_ = tfkl.Input(shape=(1,), dtype=tf.float32)
   c_ = tfkl.Input(shape=(1,), dtype=tf.float32)
-  log_prob_ = distribution.log_prob(x_, bijector_kwargs={'conditional_input': c_})
+  log_prob_ = distribution.log_prob(
+    x_, bijector_kwargs={'conditional_input': c_})
   model = tfk.Model([x_, c_], log_prob_)
 
   model.compile(optimizer=tf.optimizers.Adam(),
@@ -722,14 +723,16 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
             y=np.zeros((n, 0), dtype=np.float32),
             batch_size=batch_size,
             epochs=2,
-            steps_per_epoch=n // batch_size,  
+            steps_per_epoch=n // batch_size,
             shuffle=True,
             verbose=True)
 
   # Use the fitted distribution to sample condition on c = 1
   n_samples = 1000
   cond = 1
-  samples = distribution.sample((n_samples,), bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
+  samples = distribution.sample(
+    (n_samples,), 
+    bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
   ```
 
   #### Examples: Handling Rank-2+ Tensors

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -686,22 +686,22 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   # Generate data as the mixture of two distributions.
   n = 2000
   c = np.r_[
-		np.zeros(n//2),
-		np.ones(n//2)
+    np.zeros(n//2),
+    np.ones(n//2)
   ]
   x = np.r_[
-		np.random.randn(n//2).astype(dtype=np.float32) * 2,
-		np.random.randn(n//2).astype(dtype=np.float32) + 5
+    np.random.randn(n//2).astype(dtype=np.float32) * 2,
+    np.random.randn(n//2).astype(dtype=np.float32) + 5
   ]
 
   # Density estimation with MADE.
   made = tfb.AutoregressiveNetwork(
-		params=2, 
-		hidden_units=[10, 10],
-		event_shape=(1,),
+    params=2, 
+    hidden_units=[10, 10],
+    event_shape=(1,),
     conditional=True, 
-		conditional_event_shape=(1,)
-	)
+    conditional_event_shape=(1,)
+  )
 
   distribution = tfd.TransformedDistribution(
     distribution=tfd.Sample(tfd.Normal(loc=0., scale=1.), sample_shape=[1]),
@@ -714,16 +714,16 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   model = tfk.Model([x_, c_], log_prob_)
 
   model.compile(optimizer=tf.optimizers.Adam(),
- 	              loss=lambda _, log_prob: -log_prob)
+                 loss=lambda _, log_prob: -log_prob)
 
   batch_size = 25
   model.fit(x=[x, c],
-						y=np.zeros((n, 0), dtype=np.float32),
-						batch_size=batch_size,
-						epochs=1,
-						steps_per_epoch=1,  # Usually `n // batch_size`.
-						shuffle=True,
-						verbose=True)
+            y=np.zeros((n, 0), dtype=np.float32),
+            batch_size=batch_size,
+            epochs=1,
+            steps_per_epoch=1,  # Usually `n // batch_size`.
+            shuffle=True,
+            verbose=True)
 
   # Use the fitted distribution to sample condition on c = 1
   distribution.sample((3,), bijector_kwargs={'conditional_input': np.ones((3, 1))})

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -242,7 +242,7 @@ class MaskedAutoregressiveFlow(bijector_lib.Bijector):
        Autoregressive Flow. In _Neural Information Processing Systems_, 2016.
        https://arxiv.org/abs/1606.04934
 
-  [3]: George Papamakarios  , Theo Pavlakou, and Iain Murray. Masked
+  [3]: George Papamakarios, Theo Pavlakou, and Iain Murray. Masked
        Autoregressive Flow for Density Estimation. In _Neural Information
        Processing Systems_, 2017. https://arxiv.org/abs/1705.07057
 
@@ -686,41 +686,41 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   # Generate data as the mixture of two distributions.
   n = 2000
   c = np.r_[
-    np.zeros(n/2),
-    np.ones(n/2)
+  np.zeros(n//2),
+  np.ones(n//2)
   ]
   x = np.r_[
-    np.random.randn(n/2).astype(dtype=np.float32) * 2,
-    np.random.randn(n/2).astype(dtype=np.float32) + 5
+  np.random.randn(n//2).astype(dtype=np.float32) * 2,
+  np.random.randn(n//2).astype(dtype=np.float32) + 5
   ]
 
   # Density estimation with MADE.
   made = tfb.AutoregressiveNetwork(params=2, hidden_units=[10, 10])
 
   distribution = tfd.TransformedDistribution(
-      distribution=tfd.Sample(tfd.Normal(loc=0., scale=1.), sample_shape=[1]),
-      bijector=tfb.MaskedAutoregressiveFlow(made))
+    distribution=tfd.Sample(tfd.Normal(loc=0., scale=1.), sample_shape=[1]),
+    bijector=tfb.MaskedAutoregressiveFlow(made))
 
   # Construct and fit model.
   x_ = tfkl.Input(shape=(1,), dtype=tf.float32)
   c_ = tfkl.Input(shape=(1,), dtype=tf.float32)
   log_prob_ = distribution.log_prob(x_, bijector_kwargs={'conditional_input': c_})
-  model = tfk.Model(x_, log_prob_)
+  model = tfk.Model([x_, c_], log_prob_)
 
   model.compile(optimizer=tf.optimizers.Adam(),
-                loss=lambda _, log_prob: -log_prob)
+              loss=lambda _, log_prob: -log_prob)
 
   batch_size = 25
   model.fit(x=[x, c],
-            y=np.zeros((n, 0), dtype=np.float32),
-            batch_size=batch_size,
-            epochs=1,
-            steps_per_epoch=1,  # Usually `n // batch_size`.
-            shuffle=True,
-            verbose=True)
+          y=np.zeros((n, 0), dtype=np.float32),
+          batch_size=batch_size,
+          epochs=1,
+          steps_per_epoch=1,  # Usually `n // batch_size`.
+          shuffle=True,
+          verbose=True)
 
   # Use the fitted distribution to sample condition on c = 1
-  distribution.sample((3,), bijector_kwargs={'conditional_input': np.ones(3, 1))})
+  distribution.sample((3,), bijector_kwargs={'conditional_input': np.ones((3, 1))})
   ```
 
   #### Examples: Handling Rank-2+ Tensors

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -731,7 +731,7 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   n_samples = 1000
   cond = 1
   samples = distribution.sample(
-    (n_samples,), 
+    (n_samples,),
     bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
   ```
 

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -713,19 +713,17 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
   log_prob_ = distribution.log_prob(x_, bijector_kwargs={'conditional_input': c_})
   model = tfk.Model([x_, c_], log_prob_)
 
-  model.compile(
-		optimizer=tf.optimizers.Adam(),
- 	  loss=lambda _, log_prob: -log_prob
-	)
+  model.compile(optimizer=tf.optimizers.Adam(),
+ 	              loss=lambda _, log_prob: -log_prob)
 
   batch_size = 25
   model.fit(x=[x, c],
-          y=np.zeros((n, 0), dtype=np.float32),
-          batch_size=batch_size,
-          epochs=1,
-          steps_per_epoch=1,  # Usually `n // batch_size`.
-          shuffle=True,
-          verbose=True)
+						y=np.zeros((n, 0), dtype=np.float32),
+						batch_size=batch_size,
+						epochs=1,
+						steps_per_epoch=1,  # Usually `n // batch_size`.
+						shuffle=True,
+						verbose=True)
 
   # Use the fitted distribution to sample condition on c = 1
   distribution.sample((3,), bijector_kwargs={'conditional_input': np.ones((3, 1))})

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -330,7 +330,7 @@ class MaskedAutoregressiveFlow(bijector_lib.Bijector):
       # Still do this assignment for variable tracking.
       self._shift_and_log_scale_fn = shift_and_log_scale_fn
       self._bijector_fn = bijector_fn
-      super(MaskedAutoregressiveFlow, self).__init__(
+      super().__init__(
           forward_min_event_ndims=self._event_ndims,
           is_constant_jacobian=is_constant_jacobian,
           validate_args=validate_args,
@@ -943,7 +943,7 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
       **kwargs: Additional keyword arguments passed to this layer (but not to
         the `tf.keras.layer.Dense` layers constructed by this layer).
     """
-    super(AutoregressiveNetwork, self).__init__(**kwargs)
+    super().__init__(**kwargs)
 
     self._params = params
     self._event_shape = _list(event_shape) if event_shape is not None else None
@@ -1083,7 +1083,7 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
     # the specs of the network's input layers.
     self._network.input_spec = None
     # Record that the layer has been built.
-    super(AutoregressiveNetwork, self).build(input_shape)
+    super().build(input_shape)
 
   def call(self, x, conditional_input=None):
     """Transforms the inputs and returns the outputs.

--- a/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
@@ -744,10 +744,10 @@ class AutoregressiveNetworkTest(test_util.TestCase):
 
     # Density estimation with MADE.
     made = tfb.AutoregressiveNetwork(
-      params=2, 
+      params=2,
       hidden_units=[2, 2],
       event_shape=(1,),
-      conditional=True, 
+      conditional=True,
       conditional_event_shape=(1,)
     )
 
@@ -769,7 +769,7 @@ class AutoregressiveNetworkTest(test_util.TestCase):
               y=np.zeros((n, 0), dtype=np.float32),
               batch_size=batch_size,
               epochs=2,
-              steps_per_epoch=n // batch_size,  
+              steps_per_epoch=n // batch_size,
               shuffle=True,
               verbose=True)
 

--- a/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
@@ -729,6 +729,57 @@ class AutoregressiveNetworkTest(test_util.TestCase):
     self.assertAllEqual(
         (3,), distribution.log_prob(np.ones((3, 2), dtype=np.float32)).shape)
 
+  def test_doc_string_2(self):
+    np.random.seed(123)
+    n = 10000
+    c = np.r_[
+      np.zeros(n//2),
+      np.ones(n//2)
+    ]
+    mean_0, mean_1 = 0, 5
+    x = np.r_[
+      np.random.randn(n//2).astype(dtype=np.float32) + mean_0,
+      np.random.randn(n//2).astype(dtype=np.float32) + mean_1
+    ]
+
+    # Density estimation with MADE.
+    made = tfb.AutoregressiveNetwork(
+      params=2, 
+      hidden_units=[2, 2],
+      event_shape=(1,),
+      conditional=True, 
+      conditional_event_shape=(1,)
+    )
+
+    distribution = tfd.TransformedDistribution(
+      distribution=tfd.Sample(tfd.Normal(loc=0., scale=1.), sample_shape=[1]),
+      bijector=tfb.MaskedAutoregressiveFlow(made))
+
+    # Construct and fit model.
+    x_ = tfkl.Input(shape=(1,), dtype=tf.float32)
+    c_ = tfkl.Input(shape=(1,), dtype=tf.float32)
+    log_prob_ = distribution.log_prob(x_, bijector_kwargs={'conditional_input': c_})
+    model = tfk.Model([x_, c_], log_prob_)
+
+    model.compile(optimizer=tf.optimizers.Adam(),
+                  loss=lambda _, log_prob: -log_prob)
+
+    batch_size = 25
+    model.fit(x=[x, c],
+              y=np.zeros((n, 0), dtype=np.float32),
+              batch_size=batch_size,
+              epochs=2,
+              steps_per_epoch=n // batch_size,  
+              shuffle=True,
+              verbose=True)
+
+    # Use the fitted distribution to sample condition on c = 1
+    n_samples = 1000
+    cond = 1
+    samples = distribution.sample((n_samples,), bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
+    # Assert mean is close to conditional mean
+    self.assertAllClose(tf.reduce_mean(samples).numpy(), mean_1, atol=0.2)
+
   def test_doc_string_images_case_1(self):
     # Generate fake images.
     images = np.random.choice([0, 1], size=(100, 8, 8, 3))
@@ -909,6 +960,7 @@ class ConditionalTests(test_util.TestCase):
     )
     self.assertAllEqual(
         self.evaluate(tf.concat([broadcast_shape, [2]], axis=0)), made_shape)
+
 
 
 del _MaskedAutoregressiveFlowTest

--- a/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
@@ -758,7 +758,8 @@ class AutoregressiveNetworkTest(test_util.TestCase):
     # Construct and fit model.
     x_ = tfkl.Input(shape=(1,), dtype=tf.float32)
     c_ = tfkl.Input(shape=(1,), dtype=tf.float32)
-    log_prob_ = distribution.log_prob(x_, bijector_kwargs={'conditional_input': c_})
+    log_prob_ = distribution.log_prob(
+      x_, bijector_kwargs={'conditional_input': c_})
     model = tfk.Model([x_, c_], log_prob_)
 
     model.compile(optimizer=tf.optimizers.Adam(),
@@ -776,7 +777,9 @@ class AutoregressiveNetworkTest(test_util.TestCase):
     # Use the fitted distribution to sample condition on c = 1
     n_samples = 1000
     cond = 1
-    samples = distribution.sample((n_samples,), bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
+    samples = distribution.sample(
+      (n_samples,), 
+      bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
     # Assert mean is close to conditional mean
     self.assertAllClose(tf.reduce_mean(samples).numpy(), mean_1, atol=0.2)
 

--- a/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
@@ -778,7 +778,7 @@ class AutoregressiveNetworkTest(test_util.TestCase):
     n_samples = 1000
     cond = 1
     samples = distribution.sample(
-      (n_samples,), 
+      (n_samples,),
       bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
     # Assert mean is close to conditional mean
     self.assertAllClose(tf.reduce_mean(samples).numpy(), mean_1, atol=0.2)

--- a/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
@@ -730,7 +730,7 @@ class AutoregressiveNetworkTest(test_util.TestCase):
         (3,), distribution.log_prob(np.ones((3, 2), dtype=np.float32)).shape)
 
   def test_doc_string_2(self):
-    n = 10000
+    n = 20000
     c = np.r_[
       np.zeros(n//2),
       np.ones(n//2)
@@ -768,13 +768,13 @@ class AutoregressiveNetworkTest(test_util.TestCase):
     model.fit(x=[x, c],
               y=np.zeros((n, 0), dtype=np.float32),
               batch_size=batch_size,
-              epochs=2,
+              epochs=3,
               steps_per_epoch=n // batch_size,
               shuffle=True,
               verbose=True)
 
     # Use the fitted distribution to sample condition on c = 1
-    n_samples = 1000
+    n_samples = 10000
     cond = 1
     samples = distribution.sample(
       (n_samples,),

--- a/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive_test.py
@@ -730,7 +730,6 @@ class AutoregressiveNetworkTest(test_util.TestCase):
         (3,), distribution.log_prob(np.ones((3, 2), dtype=np.float32)).shape)
 
   def test_doc_string_2(self):
-    np.random.seed(123)
     n = 10000
     c = np.r_[
       np.zeros(n//2),
@@ -781,7 +780,7 @@ class AutoregressiveNetworkTest(test_util.TestCase):
       (n_samples,),
       bijector_kwargs={'conditional_input': cond * np.ones((n_samples, 1))})
     # Assert mean is close to conditional mean
-    self.assertAllClose(tf.reduce_mean(samples).numpy(), mean_1, atol=0.2)
+    self.assertAllClose(tf.reduce_mean(samples), mean_1, atol=0.2)
 
   def test_doc_string_images_case_1(self):
     # Generate fake images.


### PR DESCRIPTION
I was reading the docs here: https://www.tensorflow.org/probability/api_docs/python/tfp/bijectors/AutoregressiveNetwork and couldn't immediately see how to use `conditional`. So after figuring it out I decided it would be useful to submit an example.

Simply adds an example of conditional density estimation to the doc string.