### PR TITLE
add casting to backend for Owen's T function

### DIFF
--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -1748,7 +1748,7 @@ def _owens_t_naive_gradient(h, a):
        tf.math.erfc(modified_h / np.sqrt(2.))), result)
 
   # When a = 0, we should return 0.
-  result = tf.where(tf.math.equal(modified_a, 0.), 0., result)
+  result = tf.where(tf.math.equal(modified_a, 0.), numpy_dtype(0.), result)
 
   normh = tf.math.erfc(h / np.sqrt(2.))
   normah = tf.math.erfc(abs_a * h / np.sqrt(2.))
@@ -1764,7 +1764,9 @@ def _owens_t_naive_gradient(h, a):
 
   result = tf.math.sign(a) * result
 
-  result = tf.where(tf.math.is_nan(a) | tf.math.is_nan(h), np.nan, result)
+  result = tf.where(tf.math.is_nan(a) | tf.math.is_nan(h),
+                    numpy_dtype(np.nan),
+                    result)
   return result
 
 


### PR DESCRIPTION
When compiled using `tf.function`, Owen's T function currently fails for `tf.float64` typed inputs. By way of example,
```python
import tensorflow as tf
from tensorflow_probability.python.math.special import owens_t

h = tf.cast(1, tf.float64)
a = tf.cast(1, tf.float64)

@tf.function
def closure():
  return owens_t(h, a)

T = closure()  # fails
```
Fortunately, this looks to be a quick fix. The fallback values used in two `tf.where` statements simply need to be wrapped by the `numpy_dtype` helper.