### PR TITLE
add weights support for histogram

### DIFF
--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -399,7 +399,7 @@ def histogram(x,
           raise ValueError('Shape of `x` and `weights` have to coincide.  '
                            'Found: x.shape={} weights.shape={}'
                            ''.format(x.shape, weights.shape))
-        weights = _move_dims_to_flat_end(weights, axis, x_ndims,
+        weights = _move_dims_to_flat_end(weights, axis, weights_ndims,
                                          right_end=False)
 
     # bins.shape = x.shape = [n_samples] + E,

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -391,7 +391,7 @@ def histogram(x,
       if not axis:
         raise ValueError('`axis` cannot be empty.  Found: {}'.format(axis))
       x = _move_dims_to_flat_end(x, axis, x_ndims, right_end=False)
-    
+
       if weights is not None:
         weights_ndims = _get_static_ndims(
           x, expect_static=True, expect_ndims_at_least=1)

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -342,8 +342,8 @@ def histogram(x,
       `~axis = [i for i in range(arr.ndim) if i not in axis]`,
       `counts.shape = [edges.shape[0]] + x.shape[~axis]`.
       With `I` a multi-index into `~axis`, `counts[k][I]` is the number of times
-      event(s) fell into the `kth` interval of `edges` or with `weights` non-None
-      the sum of the weight(s) corresponding to the event(s) in a bin.
+      event(s) fell into the `kth` interval of `edges` or with `weights`
+      non-None the sum of the weight(s) corresponding to the event(s) in a bin.
 
   Raises:
     ValueError: if the shape of `x` and `weights` are not the same.

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -396,9 +396,10 @@ def histogram(x,
         weights_ndims = _get_static_ndims(
           x, expect_static=True, expect_ndims_at_least=1)
         if x_ndims != weights_ndims:
-          raise ValueError('Shape of `x` and `weights` have to coincide.  '
-                           'Found: x.shape={} weights.shape={}'
-                           ''.format(x.shape, weights.shape))
+          raise ValueError('Number of dimensions of `x` and `weights` '
+                           'have to coincide.  '
+                           'Found: x has {}, weights has {}'
+                           ''.format(x_ndims, weights_ndims))
         weights = _move_dims_to_flat_end(weights, axis, weights_ndims,
                                          right_end=False)
 

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -326,9 +326,9 @@ def histogram(x,
     axis:  Optional `0-D` or `1-D` integer `Tensor` with constant
       values. The axis in `x` that index iid samples.
       `Default value:` `None` (treat every dimension as sample dimension).
-    weights:  Optional `Tensor` of same `dtype` and `shape` as `x`. The weights
-      that specify the count of each value in `x`. If not given, it is
-      assumed to be one.
+    weights:  Optional `Tensor` of same `dtype` and `shape` as `x`.
+      For each value in `x`, the bin will be incremented by
+      the corresponding weight instead of 1.
     extend_lower_interval:  Python `bool`.  If `True`, extend the lowest
       interval `I0` to `(-inf, c1]`.
     extend_upper_interval:  Python `bool`.  If `True`, extend the upper

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -391,8 +391,8 @@ def histogram(x,
       if not axis:
         raise ValueError('`axis` cannot be empty.  Found: {}'.format(axis))
       x = _move_dims_to_flat_end(x, axis, x_ndims, right_end=False)
+    
       if weights is not None:
-
         weights_ndims = _get_static_ndims(
           x, expect_static=True, expect_ndims_at_least=1)
         if x_ndims != weights_ndims:

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -342,8 +342,11 @@ def histogram(x,
       `~axis = [i for i in range(arr.ndim) if i not in axis]`,
       `counts.shape = [edges.shape[0]] + x.shape[~axis]`.
       With `I` a multi-index into `~axis`, `counts[k][I]` is the number of times
-      event(s) fell into the `kth` interval of `edges` or, if weights are given,
-      the sum of the weight(s) corresponding to event(s) in a bin.
+      event(s) fell into the `kth` interval of `edges` or with `weights` non-None
+      the sum of the weight(s) corresponding to the event(s) in a bin.
+
+  Raises:
+    ValueError: if the shape of `x` and `weights` are not the same.
 
   #### Examples
 
@@ -393,7 +396,7 @@ def histogram(x,
         weights_ndims = _get_static_ndims(
           x, expect_static=True, expect_ndims_at_least=1)
         if x_ndims != weights_ndims:
-          raise ValueError('Dimensions of `x` and `weights` have to coincide.  '
+          raise ValueError('Shape of `x` and `weights` have to coincide.  '
                            'Found: x.shape={} weights.shape={}'
                            ''.format(x.shape, weights.shape))
         weights = _move_dims_to_flat_end(weights, axis, x_ndims,

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -298,6 +298,7 @@ def find_bins(x,
 def histogram(x,
               edges,
               axis=None,
+              weights=None,
               extend_lower_interval=False,
               extend_upper_interval=False,
               dtype=None,
@@ -325,6 +326,9 @@ def histogram(x,
     axis:  Optional `0-D` or `1-D` integer `Tensor` with constant
       values. The axis in `x` that index iid samples.
       `Default value:` `None` (treat every dimension as sample dimension).
+    weights:  Optional `Tensor` of same `dtype` and `shape` as `x`. The weights
+      that specify the count of each value in `x`. If not given, it is
+      assumed to be one.
     extend_lower_interval:  Python `bool`.  If `True`, extend the lowest
       interval `I0` to `(-inf, c1]`.
     extend_upper_interval:  Python `bool`.  If `True`, extend the upper
@@ -338,7 +342,8 @@ def histogram(x,
       `~axis = [i for i in range(arr.ndim) if i not in axis]`,
       `counts.shape = [edges.shape[0]] + x.shape[~axis]`.
       With `I` a multi-index into `~axis`, `counts[k][I]` is the number of times
-      event(s) fell into the `kth` interval of `edges`.
+      event(s) fell into the `kth` interval of `edges` or, if weights are given,
+      the sum of the weight(s) corresponding to event(s) in a bin.
 
   #### Examples
 
@@ -362,15 +367,20 @@ def histogram(x,
   with tf.name_scope(name or 'histogram'):
 
     # Tensor conversions.
-    in_dtype = dtype_util.common_dtype([x, edges], dtype_hint=tf.float32)
+    in_dtype = dtype_util.common_dtype([x, edges, weights],
+                                       dtype_hint=tf.float32)
 
     x = tf.convert_to_tensor(x, name='x', dtype=in_dtype)
     edges = tf.convert_to_tensor(edges, name='edges', dtype=in_dtype)
+    if weights is not None:
+      weights = tf.convert_to_tensor(weights, name='weights', dtype=in_dtype)
 
     # Move dims in axis to the left end as one flattened dim.
     # After this, x.shape = [n_samples] + E.
     if axis is None:
       x = tf.reshape(x, shape=[-1])
+      if weights is not None:
+        weights = tf.reshape(x, shape=[-1])
     else:
       x_ndims = _get_static_ndims(
           x, expect_static=True, expect_ndims_at_least=1)
@@ -378,6 +388,16 @@ def histogram(x,
       if not axis:
         raise ValueError('`axis` cannot be empty.  Found: {}'.format(axis))
       x = _move_dims_to_flat_end(x, axis, x_ndims, right_end=False)
+      if weights is not None:
+
+        weights_ndims = _get_static_ndims(
+          x, expect_static=True, expect_ndims_at_least=1)
+        if x_ndims != weights_ndims:
+          raise ValueError('Dimensions of `x` and `weights` have to coincide.  '
+                           'Found: x.shape={} weights.shape={}'
+                           ''.format(x.shape, weights.shape))
+        weights = _move_dims_to_flat_end(weights, axis, x_ndims,
+                                         right_end=False)
 
     # bins.shape = x.shape = [n_samples] + E,
     # and bins[i] is a shape E Tensor of the bins that sample `i` fell into.
@@ -394,6 +414,7 @@ def histogram(x,
     # TODO(b/124015136) Use standard tf.math.bincount once it supports `axis`.
     counts = count_integers(
         bins,
+        weights=weights,
         # Ensure we get correct output, even if x did not fall into every bin
         minlength=tf.shape(edges)[0] - 1,
         maxlength=tf.shape(edges)[0] - 1,

--- a/tensorflow_probability/python/stats/quantiles.py
+++ b/tensorflow_probability/python/stats/quantiles.py
@@ -14,15 +14,21 @@
 # ============================================================================
 """Functions for computing statistics of samples."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 # Dependency imports
 import numpy as np
 import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import prefer_static as ps
+from tensorflow_probability.python.internal import tensorshape_util
 from tensorflow.python.util import deprecation  # pylint: disable=g-direct-tensorflow-import
 
-from tensorflow_probability.python.internal import assert_util, distribution_util, dtype_util, prefer_static as ps, \
-  tensorshape_util
 
 __all__ = [
     'count_integers',
@@ -320,9 +326,7 @@ def histogram(x,
     axis:  Optional `0-D` or `1-D` integer `Tensor` with constant
       values. The axis in `x` that index iid samples.
       `Default value:` `None` (treat every dimension as sample dimension).
-    weights:  Optional `Tensor` of same `dtype` as `x`. Will be flattened
-      and corresponds in shape to the histogram axes. Product of
-      `x.shape[axis]` has to be equal to the size of the flattened weights.
+    weights:  Optional `Tensor` of same `dtype` and `shape` as `x`.
       For each value in `x`, the bin will be incremented by
       the corresponding weight instead of 1.
     extend_lower_interval:  Python `bool`.  If `True`, extend the lowest
@@ -374,14 +378,12 @@ def histogram(x,
     if weights is not None:
       weights = tf.convert_to_tensor(weights, name='weights', dtype=in_dtype)
 
-      # flatten weights as they correspond to n_samples
-      weights = tf.reshape(weights, shape=[-1])
-
     # Move dims in axis to the left end as one flattened dim.
     # After this, x.shape = [n_samples] + E.
     if axis is None:
       x = tf.reshape(x, shape=[-1])
-      # TODO: check if weights shape does match x shape (dynamic)?
+      if weights is not None:
+        weights = tf.reshape(weights, shape=[-1])
     else:
       x_ndims = _get_static_ndims(
           x, expect_static=True, expect_ndims_at_least=1)
@@ -389,13 +391,16 @@ def histogram(x,
       if not axis:
         raise ValueError('`axis` cannot be empty.  Found: {}'.format(axis))
       x = _move_dims_to_flat_end(x, axis, x_ndims, right_end=False)
+      if weights is not None:
 
-      if weights is not None and (tf.compat.dimension_value(x.shape[0]) !=
-                                  tf.compat.dimension_value(weights.shape[0])):
-        raise ValueError('Size of  `x` dimensions specified with `axis` '
-                         'and `weights` have to coincide.  '
-                         'Found: x.shape={} weights.shape={}'
-                         ''.format(x.shape, weights.shape))
+        weights_ndims = _get_static_ndims(
+          x, expect_static=True, expect_ndims_at_least=1)
+        if x_ndims != weights_ndims:
+          raise ValueError('Shape of `x` and `weights` have to coincide.  '
+                           'Found: x.shape={} weights.shape={}'
+                           ''.format(x.shape, weights.shape))
+        weights = _move_dims_to_flat_end(weights, axis, x_ndims,
+                                         right_end=False)
 
     # bins.shape = x.shape = [n_samples] + E,
     # and bins[i] is a shape E Tensor of the bins that sample `i` fell into.

--- a/tensorflow_probability/python/stats/quantiles_test.py
+++ b/tensorflow_probability/python/stats/quantiles_test.py
@@ -14,16 +14,14 @@
 # ============================================================================
 """Tests for quantiles.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 # Dependency imports
 import numpy as np
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
-import tensorflow_probability as tfp
 
+import tensorflow_probability as tfp
 from tensorflow_probability.python.internal import test_util
 
 
@@ -277,6 +275,52 @@ class HistogramTest(test_util.TestCase):
         # which is approximately Sqrt[1 / (p * N)].  Bound by 4 times this,
         # which means an unseeded test fails with probability 3e-5.
         rtol=4 / np.sqrt(0.25 * n_samples))
+
+  def test_2d_uniform_reduce_axis_0_yes_weights(self):
+    n_samples = 1000
+
+    # Shape [n_samples, 2]
+    x = np.stack([np.random.rand(n_samples), 1 + np.random.rand(n_samples)],
+                 axis=-1)
+    weights = np.stack([np.random.rand(n_samples), np.random.rand(n_samples)],
+                       axis=-1)
+
+    # Intervals are:
+    edges = np.float64([-1., 0., 0.5, 1.0, 1.5, 2.0, 2.5])
+
+    counts = tfp.stats.histogram(x, edges=edges, axis=0)
+
+    self.assertAllEqual((6, 2), counts.shape)
+    self.assertDTypeEqual(counts, np.float64)
+
+    # x[:, 0] ~ Uniform(0, 1)
+    event_0_expected_counts = [
+        #     [-1, 0)          [0, 0.5)         [0.5, 1)
+        0.0 * n_samples, 0.5 * n_samples, 0.5 * n_samples,
+        #     [1, 1.5)         [1.5, 2)         [2, 2.5]
+        0.0 * n_samples, 0.0 * n_samples, 0.0 * n_samples,
+    ]
+
+    # x[:, 1] ~ Uniform(1, 2)
+    event_1_expected_counts = [
+        #     [-1, 0)          [0, 0.5)         [0.5, 1)
+        0.0 * n_samples, 0.0 * n_samples, 0.0 * n_samples,
+        #     [1, 1.5)         [1.5, 2)         [2, 2.5]
+        0.5 * n_samples, 0.5 * n_samples, 0.0 * n_samples,
+    ]
+
+    expected_counts = np.stack([event_0_expected_counts,
+                                event_1_expected_counts], axis=-1)
+
+    self.assertAllClose(
+        expected_counts,
+        self.evaluate(counts),
+        # Standard error for each count is Sqrt[p * (1 - p) / (p * N)],
+        # which is approximately Sqrt[1 / (p * N)].  Bound by 4 times this,
+        # which means an unseeded test fails with probability 3e-5.
+        rtol=4 / np.sqrt(0.25 * n_samples))
+
+
 
   def test_2d_uniform_reduce_axis_1_and_change_dtype(self):
     n_samples = 1000

--- a/tensorflow_probability/python/stats/quantiles_test.py
+++ b/tensorflow_probability/python/stats/quantiles_test.py
@@ -312,7 +312,8 @@ class HistogramTest(test_util.TestCase):
     # scale the expected counts by the average weight
     expected_counts = np.stack([event_0_expected_counts,
                                 event_1_expected_counts],
-                               axis=-1) * np.mean(weights, axis=0, keepdims=True)
+                               axis=-1) * np.mean(weights, axis=0,
+                                                  keepdims=True)
 
     self.assertAllClose(
         expected_counts,

--- a/tensorflow_probability/python/stats/quantiles_test.py
+++ b/tensorflow_probability/python/stats/quantiles_test.py
@@ -14,14 +14,16 @@
 # ============================================================================
 """Tests for quantiles.py."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 # Dependency imports
 import numpy as np
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
-
 import tensorflow_probability as tfp
+
 from tensorflow_probability.python.internal import test_util
 
 

--- a/tensorflow_probability/python/stats/quantiles_test.py
+++ b/tensorflow_probability/python/stats/quantiles_test.py
@@ -282,13 +282,13 @@ class HistogramTest(test_util.TestCase):
     # Shape [n_samples, 2]
     x = np.stack([np.random.rand(n_samples), 1 + np.random.rand(n_samples)],
                  axis=-1)
-    weights = np.stack([np.random.rand(n_samples), np.random.rand(n_samples)],
-                       axis=-1)
+    weights = np.stack([np.random.uniform(size=n_samples),
+                        2 + np.random.uniform(size=n_samples)], axis=-1)
 
     # Intervals are:
     edges = np.float64([-1., 0., 0.5, 1.0, 1.5, 2.0, 2.5])
 
-    counts = tfp.stats.histogram(x, edges=edges, axis=0)
+    counts = tfp.stats.histogram(x, edges=edges, axis=0, weights=weights)
 
     self.assertAllEqual((6, 2), counts.shape)
     self.assertDTypeEqual(counts, np.float64)
@@ -309,8 +309,10 @@ class HistogramTest(test_util.TestCase):
         0.5 * n_samples, 0.5 * n_samples, 0.0 * n_samples,
     ]
 
+    # scale the expected counts by the average weight
     expected_counts = np.stack([event_0_expected_counts,
-                                event_1_expected_counts], axis=-1)
+                                event_1_expected_counts],
+                               axis=-1) * np.mean(weights, axis=0, keepdims=True)
 
     self.assertAllClose(
         expected_counts,


### PR DESCRIPTION
Add weights support for the `stats.histogram` function. This is a crucial feature for zfit, a likelihood model fitting library for High Energy Physics, as there are always weights involved.

Since weights are supported already in the internally used `count_integer` and basically just needs to be passed through.

The requirement and behavior of the `weights` is equivalent to `count_integers`.

TODO:

- [ ] Approve changes by TFP
- [ ] Explicitly fail if dynamic shapes don't match?
- [x] Add unittest
- [x] Update Docstring