### PR TITLE
Hmm step prediction

### DIFF
--- a/tensorflow_probability/python/distributions/hidden_markov_model.py
+++ b/tensorflow_probability/python/distributions/hidden_markov_model.py
@@ -1181,6 +1181,39 @@ class HiddenMarkovModel(distribution.Distribution):
         return ps.cond(self.num_steps > 1, _reduce_multiple_steps,
                        _reduce_one_step)
 
+  def single_step_prediction(self, observation, prediction_distribution=None, initialisation_step=True):
+      """
+      Function to run single prediction step based on incoming observation data point and the current prediction
+      distribution of the hmm model.
+      If initialisation_step is True, then no prediction distribution is required initially and the initial prediction
+      distribution is derived from the priors of the hmm (the initial_distribution over the states). In a forecasting
+      model that runs on live data, the first step would require initialisation while subsequent steps would use the
+      previous step's prediction distribution as input.
+      The prediction distribution is updated and returned from this function.
+      """
+      observation = tf.convert_to_tensor(observation, name='observations')
+
+      if not isinstance(initialisation_step, bool):
+          raise TypeError('initialisation_step must be of type bool, but saw: %s' % initialisation_step)
+
+      if(initialisation_step):
+          num = self.initial_distribution.log_prob(range(self.num_states_static)) \
+                + self.observation_distribution.log_prob(observation)
+      else:
+          if not isinstance(prediction_distribution, distribution.Distribution):
+              raise TypeError('If initialisation_step is False, then current prediction distribution must be provided.'
+                              'prediction_distribution must be a Distribution instance, but saw: %s' %
+                              prediction_distribution)
+          num = tf.math.log(prediction_distribution) \
+                + self.observation_distribution.log_prob(observation)
+
+      filtering_distribution = tf.exp(num - tf.reduce_logsumexp(num))
+      prediction_distribution = tf.tensordot(self.transition_distribution.probs_parameter(),
+                                             filtering_distribution, axes=1)
+      observation_prediction = tf.tensordot(prediction_distribution, self.observation_distribution.mean(), axes=1)
+
+      return prediction_distribution, observation_prediction
+
   # pylint: disable=protected-access
   def _default_event_space_bijector(self):
     return (self._observation_distribution.

--- a/tensorflow_probability/python/distributions/hidden_markov_model.py
+++ b/tensorflow_probability/python/distributions/hidden_markov_model.py
@@ -1196,7 +1196,7 @@ class HiddenMarkovModel(distribution.Distribution):
       if not isinstance(initialisation_step, bool):
           raise TypeError('initialisation_step must be of type bool, but saw: %s' % initialisation_step)
 
-      if(initialisation_step):
+      if (initialisation_step):
           num = self.initial_distribution.log_prob(range(self.num_states_static)) \
                 + self.observation_distribution.log_prob(observation)
       else:
@@ -1204,13 +1204,13 @@ class HiddenMarkovModel(distribution.Distribution):
               raise TypeError('If initialisation_step is False, then current prediction distribution must be provided.'
                               'prediction_distribution must be a Distribution instance, but saw: %s' %
                               prediction_distribution)
-          num = tf.math.log(prediction_distribution) \
+          num = tf.math.log(prediction_distribution.probs) \
                 + self.observation_distribution.log_prob(observation)
 
       filtering_distribution = tf.exp(num - tf.reduce_logsumexp(num))
-      prediction_distribution = tf.tensordot(self.transition_distribution.probs_parameter(),
-                                             filtering_distribution, axes=1)
-      observation_prediction = tf.tensordot(prediction_distribution, self.observation_distribution.mean(), axes=1)
+      prediction_distribution = categorical.Categorical(probs=tf.tensordot(self.transition_distribution.probs_parameter(),
+                                             filtering_distribution, axes=1))
+      observation_prediction = tf.tensordot(prediction_distribution.probs, self.observation_distribution.mean(), axes=1)
 
       return prediction_distribution, observation_prediction
 

--- a/tensorflow_probability/python/distributions/hidden_markov_model.py
+++ b/tensorflow_probability/python/distributions/hidden_markov_model.py
@@ -1189,9 +1189,10 @@ class HiddenMarkovModel(distribution.Distribution):
       distribution is derived from the priors of the hmm (the initial_distribution over the states). In a forecasting
       model that runs on live data, the first step would require initialisation while subsequent steps would use the
       previous step's prediction distribution as input.
-      The prediction distribution is updated and returned from this function.
+      The prediction distribution (categorical distribution with probability of being in each of the hidden states) is
+      updated and returned from this function and can be used as input for the subsequent prediction step.
       """
-      observation = tf.convert_to_tensor(observation, name='observations')
+      observation = tf.convert_to_tensor(observation, name='observation')
 
       if not isinstance(initialisation_step, bool):
           raise TypeError('initialisation_step must be of type bool, but saw: %s' % initialisation_step)


### PR DESCRIPTION
Hello all,
my first attempt at a pull request - given a (pre-trained/ configured) HMM and an additional observation point, the function single_step_prediction outputs the probability over the hidden states (as a categorical distribution) and also returns a prediction for the next observed value (as a probs-weighted mean of the possible observation distributions).

In the initial step this is effectively the posterior_marginal (of the initial observation point). In a subsequent step, the function can then take the previous probability over hidden states (its output from the previous step) as a prior and a new observation point to update the probability over hidden states.
This way the function can be used to employ a trained HMM to make continuous predictions based on a stream of incoming (new) observation points.

Any suggestions/ tips as to what needs to be improved/ added most welcome.
Many thanks!