### PR TITLE
changes to rethinking.quap.py

### DIFF
--- a/tensorflow_probability/examples/statistical_rethinking/rethinking/quap.py
+++ b/tensorflow_probability/examples/statistical_rethinking/rethinking/quap.py
@@ -55,7 +55,7 @@ def quap(joint_dist, data=None, max_tries=20, initial_position=None, name=None):
     joint_dist: A `JointDistributionNamed` or `JointDistributionSequential`
       model. Also works with auto batched versions of the same.
     data: Optional `dict` of data to condition the joint_dist with. The return
-      value will be conditioned o this data. If this is `None`, the return
+      value will be conditioned on this data. If this is `None`, the return
       value will be a quadratic approximation to the distribution itself.
     max_tries: Optional `int` of number of times to run the optimizer internally
       before raising a `RuntimeError`. Default is 20.

--- a/tensorflow_probability/examples/statistical_rethinking/rethinking/quap.py
+++ b/tensorflow_probability/examples/statistical_rethinking/rethinking/quap.py
@@ -58,7 +58,7 @@ def quap(joint_dist, data=None, max_tries=20, initial_position=None, name=None):
       value will be conditioned o this data. If this is `None`, the return
       value will be a quadratic approximation to the distribution itself.
     max_tries: Optional `int` of number of times to run the optimizer internally
-      before raising a `RuntimeError`. Default is 10.
+      before raising a `RuntimeError`. Default is 20.
     initial_position: Optional `dict` to initialize the optimizer. Keys should
       correspond to names in the JointDistribution. Defaults to random draws
       from `joint_dist`.

--- a/tensorflow_probability/examples/statistical_rethinking/rethinking/quap.py
+++ b/tensorflow_probability/examples/statistical_rethinking/rethinking/quap.py
@@ -59,7 +59,7 @@ def quap(joint_dist, data=None, max_tries=20, initial_position=None, name=None):
       value will be a quadratic approximation to the distribution itself.
     max_tries: Optional `int` of number of times to run the optimizer internally
       before raising a `RuntimeError`. Default is 10.
-      initial_position: Optional `dict` to initialize the optimizer. Keys should
+    initial_position: Optional `dict` to initialize the optimizer. Keys should
       correspond to names in the JointDistribution. Defaults to random draws
       from `joint_dist`.
     name: Python `str` name prefixed to ops created by this function.

--- a/tensorflow_probability/examples/statistical_rethinking/rethinking/quap_test.py
+++ b/tensorflow_probability/examples/statistical_rethinking/rethinking/quap_test.py
@@ -111,7 +111,8 @@ class QuapTestJDNamedTuple(test_util.TestCase):
 
     approx = rethinking.quap(model,
                              data=ModelSpec(a=None, b=2.),
-                             initial_position=ModelSpec(a=1.5, b=None))
+                             initial_position=ModelSpec(a=1.5, b=None),
+                             max_tries=10)
 
     dists, _ = approx.sample_distributions()
     # See, e.g., Bishop, equation 2.116


### PR DESCRIPTION
Hello, as per https://github.com/tensorflow/probability/issues/1161 I had a look at the `quap` function. I've added a few noddy changes to it, I hope that it's helpful and not annoying (if the latter please let me know and I will change back).

@ColCarroll is there anything in particular you would like me to attempt to improve in the `quap` function further? I've updated my version of `find_map` (gist here: https://gist.github.com/jeffpollock9/0cc298641722277cf30e438f04eb8609) so please let me know if there is anything you'd like to take. I wasn't sure the best way to change `quap` to use this stuff without changing the API, which I would prefer not to do unless someone else is happy with that.