### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_probability/examples/latent_dirichlet_allocation_distributions.py
+++ b/tensorflow_probability/examples/latent_dirichlet_allocation_distributions.py
@@ -248,7 +248,7 @@ def make_prior(num_topics, initial_value):
 def model_fn(features, labels, mode, params, config):
   """Build the model function for use in an estimator.
 
-  Arguments:
+  Args:
     features: The input features for the estimator.
     labels: The labels, unused here.
     mode: Signifies whether it is train or test or predict.
@@ -353,7 +353,7 @@ def get_topics_strings(topics_words, alpha, vocabulary,
                        topics_to_print=10, words_per_topic=10):
   """Returns the summary of the learned topics.
 
-  Arguments:
+  Args:
     topics_words: KxV tensor with topics as rows and words as columns.
     alpha: 1xK tensor of prior Dirichlet concentrations for the
         topics.
@@ -464,7 +464,7 @@ def build_input_fns(data_dir, batch_size):
 
   Each object is represented as a bag-of-words vector.
 
-  Arguments:
+  Args:
     data_dir: Folder in which to store the data.
     batch_size: Batch size for both train and evaluation.
   Returns:

--- a/tensorflow_probability/examples/vae.py
+++ b/tensorflow_probability/examples/vae.py
@@ -325,7 +325,7 @@ def image_tile_summary(name, tensor, rows=8, cols=8):
 def model_fn(features, labels, mode, params, config):
   """Builds the model function for use in an estimator.
 
-  Arguments:
+  Args:
     features: The input features for the estimator.
     labels: The labels, unused here.
     mode: Signifies whether it is train or test or predict.

--- a/tensorflow_probability/python/bijectors/composition.py
+++ b/tensorflow_probability/python/bijectors/composition.py
@@ -293,7 +293,7 @@ class Composition(bijector.Bijector):
     The `_walk_{direction}` methods define how arguments are routed through
     nested bijectors, expressing the directed topology of the underlying graph.
 
-    Arguments:
+    Args:
       step_fn: A method taking a bijector, a single positional argument
         matching `bijector.forward_min_event_ndims`, and arbitrary **kwargs,
         and returning a structure matching `bijector.inverse_min_event_ndims`.
@@ -312,7 +312,7 @@ class Composition(bijector.Bijector):
     The `_walk_{direction}` methods define how arguments are routed through
     nested bijectors, expressing the directed topology of the underlying graph.
 
-    Arguments:
+    Args:
       step_fn: A method taking a bijector, a single positional argument
         matching `bijector.inverse_min_event_ndims`, and arbitrary **kwargs,
         and returning a structure matching `bijector.forward_min_event_ndims`.

--- a/tensorflow_probability/python/bijectors/masked_autoregressive.py
+++ b/tensorflow_probability/python/bijectors/masked_autoregressive.py
@@ -435,7 +435,7 @@ def masked_dense(inputs,
 
   See [Germain et al. (2015)][1] for detailed explanation.
 
-  Arguments:
+  Args:
     inputs: Tensor input.
     units: Python `int` scalar representing the dimensionality of the output
       space.
@@ -894,7 +894,7 @@ class AutoregressiveNetwork(tf.keras.layers.Layer):
                **kwargs):
     """Constructs the MADE layer.
 
-    Arguments:
+    Args:
       params: Python integer specifying the number of parameters to output
         per input.
       event_shape: Python `list`-like of positive integers (or a single int),

--- a/tensorflow_probability/python/bijectors/real_nvp.py
+++ b/tensorflow_probability/python/bijectors/real_nvp.py
@@ -344,7 +344,7 @@ def real_nvp_default_template(hidden_layers,
   Real NVP bijector, implement a conditioned shift/scale template that
   handles the `condition_kwargs`.
 
-  Arguments:
+  Args:
     hidden_layers: Python `list`-like of non-negative integer, scalars
       indicating the number of units in each hidden layer. Default: `[512,
         512]`.

--- a/tensorflow_probability/python/distributions/mixture_same_family.py
+++ b/tensorflow_probability/python/distributions/mixture_same_family.py
@@ -453,7 +453,7 @@ class MixtureSameFamily(distribution.Distribution):
       3. Distributional transform currently only works for known rank of the
         batch tensor.
 
-    Arguments:
+    Args:
       x: Sample of mixture distribution
       event_shape: The event shape of this distribution
 
@@ -512,7 +512,7 @@ class MixtureSameFamily(distribution.Distribution):
       w_i^k = w_k prob_k(x_1, ..., x_i-1) / sum_k' w_k' prob_k'(x_1, ..., x_i-1)
     and w_0^k = w_k is the mixture probability of the k-th component.
 
-    Arguments:
+    Args:
       x: Sample of mixture distribution
       event_shape: The event shape of this distribution
 
@@ -682,7 +682,7 @@ def _prevent_2nd_derivative(x):
   NB: you need to apply a non-identity function to the output tensor for the
   exception to be raised.
 
-  Arguments:
+  Args:
     x: A tensor.
 
   Returns:

--- a/tensorflow_probability/python/distributions/von_mises.py
+++ b/tensorflow_probability/python/distributions/von_mises.py
@@ -371,7 +371,7 @@ def von_mises_cdf(x, concentration):
   using automatic differentiation. We use forward mode for the series case
   (which allows to save memory) and backward mode for the Normal approximation.
 
-  Arguments:
+  Args:
     x: The point at which to evaluate the CDF.
     concentration: The concentration parameter of the von Mises distribution.
 
@@ -498,7 +498,7 @@ def _von_mises_cdf_normal(x, concentration, dtype):
 def _von_mises_sample_no_gradient(shape, concentration, seed):
   """Performs rejection sampling for standardized von Mises.
 
-  Arguments:
+  Args:
     shape: The output sample shape.
     concentration: The concentration parameter of the distribution.
     seed: The random seed.
@@ -641,7 +641,7 @@ def _von_mises_sample_jvp(shape, primals, tangents):
 def _von_mises_sample_with_gradient(shape, concentration, seed):
   """Performs rejection sampling for standardized von Mises.
 
-  Arguments:
+  Args:
     shape: The output sample shape.
     concentration: The concentration parameter of the distribution.
     seed: (optional) The random seed.
@@ -662,7 +662,7 @@ def random_von_mises(shape, concentration, dtype=tf.float32, seed=None):
   The sampling algorithm is rejection sampling with wrapped Cauchy proposal [1].
   The samples are pathwise differentiable using the approach of [2].
 
-  Arguments:
+  Args:
     shape: The output sample shape.
     concentration: The concentration parameter of the von Mises distribution.
     dtype: The data type of concentration and the outputs.

--- a/tensorflow_probability/python/distributions/zipf.py
+++ b/tensorflow_probability/python/distributions/zipf.py
@@ -353,7 +353,7 @@ class Zipf(distribution.Distribution):
     pmf. This function implements `hat` integral: H(x) = int_x^inf h(t) dt;
     which is needed for sampling purposes.
 
-    Arguments:
+    Args:
       x: A Tensor of points x at which to evaluate H(x).
       power: Power that parameterized hat function.
 

--- a/tensorflow_probability/python/experimental/lazybones/utils/weak_container.py
+++ b/tensorflow_probability/python/experimental/lazybones/utils/weak_container.py
@@ -114,7 +114,7 @@ class HashableWeakRef(weakref.ref):
   def __init__(self, referrent, callback=None):
     """weakref.ref which makes any object hashable.
 
-    Arguments:
+    Args:
       referrent: Object that is being referred to.
       callback: Optional callback to invoke when object is GCed.
     """

--- a/tensorflow_probability/python/internal/backend/numpy/gen/tensor_shape.py
+++ b/tensorflow_probability/python/internal/backend/numpy/gen/tensor_shape.py
@@ -143,7 +143,7 @@ def dimension_value(dimension):
   value = tensor_shape[i]  # Warning: this will return the dim value in V2!
   ```
 
-  Arguments:
+  Args:
     dimension: Either a `Dimension` instance, an integer, or None.
 
   Returns:
@@ -189,7 +189,7 @@ def dimension_at_index(shape, index):
   # instantiated on the fly.
   ```
 
-  Arguments:
+  Args:
     shape: A TensorShape instance.
     index: An integer index.
 

--- a/tensorflow_probability/python/internal/cache_util.py
+++ b/tensorflow_probability/python/internal/cache_util.py
@@ -91,7 +91,7 @@ class HashableWeakRef(weakref.ref):
   def __init__(self, referrent, callback=None):
     """weakref.ref which makes tf.Tensor and np.array objects hashable.
 
-    Arguments:
+    Args:
       referrent: Object that is being referred to.
       callback: Optional callback to invoke when object is GCed.
     """
@@ -327,7 +327,7 @@ class BijectorCache(object):
   def forward(self, x, **kwargs):
     """Invokes the 'forward' transformation, or looks up previous results.
 
-    Arguments:
+    Args:
       x: The singular argument passed to `bijector._forward`.
       **kwargs: Any auxiliary arguments passed to the function.
         These reflect shared context to the function, and are associated
@@ -340,7 +340,7 @@ class BijectorCache(object):
   def inverse(self, y, **kwargs):
     """Invokes the 'inverse' transformation, or looks up previous results.
 
-    Arguments:
+    Args:
       y: The singular argument passed to `bijector._inverse`.
       **kwargs: Any auxiliary arguments passed to the function.
         These reflect shared context to the function, and are associated
@@ -431,7 +431,7 @@ class BijectorCache(object):
             == 0)
     ```
 
-    Arguments:
+    Args:
       input: The singular ordered argument passed to the wrapped function.
       fn_name: `str`, name of the directed function to which `input` is an arg
         (typically `'_forward'` or `'_inverse'`).
@@ -469,7 +469,7 @@ class BijectorCache(object):
     assert cache.inverse._lookup(y, '_inverse', '_forward') == (x, attrs)
     ```
 
-    Arguments:
+    Args:
       input: The singular ordered argument passed to the wrapped function.
       forward_name: `str`, the name of the function implementing the bijector's
         forward transformation (typically `'_forward'`).

--- a/tensorflow_probability/python/internal/prefer_static.py
+++ b/tensorflow_probability/python/internal/prefer_static.py
@@ -205,7 +205,7 @@ def broadcast_shape(x_shape, y_shape):
   computed statically and returned as a `TensorShape`.  Otherwise, a rank-1
   `Tensor` will be returned.
 
-  Arguments:
+  Args:
     x_shape: A `TensorShape` or rank-1 integer `Tensor`.  The input `Tensor` is
       broadcast against this shape.
     y_shape: A `TensorShape` or rank-1 integer `Tensor`.  The input `Tensor` is
@@ -230,7 +230,7 @@ def cond(pred, true_fn=None, false_fn=None, name=None):
   If `pred` is a bool or has a constant value, we return either `true_fn()`
   or `false_fn()`, otherwise we use `tf.cond` to dynamically route to both.
 
-  Arguments:
+  Args:
     pred: A scalar determining whether to return the result of `true_fn` or
       `false_fn`.
     true_fn: The callable to be performed if pred is true.

--- a/tensorflow_probability/python/internal/test_combinations.py
+++ b/tensorflow_probability/python/internal/test_combinations.py
@@ -78,7 +78,7 @@ class TestCombination(object):
     If the environment doesn't satisfy the dependencies of the test
     combination, then it can be skipped.
 
-    Arguments:
+    Args:
       kwargs:  Arguments that are passed to the test combination.
 
     Returns:
@@ -100,7 +100,7 @@ class TestCombination(object):
     The test combination will run under all context managers that all
     `TestCombination` instances return.
 
-    Arguments:
+    Args:
       kwargs:  Arguments and their values that are passed to the test
         combination.
 
@@ -119,7 +119,7 @@ class ParameterModifier(object):
   def __init__(self, parameter_name=None):
     """Construct a parameter modifier that may be specific to a parameter.
 
-    Arguments:
+    Args:
       parameter_name:  A `ParameterModifier` instance may operate on a class of
         parameters or on a parameter with a particular name.  Only
         `ParameterModifier` instances that are of a unique type or were
@@ -135,7 +135,7 @@ class ParameterModifier(object):
     This makes it possible to adjust user-provided arguments before passing
     them to the test method.
 
-    Arguments:
+    Args:
       kwargs:  The combined arguments for the test.
       requested_parameters: The set of parameters that are defined in the
         signature of the test method.

--- a/tensorflow_probability/python/layers/dense_variational_v2.py
+++ b/tensorflow_probability/python/layers/dense_variational_v2.py
@@ -53,7 +53,7 @@ class DenseVariational(tf.keras.layers.Layer):
                **kwargs):
     """Creates the `DenseVariational` layer.
 
-    Arguments:
+    Args:
       units: Positive integer, dimensionality of the output space.
       make_posterior_fn: Python callable taking `tf.size(kernel)`,
         `tf.size(bias)`, `dtype` and returns another callable which takes an

--- a/tensorflow_probability/python/layers/distribution_layer.py
+++ b/tensorflow_probability/python/layers/distribution_layer.py
@@ -1490,7 +1490,7 @@ class MixtureSameFamily(DistributionLambda):
   def params_size(num_components, component_params_size, name=None):
     """Number of `params` needed to create a `MixtureSameFamily` distribution.
 
-    Arguments:
+    Args:
       num_components: Number of component distributions in the mixture
         distribution.
       component_params_size: Number of parameters needed to create a single

--- a/tensorflow_probability/python/layers/distribution_layer_test.py
+++ b/tensorflow_probability/python/layers/distribution_layer_test.py
@@ -320,7 +320,7 @@ class DistributionLambdaSerializationTest(test_util.TestCase):
   def assertSerializable(self, model, batch_size=1):
     """Assert that a model can be saved/loaded via Keras Model.save/load_model.
 
-    Arguments:
+    Args:
       model: A Keras model that outputs a `tfd.Distribution`.
       batch_size: The batch size to use when checking that the model produces
         the same results as a serialized/deserialized copy.  Default value: 1.
@@ -348,7 +348,7 @@ class DistributionLambdaSerializationTest(test_util.TestCase):
   def assertExportable(self, model, batch_size=1):
     """Assert a Keras model supports export_saved_model/load_from_saved_model.
 
-    Arguments:
+    Args:
       model: A Keras model with Tensor output.
       batch_size: The batch size to use when checking that the model produces
         the same results as a serialized/deserialized copy.  Default value: 1.

--- a/tensorflow_probability/python/layers/initializers.py
+++ b/tensorflow_probability/python/layers/initializers.py
@@ -30,7 +30,7 @@ class BlockwiseInitializer(tf.keras.initializers.Initializer):
   def __init__(self, initializers, sizes, validate_args=False):
     """Creates the `BlockwiseInitializer`.
 
-    Arguments:
+    Args:
       initializers: `list` of Keras initializers, e.g., `"glorot_uniform"` or
         `tf.keras.initializers.Constant(0.5413)`.
       sizes: `list` of `int` scalars representing the number of elements

--- a/tensorflow_probability/python/layers/masked_autoregressive.py
+++ b/tensorflow_probability/python/layers/masked_autoregressive.py
@@ -123,7 +123,7 @@ class AutoregressiveTransform(DistributionLambda):
   def __init__(self, made, **kwargs):
     """Constructs the AutoregressiveTransform layer.
 
-    Arguments:
+    Args:
       made: A `Made` layer, which must output two parameters for each input.
       **kwargs: Additional keyword arguments passed to `tf.keras.Layer`.
     """

--- a/tensorflow_probability/python/layers/variable_input.py
+++ b/tensorflow_probability/python/layers/variable_input.py
@@ -83,7 +83,7 @@ class VariableLayer(tf.keras.layers.Layer):
                **kwargs):
     """Creates the `VariableLayer`.
 
-    Arguments:
+    Args:
       shape: integer or integer vector specifying the shape of the output of
         this layer.
       dtype: TensorFlow `dtype` of the variable created by this layer.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420