### PR TITLE
Fix: `index_points` coming from `self._get_index_points(index_points)`

### DIFF
--- a/tensorflow_probability/python/distributions/variational_gaussian_process.py
+++ b/tensorflow_probability/python/distributions/variational_gaussian_process.py
@@ -934,9 +934,9 @@ class VariationalGaussianProcess(gaussian_process.GaussianProcess):
     batch_shapes = [
         self.kernel.batch_shape,
         self.variational_inducing_observations_loc.shape[:-1]]
-    if self.index_points is not None:
+    if index_points is not None:
       batch_shapes.append(
-          self.index_points.shape[:-(self.kernel.feature_ndims + 1)])
+          index_points.shape[:-(self.kernel.feature_ndims + 1)])
     return functools.reduce(tf.broadcast_static_shape, batch_shapes)
 
   def _batch_shape_tensor(self, index_points=None):
@@ -944,9 +944,9 @@ class VariationalGaussianProcess(gaussian_process.GaussianProcess):
     batch_shape_tensors = [
         self.kernel.batch_shape_tensor(),
         tf.shape(self.variational_inducing_observations_loc)[:-1]]
-    if self.index_points is not None:
+    if index_points is not None:
       batch_shape_tensors.append(
-          tf.shape(self.index_points)[:-(self.kernel.feature_ndims + 1)])
+          tf.shape(index_points)[:-(self.kernel.feature_ndims + 1)])
     return functools.reduce(tf.broadcast_dynamic_shape, batch_shape_tensors)
 
   def surrogate_posterior_expected_log_likelihood(


### PR DESCRIPTION
This fixes #1083 .

`index_points = self._get_index_points(index_points)` were not used in the VariationalGaussianProcess class, in both `_batch_shape` and `_batch_shape_tensor` methods. Now the index points are correctly used to understand the batch_shape (without relying on `self.index_points`).