### PR TITLE
Updated ExpGamma formula to be correct

### DIFF
--- a/tensorflow_probability/python/distributions/exp_gamma.py
+++ b/tensorflow_probability/python/distributions/exp_gamma.py
@@ -59,7 +59,7 @@ class ExpGamma(distribution.Distribution):
   `tfb.Log()(tfd.Gamma(..))`):
 
   ```none
-  pdf(x; alpha, beta > 0) = exp(x)**(alpha - 1) exp(-exp(x) beta) / Z + x
+  pdf(x; alpha, beta > 0) = exp(x)**(alpha) exp(-exp(x) beta) / Z
   Z = Gamma(alpha) beta**(-alpha)
   ```
 
@@ -302,7 +302,7 @@ class ExpInverseGamma(transformed_distribution.TransformedDistribution):
   The probability density function (pdf) is very similar to ExpGamma,
 
   ```none
-  pdf(x; alpha, beta > 0) = exp(-x)**(alpha - 1) exp(-exp(-x) beta) / Z - x
+  pdf(x; alpha, beta > 0) = exp(-x)**(alpha) exp(-exp(-x) beta) / Z
   Z = Gamma(alpha) beta**(-alpha)
   ```
 


### PR DESCRIPTION
In prepping to implement the SigmoidBeta distribution, I reviewed the ExpGamma distribution to understand the rough code structure. I saw that the formula in the comments didn't match the code or the derivation using the change of variables formula. This PR makes the minor modifications to fix that. The formula now agrees with the log_prob formula.