### PR TITLE
Fix dtype error independent normal distribution

### DIFF
--- a/tensorflow_probability/python/layers/distribution_layer.py
+++ b/tensorflow_probability/python/layers/distribution_layer.py
@@ -896,7 +896,7 @@ class IndependentLogistic(DistributionLambda):
     with tf.name_scope(name or 'IndependentLogistic_params_size'):
       event_shape = tf.convert_to_tensor(
           event_shape, name='event_shape', dtype_hint=tf.int32)
-      return 2 * _event_size(
+      return np.int32(2) * _event_size(
           event_shape, name=name or 'IndependentLogistic_params_size')
 
   def get_config(self):
@@ -1011,7 +1011,7 @@ class IndependentNormal(DistributionLambda):
     with tf.name_scope(name or 'IndependentNormal_params_size'):
       event_shape = tf.convert_to_tensor(
           event_shape, name='event_shape', dtype_hint=tf.int32)
-      return 2 * _event_size(
+      return np.int32(2) * _event_size(
           event_shape, name=name or 'IndependentNormal_params_size')
 
   def get_config(self):

--- a/tensorflow_probability/python/layers/distribution_layer.py
+++ b/tensorflow_probability/python/layers/distribution_layer.py
@@ -92,7 +92,7 @@ def _event_size(event_shape, name=None):
 
     event_shape_const = tf.get_static_value(event_shape)
     if event_shape_const is not None:
-      return np.prod(event_shape_const)
+      return np.prod(event_shape_const, dtype=np.int32)
     else:
       return tf.reduce_prod(event_shape)
 

--- a/tensorflow_probability/python/layers/distribution_layer_test.py
+++ b/tensorflow_probability/python/layers/distribution_layer_test.py
@@ -826,6 +826,7 @@ class _IndependentLayerTest(object):
   def test_layer(self):
     batch_shape = self._build_tensor([5, 5], dtype=np.int32)
     p = self.layer_class.params_size()
+    self.assertDTypeEqual(p, np.int32)
 
     low = self._build_tensor(-3.)
     high = self._build_tensor(3.)


### PR DESCRIPTION
Please check my pull request about #1080 .
I solved this problem and modified a test.

I always cast Python integer to numpy.int32 because the value of numpy.int32 will upcast with computing Python integer on the Linux.