### PR TITLE
avoid gast 0.4.0 for tensorflow 2.2.0 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.13.3',
     'decorator',
     'cloudpickle == 1.3',  # TODO(b/155109696): Unpin cloudpickle version.
-    'gast >= 0.3.2'  # For autobatching
+    'gast ~= 0.3.2'  # For autobatching
 ]
 
 if '--release' in sys.argv:


### PR DESCRIPTION
as the documentation says tensorflow probability 0.10 should support tensorflow 2.2.0.

in some cases, tfp installs gast 0.4 which causes errors with tensorflow 2.2
Note that tensorflow 2.3 is very buggy on windows so this issue is relevant to current tfp and tf users, not just maintenance