### PR TITLE
Add missing dtype in `diagonal_mass_matrix_adaptation`

### DIFF
--- a/tensorflow_probability/python/experimental/mcmc/diagonal_mass_matrix_adaptation.py
+++ b/tensorflow_probability/python/experimental/mcmc/diagonal_mass_matrix_adaptation.py
@@ -293,7 +293,8 @@ def _make_momentum_distribution(running_variance_parts, state_parts,
     running_variance_rank = ps.rank(variance_part)
     state_rank = ps.rank(state_part)
     # Pad dimensions and tile by multiplying by tf.ones to add a batch shape
-    ones = tf.ones(ps.shape(state_part)[:-(state_rank - running_variance_rank)])
+    ones = tf.ones(ps.shape(state_part)[:-(state_rank - running_variance_rank)],
+                   dtype=variance_part.dtype)
     ones = bu.left_justified_expand_dims_like(ones, state_part)
     variance_tiled = variance_part * ones
     reinterpreted_batch_ndims = state_rank - batch_ndims - 1


### PR DESCRIPTION
Currently, `tf.experimental.mcmc.DiagonalMassMatrixAdaptation` will not work with float64 variance and state parts.  This is because a `tf.ones` tensor is constructed without an explicit `dtype` in `_make_momentum_distribution`.  Here's a simple suggested fix. 