### PR TITLE
Update jax to explicit version number on r0.11 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     ],
     keywords='tensorflow probability statistics bayesian machine learning',
     extras_require={  # e.g. `pip install tfp-nightly[jax]`
-        'jax': ['jax', 'jaxlib'],
+        'jax': ['jax==0.1.74', 'jaxlib==0.1.52'],
         'tfds': [TFDS_PACKAGE],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'numpy >= 1.13.3',
     'decorator',
-    'cloudpickle == 1.3',  # TODO(b/155109696): Unpin cloudpickle version.
+    'cloudpickle >= 1.3',
     'gast >= 0.3.2',  # For autobatching
     'dm-tree'  # For NumPy/JAX backends (hence, also for prefer_static)
 ]

--- a/tensorflow_probability/python/layers/BUILD
+++ b/tensorflow_probability/python/layers/BUILD
@@ -163,6 +163,7 @@ py_test(
     shard_count = 5,
     deps = [
         # numpy dep,
+        # six dep,
         # tensorflow dep,
         "//tensorflow_probability",
         "//tensorflow_probability/python/internal:test_util",

--- a/tensorflow_probability/python/layers/distribution_layer_test.py
+++ b/tensorflow_probability/python/layers/distribution_layer_test.py
@@ -21,6 +21,7 @@ import functools
 # Dependency imports
 
 import numpy as np
+import six
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
@@ -396,8 +397,7 @@ class DistributionLambdaSerializationTest(test_util.TestCase):
             lambda t: DistributionLambdaSerializationTest._make_distribution(t))
     ])
     model.compile(optimizer='adam', loss='mse')
-    # TODO(b/138375951): Re-enable this test.
-    # self.assertSerializable(model, batch_size=3)
+    self.assertSerializable(model, batch_size=3)
 
     model = tfk.Sequential([
         tfkl.Dense(15, input_shape=(5,)),
@@ -410,6 +410,10 @@ class DistributionLambdaSerializationTest(test_util.TestCase):
     self.assertExportable(model)
 
   def test_serialization_closure_over_lambdas_tensors_and_numpy_array(self):
+    if six.PY2 and not tf.executing_eagerly():
+      self.skipTest('Serialization of constant graph-mode Tensors is not '
+                    'supported under Python 2.')
+
     num_components = np.array(3)
     one = tf.convert_to_tensor(1)
     mk_ind_norm = lambda event_shape: tfpl.IndependentNormal(event_shape + one)

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -150,7 +150,7 @@ install_python_packages() {
   python -m pip install $PIP_FLAGS $TF_NIGHTLY_PACKAGE==$TF_VERSION_STR
 
   # For the JAX backend.
-  python -m pip install jax jaxlib
+  python -m pip install jax==0.1.74 jaxlib==0.1.52
 
   # The following unofficial dependencies are used only by tests.
   # TODO(b/148685448): Unpin Hypothesis and coverage versions.

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -157,7 +157,7 @@ install_python_packages() {
   python -m pip install $PIP_FLAGS hypothesis==3.56.5 coverage==4.4.2 matplotlib mock scipy
 
   # Install additional TFP dependencies.
-  python -m pip install $PIP_FLAGS decorator cloudpickle==1.3 dm-tree  # TODO(b/155109696): Unpin cloudpickle version.
+  python -m pip install $PIP_FLAGS decorator 'cloudpickle>=1.3' dm-tree
 
   # Upgrade numpy to the latest to address issues that happen when testing with
   # Python 3 (https://github.com/tensorflow/tensorflow/issues/16488).


### PR DESCRIPTION
PR also Includes cherrypick of past change to support later cloudpickle versions