### PR TITLE
Make deprecation warning clearer

### DIFF
--- a/tensorflow_probability/python/distributions/mvn_diag.py
+++ b/tensorflow_probability/python/distributions/mvn_diag.py
@@ -149,7 +149,7 @@ class MultivariateNormalDiag(
 
   @deprecation.deprecated_args(
       '2020-01-01',
-      '`scale_identity_multiplier` is deprecated; please combine it with '
+      '`scale_identity_multiplier` is deprecated; please combine it into '
       '`scale_diag` directly instead.',
       'scale_identity_multiplier')
   def __init__(self,


### PR DESCRIPTION
The message to 'combine scale_identity_multiplier with scale_diag' seemed to suggest that the arguments `scale_identity_multiplier` and `scale_diag` should be combined together, but what is actually meant is that `scale_diag` should be used in favour of `scale_identity_multiplier`. The comment down below in the body of `__init__` was clearer.