### PR TITLE
Adds the SigmoidBeta distribution

### DIFF
--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -133,6 +133,7 @@ multi_substrate_py_library(
         ":relaxed_bernoulli",
         ":relaxed_onehot_categorical",
         ":sample",
+        ":sigmoid_beta",
         ":sinh_arcsinh",
         ":skellam",
         ":spherical_uniform",
@@ -1812,6 +1813,22 @@ multi_substrate_py_library(
         "//tensorflow_probability/python/internal:prefer_static",
         "//tensorflow_probability/python/internal:tensor_util",
         "//tensorflow_probability/python/internal:tensorshape_util",
+    ],
+)
+
+multi_substrate_py_library(
+    name = "sigmoid_beta",
+    srcs = ["sigmoid_beta.py"],
+    deps = [
+        ":gamma",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/bijectors:identity",
+        "//tensorflow_probability/python/bijectors:softplus",
+        "//tensorflow_probability/python/internal:dtype_util",
+        "//tensorflow_probability/python/internal:parameter_properties",
+        "//tensorflow_probability/python/internal:samplers",
+        "//tensorflow_probability/python/internal:tensor_util",
     ],
 )
 
@@ -3715,6 +3732,27 @@ multi_substrate_py_test(
         # tensorflow dep,
         "//tensorflow_probability",
         "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+multi_substrate_py_test(
+    name = "sigmoid_beta_test",
+    size = "medium",
+    srcs = ["sigmoid_beta_test.py"],
+    jax_size = "large",
+    numpy_tags = ["notap"],
+    shard_count = 2,
+    deps = [
+        ":sigmoid_beta",
+        # numpy dep,
+        # scipy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/distributions/internal:statistical_testing",
+        "//tensorflow_probability/python/internal:dtype_util",
+        "//tensorflow_probability/python/internal:test_util",
+        "//tensorflow_probability/python/math:gradient",
+        # tensorflow/compiler/jit dep,
     ],
 )
 

--- a/tensorflow_probability/python/distributions/__init__.py
+++ b/tensorflow_probability/python/distributions/__init__.py
@@ -111,6 +111,7 @@ from tensorflow_probability.python.distributions.relaxed_bernoulli import Relaxe
 from tensorflow_probability.python.distributions.relaxed_onehot_categorical import ExpRelaxedOneHotCategorical
 from tensorflow_probability.python.distributions.relaxed_onehot_categorical import RelaxedOneHotCategorical
 from tensorflow_probability.python.distributions.sample import Sample
+from tensorflow_probability.python.distributions.sigmoid_beta import SigmoidBeta
 from tensorflow_probability.python.distributions.sinh_arcsinh import SinhArcsinh
 from tensorflow_probability.python.distributions.skellam import Skellam
 from tensorflow_probability.python.distributions.spherical_uniform import SphericalUniform
@@ -228,6 +229,7 @@ __all__ = [
     'PoissonLogNormalQuadratureCompound',
     'ProbitBernoulli',
     'Sample',
+    'SigmoidBeta',
     'SinhArcsinh',
     'Skellam',
     'SphericalUniform',

--- a/tensorflow_probability/python/distributions/hypothesis_testlib.py
+++ b/tensorflow_probability/python/distributions/hypothesis_testlib.py
@@ -104,6 +104,7 @@ TF2_FRIENDLY_DISTS = (
     'ProbitBernoulli',
     'RelaxedBernoulli',
     'ExpRelaxedOneHotCategorical',
+    'SigmoidBeta',
     # 'SinhArcsinh' TODO(b/137956955): Add support for hypothesis testing
     'Skellam',
     'SphericalUniform',

--- a/tensorflow_probability/python/distributions/platform_compatibility_test.py
+++ b/tensorflow_probability/python/distributions/platform_compatibility_test.py
@@ -152,6 +152,7 @@ XLA_LOGPROB_ATOL.update({
     'Logistic': 3e-6,
     'Multinomial': 2e-4,
     'PowerSpherical': 2e-5,
+    'SigmoidBeta': 5e-4,
     'Skellam': 1e-4
 })
 
@@ -184,6 +185,7 @@ XLA_LOGPROB_RTOL.update({
     'Poisson': 3e-2,  # TODO(b/159999573)
     'PowerSpherical': .003,
     'RelaxedBernoulli': 3e-3,
+    'SigmoidBeta': 5e-4,
     'VonMises': 2e-2,  # TODO(b/160000258):
     'VonMisesFisher': 5e-3,
     'WishartTriL': 1e-5,

--- a/tensorflow_probability/python/distributions/sigmoid_beta.py
+++ b/tensorflow_probability/python/distributions/sigmoid_beta.py
@@ -1,0 +1,276 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""The SigmoidBeta distribution class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import functools
+
+# Dependency imports
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python import math as tfp_math
+from tensorflow_probability.python.bijectors import identity as identity_bijector
+from tensorflow_probability.python.bijectors import softplus as softplus_bijector
+from tensorflow_probability.python.distributions import distribution
+from tensorflow_probability.python.distributions import gamma as gamma_lib
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import parameter_properties
+from tensorflow_probability.python.internal import prefer_static as ps
+from tensorflow_probability.python.internal import reparameterization
+from tensorflow_probability.python.internal import samplers
+from tensorflow_probability.python.internal import tensor_util
+
+__all__ = [
+    'SigmoidBeta',
+]
+
+
+class SigmoidBeta(distribution.Distribution):
+  """SigmoidBeta Distribution.
+
+  The SigmoidBeta distribution is defined over the real line using parameters
+  `concentration1` (aka 'alpha') and `concentration0` (aka 'beta').
+
+  This distribution is the transformation of the Beta distribution such that
+  Sigmoid(X) ~ Beta(...) => X ~ SigmoidBeta(...).
+
+  #### Mathematical Details
+
+  The probability density function (pdf) can be derived from the change of
+  variables rule. We begin with `g(X) = Sigmoid(X)`, and note that
+
+  ```none
+  p_x(x) = p_y(g(y)) | g'(y) |.
+  ```
+  With `g'(y) = Sigmoid(x) ( 1 - Sigmoid(x))`, we arrive at
+
+  ```none
+  pdf(x; alpha, beta) = Sigmoid(x)^alpha (1 - Sigmoid(x))^beta / B(alpha, beta)
+  B(alpha, beta) = Gamma(alpha) Gamma(beta) / Gamma(alpha + beta)
+  ```
+  where:
+
+  * `concentration1 = alpha`
+  * `concentration0 = beta`
+  * `B(alpha, beta` is the [beta function](
+    https://en.wikipedia.org/wiki/Beta_function)
+  * `Gamma` is the [gamma function](
+    https://en.wikipedia.org/wiki/Gamma_function).
+
+  Critically, these parameters loose the relationship to the mean that they have
+  under the untransformed Beta distribution. We choose to keep the names to
+  draw analogy to the original Beta distribution.
+
+  ```none
+  concentration1 = alpha
+  concentration0 = beta
+  ```
+
+  where `mean` in `(0, 1)` and `total_concentration` is a positive real number
+  representing a mean `total_count = concentration1 + concentration0`.
+
+  Distribution parameters are automatically broadcast in all functions; see
+  examples for details.
+
+
+
+  The cumlative density function (cdf) can be found by integrating the pdf
+  directly from `-infinity` to x:
+
+  ```none
+   cdf(x; alpha, beta) = I_Sigmoid(x)(alpha + 1, beta + 1) / B(alpha, beta),
+  ```
+
+  where `I_x(alpha, beta)` is the [incomplete beta function](
+  https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function).
+
+  Samples of this distribution are reparameterized (pathwise differentiable).
+  The derivatives are computed using the approach described in
+  [(Figurnov et al., 2018)][1].
+
+  #### Examples
+
+    ```python
+   tfd = tfp.distributions
+
+   dist = tfd.SigmoidBeta(concentration0=tf.constant(1),
+                          concentration1=tf.constant(2))
+
+   dist.sample([4, 5])  # Shape [4, 5, 3]
+
+   # `x` has three batch entries, each with two samples.
+   x = [[.1, .4, .5],
+        [.2, .3, .5]]
+   # Calculate the probability of each pair of samples under the corresponding
+   # distribution in `dist`.
+   dist.prob(x)         # Shape [2, 3]
+    ```
+
+  #### References
+
+  [1]: Michael Figurnov, Shakir Mohamed, Andriy Mnih.
+       Implicit Reparameterization Gradients. _arXiv preprint arXiv:1805.08498_,
+       2018. https://arxiv.org/abs/1805.08498
+
+  """
+
+  def __init__(self,
+               concentration1,
+               concentration0,
+               validate_args=False,
+               allow_nan_stats=True,
+               name='SigmoidBeta'):
+    """Initialize a batch of SigmoidBeta distributions.
+
+    Args:
+      concentration1: Positive floating-point `Tensor` indicating mean
+        number of successes; aka 'alpha'.
+      concentration0: Positive floating-point `Tensor` indicating mean
+        number of failures; aka 'beta'.
+      validate_args: Python `bool`, default `False`. When `True` distribution
+        parameters are checked for validity despite possibly degrading runtime
+        performance. When `False` invalid inputs may silently render incorrect
+        outputs.
+      allow_nan_stats: Python `bool`, default `True`. When `True`, statistics
+        (e.g., mean, mode, variance) use the value '`NaN`' to indicate the
+        result is undefined. When `False`, an exception is raised if one or
+        more of the statistic's batch members are undefined.
+      name: Python `str` name prefixed to Ops created by this class.
+    """
+    parameters = dict(locals())
+    with tf.name_scope(name) as name:
+      dtype = dtype_util.common_dtype([concentration1, concentration0],
+                                       dtype_hint=tf.float32)
+      self._concentration1 = tensor_util.convert_nonref_to_tensor(
+          concentration1, dtype=dtype, name='concentration1')
+      self._concentration0 = tensor_util.convert_nonref_to_tensor(
+          concentration0, dtype=dtype, name='concentration0')
+
+    super(SigmoidBeta, self).__init__(
+        dtype=dtype,
+        validate_args=validate_args,
+        allow_nan_stats=allow_nan_stats,
+        reparameterization_type=reparameterization.FULLY_REPARAMETERIZED,
+        parameters=parameters,
+        name=name)
+
+  @classmethod
+  def _parameter_properties(cls, dtype, num_classes=None):
+    # pylint: disable=g-long-lambda
+    return dict(
+        concentration1=parameter_properties.ParameterProperties(
+            default_constraining_bijector_fn=(
+                lambda: softplus_bijector.Softplus(low=dtype_util.eps(dtype)))),
+        concentration0=parameter_properties.ParameterProperties(
+            default_constraining_bijector_fn=(
+                lambda: softplus_bijector.Softplus(low=dtype_util.eps(dtype)))))
+    # pylint: enable=g-long-lambda
+
+  @property
+  def concentration1(self):
+    """Concentration parameter associated with a `1` outcome."""
+    return self._concentration1
+
+  @property
+  def concentration0(self):
+    """Concentration parameter associated with a `0` outcome."""
+    return self._concentration0
+
+  def _default_event_space_bijector(self):
+    return identity_bijector.Identity(validate_args=self.validate_args)
+
+  def _batch_shape_tensor(self, concentration1=None, concentration0=None):
+    return ps.broadcast_shape(
+        ps.shape(self.concentration1
+                 if concentration1 is None else concentration1),
+        ps.shape(self.concentration0
+                 if concentration0 is None else concentration0))
+
+  def _batch_shape(self):
+    return tf.broadcast_static_shape(self.concentration1.shape,
+                                     self.concentration0.shape)
+
+  def _parameter_control_dependencies(self, is_init):
+    if not self.validate_args:
+      return []
+    assertions = []
+    for i, concentration in enumerate([self.concentration0,
+                                       self.concentration1]):
+      if is_init != tensor_util.is_ref(concentration):
+        assertions.append(
+            assert_util.assert_positive(
+                concentration,
+                message='Concentration{} parameter must be positive.'.format(
+                    i)))
+    return assertions
+
+  def _event_shape_tensor(self):
+    return tf.constant([], dtype=tf.int32)
+
+  def _event_shape(self):
+    return tf.TensorShape([])
+
+  def _sample_n(self, n, seed=None):
+    seed1, seed2 = samplers.split_seed(seed, salt='sigmoid_beta')
+    concentration1 = tf.convert_to_tensor(self.concentration1)
+    concentration0 = tf.convert_to_tensor(self.concentration0)
+    shape = self._batch_shape_tensor(concentration1, concentration0)
+    expanded_concentration1 = tf.broadcast_to(concentration1, shape)
+    expanded_concentration0 = tf.broadcast_to(concentration0, shape)
+    log_gamma1 = gamma_lib.random_gamma(
+        shape=[n],
+        concentration=expanded_concentration1,
+        seed=seed1,
+        log_space=True)
+    log_gamma2 = gamma_lib.random_gamma(
+        shape=[n],
+        concentration=expanded_concentration0,
+        seed=seed2,
+        log_space=True)
+
+    return log_gamma1 - log_gamma2
+
+  def _log_normalization(self, concentration0, concentration1):
+    return tfp_math.lbeta(concentration0, concentration1)
+
+  def _log_unnormalized_prob(self, concentration0, concentration1, x):
+    return (- concentration0 * tf.math.softplus(-x)
+            - concentration1 * tf.math.softplus(x))
+
+  def _log_prob(self, x):
+    a = tf.convert_to_tensor(self.concentration1)
+    b = tf.convert_to_tensor(self.concentration0)
+    return (self._log_unnormalized_prob(a, b, x) -
+            self._log_normalization(a, b))
+
+  def _cdf(self, x):
+    concentration1 = tf.convert_to_tensor(self.concentration1)
+    concentration0 = tf.convert_to_tensor(self.concentration0)
+    sig_x = tf.math.sigmoid(x)
+    shape = functools.reduce(ps.broadcast_shape, [
+        ps.shape(concentration1),
+        ps.shape(concentration0),
+        ps.shape(sig_x)
+    ])
+    concentration1 = tf.broadcast_to(concentration1, shape)
+    concentration0 = tf.broadcast_to(concentration0, shape)
+    sig_x = tf.broadcast_to(sig_x, shape)
+    return tf.math.betainc(concentration1, concentration0, sig_x)
+
+  def _mode(self):
+    return tf.math.log(self.concentration1 / self.concentration0)

--- a/tensorflow_probability/python/distributions/sigmoid_beta_test.py
+++ b/tensorflow_probability/python/distributions/sigmoid_beta_test.py
@@ -1,0 +1,267 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+import numpy as np
+from scipy import stats as sp_stats
+
+import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
+
+from tensorflow_probability.python.distributions.internal import statistical_testing as st
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import test_util
+
+tfb = tfp.bijectors
+tfd = tfp.distributions
+
+
+@test_util.test_all_tf_execution_regimes
+class SigmoidBetaTest(test_util.TestCase):
+
+  def testSimpleShapes(self):
+    a = np.random.rand(3)
+    b = np.random.rand(3)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertAllEqual([3], self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+    self.assertEqual(tf.TensorShape([3]), dist.batch_shape)
+
+  def testComplexShapes(self):
+    a = np.random.rand(3, 2, 2)
+    b = np.random.rand(3, 2, 2)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertAllEqual([3, 2, 2], self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+    self.assertEqual(tf.TensorShape([3, 2, 2]), dist.batch_shape)
+
+  def testComplexShapesBroadcast(self):
+    a = np.random.rand(3, 2, 2)
+    b = np.random.rand(2, 2)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    self.assertAllEqual([], self.evaluate(dist.event_shape_tensor()))
+    self.assertAllEqual([3, 2, 2], self.evaluate(dist.batch_shape_tensor()))
+    self.assertEqual(tf.TensorShape([]), dist.event_shape)
+    self.assertEqual(tf.TensorShape([3, 2, 2]), dist.batch_shape)
+
+  def testAlphaProperty(self):
+    a = [[1., 2, 3]]
+    b = [[2., 4, 3]]
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    self.assertEqual([1, 3], dist.concentration1.shape)
+    self.assertAllClose(a, self.evaluate(dist.concentration1))
+
+  def testBetaProperty(self):
+    a = [[1., 2, 3]]
+    b = [[2., 4, 3]]
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    self.assertEqual([1, 3], dist.concentration0.shape)
+    self.assertAllClose(b, self.evaluate(dist.concentration0))
+
+  def testPDF(self):
+    a = tf.constant(1.0)
+    b = tf.constant(2.0)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+
+    oracle = tfd.TransformedDistribution(distribution=tfd.Beta(a, b),
+                                         bijector=tfb.Invert(tfb.Sigmoid()))
+
+    x = np.array([0.0, 0.5, 0.75, 1.0])
+    log_pdf = dist.log_prob(x)
+    pdf = dist.prob(x)
+    expected_log_pdf = oracle.log_prob(x)
+    expected_pdf = oracle.prob(x)
+    self.assertAllClose(log_pdf, expected_log_pdf)
+    self.assertAllClose(pdf, expected_pdf)
+
+  def testPdfTwoBatches(self):
+    a = [1., 2]
+    b = [1., 2]
+    x = [0., 0.]
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    pdf = dist.prob(x)
+    self.assertAllClose([1. / 4., 3. / 8.], self.evaluate(pdf))
+    self.assertEqual((2,), pdf.shape)
+
+  def testLogPDF(self):
+    a = [1., 2]
+    b = [1., 2]
+    x = [0., 0.]
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    logpdf = dist.log_prob(x)
+
+    oracle = tfd.TransformedDistribution(distribution=tfd.Beta(a, b),
+                                         bijector=tfb.Invert(tfb.Sigmoid()))
+    expected_logpdf = oracle.log_prob(x)
+
+    self.assertAllClose(expected_logpdf, logpdf)
+    self.assertEqual((2,), logpdf.shape)
+
+    x = [1., 1.]
+    logpdf = dist.log_prob(x)
+    expected_logpdf = oracle.log_prob(x)
+
+    self.assertAllClose(expected_logpdf, logpdf)
+    self.assertEqual((2,), logpdf.shape)
+
+    a = [1., 2.]
+    b = [2., 1.]
+    x = [1., 1.]
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    oracle = tfd.TransformedDistribution(distribution=tfd.Beta(a, b),
+                                         bijector=tfb.Invert(tfb.Sigmoid()))
+
+    logpdf = dist.log_prob(x)
+    expected_logpdf = oracle.log_prob(x)
+    self.assertAllClose(expected_logpdf, logpdf)
+    self.assertEqual((2,), logpdf.shape)
+
+  def testSampleWithPartiallyDefinedShapeEndingInOne(self):
+    b = [[0.01, 0.1, 1., 2], [5., 10., 2., 3]]
+    pdf = self.evaluate(tfd.SigmoidBeta(1., b, validate_args=True).prob(0.))
+    self.assertAllEqual(np.ones_like(pdf, dtype=np.bool), np.isfinite(pdf))
+
+  def testIsFiniteLargeX(self):
+    a = tf.constant(1.0)
+    b = tf.constant(2.0)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    x = [1e10]
+    expected = [-2*1e10]
+    log_pdf = dist.log_prob(x)
+    self.assertAllClose(log_pdf, expected)
+
+  def testLogPDFMultidimensional(self):
+    batch_size = 6
+    a = tf.constant(1.0)
+    b = tf.constant([[1.0, 2.0]] * batch_size)
+    x = np.array([[0.0, 0.1, 0.2, 0.4, 0.5, 1.0]], dtype=np.float32).T
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    oracle = tfd.TransformedDistribution(distribution=tfd.Beta(a, b),
+                                         bijector=tfb.Invert(tfb.Sigmoid()))
+    log_pdf = dist.log_prob(x)
+    expected_logpdf = oracle.log_prob(x)
+    self.assertEqual(log_pdf.shape, (6, 2))
+    self.assertAllClose(log_pdf, expected_logpdf)
+    pdf = dist.prob(x)
+    expected_pdf = oracle.prob(x)
+    self.assertEqual(pdf.shape, (6, 2))
+    self.assertAllClose(pdf, expected_pdf)
+
+  def testCDF(self):
+    batch_size = 6
+    a = tf.constant([2.0] * batch_size)
+    b = tf.constant([3.0] * batch_size)
+    x = np.array([0.0, 0.1, 0.2, 0.4, 0.5, 1.0], dtype=np.float32)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+    cdf = dist.cdf(x)
+    self.assertEqual(cdf.shape, (6,))
+
+    expected_cdf = tfd.TransformedDistribution(distribution=tfd.Beta(a, b),
+                                               bijector=tfb.Invert(
+                                                   tfb.Sigmoid())).cdf(x)
+    self.assertAllClose(cdf, expected_cdf)
+
+  def testMode(self):
+    a = tf.constant(1.0)
+    b = tf.constant(2.0)
+    dist = tfd.SigmoidBeta(a, b, validate_args=True)
+
+    self.assertAllClose(self.evaluate(tf.math.log(a / b)),
+                        self.evaluate(dist.mode()))
+
+  def testAssertsPositiveConcentration1(self):
+    concentration1 = tf.Variable([1., 2., -3.])
+    self.evaluate(concentration1.initializer)
+    with self.assertRaisesOpError('Concentration1 parameter must be positive.'):
+      d = tfd.SigmoidBeta(concentration1=concentration1,
+                          concentration0=[5.],
+                          validate_args=True)
+      self.evaluate(d.sample(seed=test_util.test_seed()))
+
+  def testAssertsPositiveConcentration1AfterMutation(self):
+    concentration1 = tf.Variable([1., 2., 3.])
+    self.evaluate(concentration1.initializer)
+    d = tfd.SigmoidBeta(concentration1=concentration1,
+                        concentration0=[5.],
+                        validate_args=True)
+    with self.assertRaisesOpError('Concentration1 parameter must be positive.'):
+      with tf.control_dependencies([concentration1.assign([1., 2., -3.])]):
+        self.evaluate(d.sample(seed=test_util.test_seed()))
+
+  @test_util.tf_tape_safety_test
+  def testGradientThroughConcentration0(self):
+    concentration0 = tf.Variable(3.)
+    d = tfd.SigmoidBeta(concentration0=concentration0,
+                        concentration1=5.,
+                        validate_args=True)
+    with tf.GradientTape() as tape:
+      loss = -d.log_prob([0.25, 0.5, 0.9])
+    grad = tape.gradient(loss, d.trainable_variables)
+    self.assertLen(grad, 1)
+    self.assertAllNotNone(grad)
+
+  def testAssertsPositiveConcentration0(self):
+    concentration0 = tf.Variable([1., 2., -3.])
+    self.evaluate(concentration0.initializer)
+    with self.assertRaisesOpError('Concentration0 parameter must be positive.'):
+      d = tfd.SigmoidBeta(concentration0=concentration0,
+                          concentration1=[5.],
+                          validate_args=True)
+      self.evaluate(d.sample(seed=test_util.test_seed()))
+
+  def testAssertsPositiveConcentration0AfterMutation(self):
+    concentration0 = tf.Variable([1., 2., 3.])
+    self.evaluate(concentration0.initializer)
+    d = tfd.SigmoidBeta(concentration0=concentration0,
+                        concentration1=[5.],
+                        validate_args=True)
+    with self.assertRaisesOpError('Concentration0 parameter must be positive.'):
+      with tf.control_dependencies([concentration0.assign([1., 2., -3.])]):
+        self.evaluate(d.sample(seed=test_util.test_seed()))
+
+  def _kstest(self, a, b, samples):
+    # Uses the Kolmogorov-Smirnov test for goodness of fit.
+    oracle_dist = tfd.SigmoidBeta(concentration0=a, concentration1=b)
+    ks, _ = sp_stats.kstest(samples,
+                            lambda x: self.evaluate(oracle_dist.cdf(x)))
+    # Return True when the test passes.
+    return ks < 0.02
+
+  def testSample(self):
+    a = tf.constant(1.0)
+    b = tf.constant(2.0)
+    n = 500000
+    d = tfd.SigmoidBeta(concentration0=a, concentration1=b, validate_args=True)
+    samples = d.sample(n, seed=test_util.test_seed())
+    sample_values = self.evaluate(samples)
+    self.assertEqual(samples.shape, (n,))
+    self.assertEqual(sample_values.shape, (n,))
+    self.assertTrue(self._kstest(a, b, sample_values))
+
+    check_cdf_agrees = st.assert_true_cdf_equal_by_dkwm(
+        samples, d.cdf, false_fail_rate=1e-6)
+    self.evaluate(check_cdf_agrees)
+    check_enough_power = assert_util.assert_less(
+        st.min_discrepancy_of_true_cdfs_detectable_by_dkwm(
+            n, false_fail_rate=1e-6, false_pass_rate=1e-6), 0.01)
+    self.evaluate(check_enough_power)
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow_probability/python/experimental/bijectors/distribution_bijectors_test.py
+++ b/tensorflow_probability/python/experimental/bijectors/distribution_bijectors_test.py
@@ -40,6 +40,7 @@ PRECONDITIONING_FAILS_DISTS = (
     'GeneralizedNormal',  # CDF gradient incorrect at 0.
     'HalfStudentT',  # Uses StudentT CDF.
     'Laplace',  # CDF gradient incorrect at 0.
+    'SigmoidBeta', # inverse CDF numerical precision issues for large x
     'StudentT',  # CDF gradient incorrect at 0 (and unstable near zero).
     'TruncatedCauchy',  # b/175630511
     'TruncatedNormal',  # b/175630511

--- a/tensorflow_probability/python/mcmc/nuts_test.py
+++ b/tensorflow_probability/python/mcmc/nuts_test.py
@@ -209,8 +209,7 @@ class NutsTest(test_util.TestCase):
         self, normal_dist, step_size=0.2))
 
   def testSigmoidBetaTargetConservation(self):
-    sigmoid_beta_dist = tfb.Invert(tfb.Sigmoid())(
-        tfd.Beta(concentration0=1., concentration1=2.))
+    sigmoid_beta_dist = tfd.SigmoidBeta(concentration0=1., concentration1=2.)
     self.evaluate(assert_univariate_target_conservation(
         self, sigmoid_beta_dist, step_size=0.2))
 


### PR DESCRIPTION
(Note, there's lots of latex here... TeX All the Things can help...)

This PR provides an implementation for the SigmoidBeta distribution. This
distribution samples

$$
\sigma(X) ~ Beta(\alpha, \beta),
$$

which is logically equivalent to

```
tfd.TransformedDistribution(
        distribution=tfd.Beta(a, b),
        bijector=tfb.Invert(tfb.Sigmoid())
        )
```

Note, the new distribution has domain $(-\infty, \infty)$, whereas the original
beta distribution has domain $[0, 1]$.

The goal of providing such an explicitly transformed distribution is to remove
the singularities around $X ~= 0$ and $X ~= 1$, while also providing a more
robust logpdf routine. To arrive at the analytical form of the pdf, we will use
the change of variables formula for pdfs. Namely:

$$
p_x(x) = p_y(g(y)) | g'(y) |.
$$

Taking $g(y) = \sigma(y)$, and $g'(y) = \sigma(y) \left( 1 - \sigma(y) \right)$,
we arrive at a pdf of the form:

$$
p(x; \alpha, \beta) = \frac{\sigma(y)^{\alpha - 1} \left( 1 - \sigma(y) \right)^{\beta - 1}}{B(\alpha, \beta)} \left| \sigma(y) \left( 1 - \sigma(y) \right) \right|
$$

which readily simplifies to when we observe that $g'$ is always positive:

$$
p(x; \alpha, \beta) = \frac{\sigma(y)^{\alpha} \left( 1 - \sigma(y) \right)^{\beta}}{B(\alpha, \beta)}.
$$

The logpdf is similarly convenient, and given by:

$$
log(p(x; \alpha, \beta)) = - \ln\left( B(\alpha, \beta) \right) - \left( \alpha + \beta \right) \ln\left( 1 + e^{-x} \right) - \beta x.
$$

We next turn our attention to the CDF, which is given by:

$$
F(x; \alpha, \beta) = \int^x_{\-infty} p(y; \alpha, \beta) dy
$$

$$
F(x; \alpha, \beta) = \int^x_{\-infty} \frac{\sigma(y)^{\alpha} \left( 1 - \sigma(y) \right)^{\beta}}{B(\alpha, \beta)} dy
$$

$$
F(x; \alpha, \beta) = \int^x_{\-infty} \frac{\sigma(y)^{\alpha} \left( 1 - \sigma(y) \right)^{\beta}}{B(\alpha, \beta)} dy
$$

$$
F(x; \alpha, \beta) = \frac{B\left( \sigma(x); \alpha + 1, \beta + 1 \right)}{B(\alpha, \beta)}.
$$

The mode is found by computing the extreme value of the PDF. We begin with:

$$
0 = \partial_{x}\sigma^{\alpha}(1 - \sigma)^\beta + \sigma^{\alpha}\partial_{x}\left(1 - \sigma)^\beta
$$
$$
\alpha \sigma^{\alpha - 1} \sigma (1 - \sigma) (1 - \sigma)^\beta = \sigma^{\alpha} \beta (1 - \sigma)^{\beta - 1} (1 - \sigma)
$$
$$
\alpha \left( 1 - \sigma) = \beta \sigma
$$
$$
\sigma(x) = \frac{\alpha}{\alpha + \beta}
$$

$$
x = \sigma^{-1} \left( \frac{\alpha}{\alpha + \beta} \right)
$$

$$
x = \ln\left( \frac{\alpha}{\beta} \right).
$$

Unfortunately, the mean isn't quite so clean. Following from the definition
of the mean, we find that:

$$
\mu = \int^+_- x p(x; \alpha, \beta) dx
$$

$$
\mu = \frac{1}{Z_{\alpha, \beta}} \int^+_- x \sigma(x)^\alpha \left( 1 - \sigma(x) \right)^\beta dx
$$

$$
\mu = \frac{1}{Z_{\alpha, \beta}} \int^+_- x \frac{e^{\alpha - x}}{\left(1 + e^{-x}\right)^{\alpha + \beta}} dx.
$$

Unfortunately, gradshteyn and reznik didn't contain anything that was terribly
illuminating. When I turned to wolfram alpha, I was given a functional form that
contained hypergeometric functions of order $(p=2, q=1)$ and $(p=3, q=2)$. What's
more, the $Z$ argument for both is of the form $-e^x$, which will obviously
take on values larger than one -- thereby rendering the tfp provided $(p=2, q=1)$
insufficient. This isn't the end of the story, however. The integrand is quite
smooth and readily admits approximation by quadrature. I've not seen other
instances where people have estimated various central tendencies by quadrature,
so I'm not sure if it's perfectly cromulent or not. If it's interesting, I'm
certainly happy to throw in some calls to `scipy.quad`, or implement my own
gauss-kronrod quadrature. Additionally, please don't hesitate to comment if you
happen to see an integration trick that I missed.

The story above also applies to analytical computation of the entropy, variance,
and KL Divergence.

I believe I've hit most of the high points on distribution parameters, but
welcome any feedback about properties I may have missed. The same goes or
tests -- I was strongly inspired by the test suite for both the ExpGamma
and Beta distributions but likely missed something.