### PR TITLE
Remove local rademachers

### DIFF
--- a/tensorflow_probability/python/layers/conv_variational.py
+++ b/tensorflow_probability/python/layers/conv_variational.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import tensorflow.compat.v2 as tf
 
+from tensorflow_probability.python import random as tfp_random
 from tensorflow_probability.python.distributions import independent as independent_lib
 from tensorflow_probability.python.distributions import kullback_leibler as kl_lib
 from tensorflow_probability.python.distributions import normal as normal_lib
@@ -1084,18 +1085,12 @@ class _ConvFlipout(_ConvVariational):
 
     seed_stream = SeedStream(self.seed, salt='ConvFlipout')
 
-    def random_rademacher(shape, dtype=tf.float32, seed=None):
-      int_dtype = tf.int64 if tf.as_dtype(dtype) != tf.int32 else tf.int32
-      random_bernoulli = tf.random.uniform(
-          shape, minval=0, maxval=2, dtype=int_dtype, seed=seed)
-      return tf.cast(2 * random_bernoulli - 1, dtype)
-
-    sign_input = random_rademacher(
+    sign_input = tfp_random.rademacher(
         tf.concat([batch_shape,
                    tf.expand_dims(channels, 0)], 0),
         dtype=inputs.dtype,
         seed=seed_stream())
-    sign_output = random_rademacher(
+    sign_output = tfp_random.rademacher(
         tf.concat([batch_shape,
                    tf.expand_dims(self.filters, 0)], 0),
         dtype=inputs.dtype,

--- a/tensorflow_probability/python/layers/conv_variational_test.py
+++ b/tensorflow_probability/python/layers/conv_variational_test.py
@@ -455,20 +455,14 @@ class ConvVariational(object):
 
       seed_stream = tfp.util.SeedStream(layer.seed, salt='ConvFlipout')
 
-      sign_input = tf.random.uniform(
+      sign_input = tfp.random.rademacher(
           tf.concat([batch_shape, tf.expand_dims(channels, 0)], 0),
-          minval=0,
-          maxval=2,
-          dtype=tf.int64,
+          dtype=inputs.dtype,
           seed=seed_stream())
-      sign_input = tf.cast(2 * sign_input - 1, inputs.dtype)
-      sign_output = tf.random.uniform(
+      sign_output = tfp.random.rademacher(
           tf.concat([batch_shape, tf.expand_dims(filters, 0)], 0),
-          minval=0,
-          maxval=2,
-          dtype=tf.int64,
+          dtype=inputs.dtype,
           seed=seed_stream())
-      sign_output = tf.cast(2 * sign_output - 1, inputs.dtype)
 
       if self.data_format == 'channels_first':
         for _ in range(rank):

--- a/tensorflow_probability/python/layers/dense_variational.py
+++ b/tensorflow_probability/python/layers/dense_variational.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import tensorflow.compat.v2 as tf
 
+from tensorflow_probability.python import random as tfp_random
 from tensorflow_probability.python.distributions import independent as independent_lib
 from tensorflow_probability.python.distributions import kullback_leibler as kl_lib
 from tensorflow_probability.python.distributions import normal as normal_lib
@@ -687,17 +688,11 @@ class DenseFlipout(_DenseVariational):
 
     seed_stream = SeedStream(self.seed, salt='DenseFlipout')
 
-    def random_rademacher(shape, dtype=tf.float32, seed=None):
-      int_dtype = tf.int64 if tf.as_dtype(dtype) != tf.int32 else tf.int32
-      random_bernoulli = tf.random.uniform(
-          shape, minval=0, maxval=2, dtype=int_dtype, seed=seed)
-      return tf.cast(2 * random_bernoulli - 1, dtype)
-
-    sign_input = random_rademacher(
+    sign_input = tfp_random.rademacher(
         input_shape,
         dtype=inputs.dtype,
         seed=seed_stream())
-    sign_output = random_rademacher(
+    sign_output = tfp_random.rademacher(
         tf.concat([batch_shape,
                    tf.expand_dims(self.units, 0)], 0),
         dtype=inputs.dtype,

--- a/tensorflow_probability/python/layers/dense_variational_test.py
+++ b/tensorflow_probability/python/layers/dense_variational_test.py
@@ -390,20 +390,16 @@ class DenseVariational(test_util.TestCase):
       expected_kernel_posterior_affine_tensor = (
           expected_kernel_posterior_affine.sample(seed=42))
 
-      stream = tfp.util.SeedStream(layer.seed, salt='DenseFlipout')
+      seed_stream = tfp.util.SeedStream(layer.seed, salt='DenseFlipout')
 
-      sign_input = tf.random.uniform([batch_size, in_size],
-                                     minval=0,
-                                     maxval=2,
-                                     dtype=tf.int64,
-                                     seed=stream())
-      sign_input = tf.cast(2 * sign_input - 1, inputs.dtype)
-      sign_output = tf.random.uniform([batch_size, out_size],
-                                      minval=0,
-                                      maxval=2,
-                                      dtype=tf.int64,
-                                      seed=stream())
-      sign_output = tf.cast(2 * sign_output - 1, inputs.dtype)
+      sign_input = tfp.random.rademacher(
+        [batch_size, in_size],
+        dtype=inputs.dtype,
+        seed=seed_stream())
+      sign_output = tfp.random.rademacher(
+        [batch_size, out_size],
+        dtype=inputs.dtype,
+        seed=seed_stream())
       perturbed_inputs = tf.matmul(
           inputs * sign_input, expected_kernel_posterior_affine_tensor)
       perturbed_inputs *= sign_output


### PR DESCRIPTION
I noticed that `{dense,conv}_variational.py` modules were using local rademacher functions. Rademacher is now available at `tfp.random.rademacher`, so I thought it would be nice to have the variational layers use that instead of local ones.