### PR TITLE
Fix BatchNormalization docstring

### DIFF
--- a/tensorflow_probability/python/bijectors/batch_normalization.py
+++ b/tensorflow_probability/python/bijectors/batch_normalization.py
@@ -90,14 +90,13 @@ class BatchNormalization(bijector.Bijector):
   computed at training-time. De-normalization is useful for sampling.
 
   ```python
-
-  dist = tfd.TransformedDistribution(
-      distribution=tfd.Normal()),
+  distribution = tfd.TransformedDistribution(
+      distribution=tfd.Normal(loc=[0.0], scale=[1.0]),
       bijector=tfb.BatchNormalization())
 
-  y = tfd.MultivariateNormalDiag(loc=1., scale=2.).sample(100)  # ~ N(1, 2)
-  x = dist.bijector.inverse(y)  # ~ N(0, 1)
-  y = dist.sample()  # ~ N(1, 2)
+  y = tfd.Normal(loc=[1.0], scale=[2.0]).sample(100)  # ~ N(1, 2)
+  x = distribution.bijector.inverse(y)  # ~ N(0, 1)
+  y_ = distribution.sample(100)  # ~ N(1, 2)
   ```
 
   During training time, `BatchNormalization.inverse` and


### PR DESCRIPTION
The current `BatchNormalization` docstring is broken in several ways. There's a syntax error on line https://github.com/tensorflow/probability/blob/43a9d6c3f5992a24ddf7aa3fa826a038d70697c5/tensorflow_probability/python/bijectors/batch_normalization.py#L95

and the initializers both for `tfd.Normal` and `tfd.MultivariateNormalDiag` are currently broken. This should make the example runnable (save imports).