### PR TITLE
Make ReplicaExchangeMC compatible with JAX omnistaging

### DIFF
--- a/tensorflow_probability/python/mcmc/replica_exchange_mc.py
+++ b/tensorflow_probability/python/mcmc/replica_exchange_mc.py
@@ -793,7 +793,7 @@ class ReplicaExchangeMC(kernel_base.TransitionKernel):
       # then the new shape is [(T, Sx), (T, Sy)] where (a, b) means
       # concatenation and T=shape(inverse_temperature).
       num_replica = ps.size0(inverse_temperatures)
-      replica_shape = tf.convert_to_tensor([num_replica])
+      replica_shape = ps.convert_to_shape_tensor([num_replica])
 
       if self._state_includes_replicas:
         replica_states = init_state


### PR DESCRIPTION
This is a quick fix for ReplicaExchangeMC when I tried to run it inside `pmap`. Without this change, I get the error
```
/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/tensorflow_probability/substrates/jax/mcmc/replica_exchange_mc.py:816: in bootstrap_results
    for x in init_state
/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/tensorflow_probability/substrates/jax/mcmc/replica_exchange_mc.py:816: in <listcomp>
    for x in init_state
/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/tensorflow_probability/python/internal/backend/jax/ops.py:374: in <lambda>
    lambda input, shape, name=None: np.broadcast_to(input, shape))
/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/jax/numpy/lax_numpy.py:1539: in broadcast_to
    shape = canonicalize_shape(shape)  # check that shape is concrete
------------------------------
E     TypeError: Shapes must be 1D sequences of concrete values of integer type, got Traced<ShapedArray(int32[2])>with<DynamicJaxprTrace(level=0/1)>.
E     If using `jit`, try using `static_argnums` or applying `jit` to smaller subfunctions.
```