### PR TITLE
Upgrade setuptools for OSS testing

### DIFF
--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -175,7 +175,7 @@ install_jax() {
 install_python_packages() {
   # Ensure newer than 18.x pip version, which is necessary after tf-nightly
   # switched to manylinux2010.
-  python -m pip install $PIP_FLAGS --upgrade 'pip>=19.2'
+  python -m pip install $PIP_FLAGS --upgrade 'pip>=19.2' setuptools
 
   install_tensorflow
   install_jax

--- a/testing/run_github_lints.sh
+++ b/testing/run_github_lints.sh
@@ -27,13 +27,13 @@ get_changed_py_files() {
   fi
 }
 
-pip install --quiet pylint
+python -m pip install --quiet pylint
 
 # Run lints on added/changed python files.
 changed_py_files=$(get_changed_py_files)
 if [[ -n "${changed_py_files}" ]]; then
   echo "Running pylint on ${changed_py_files}"
-  pylint -j2 --rcfile=testing/pylintrc ${changed_py_files}
+  python -m pylint -j2 --rcfile=testing/pylintrc ${changed_py_files}
 else
   echo "No files to lint."
 fi

--- a/testing/run_github_lints.sh
+++ b/testing/run_github_lints.sh
@@ -27,6 +27,7 @@ get_changed_py_files() {
   fi
 }
 
+python -m pip install --upgrade --quiet pip setuptools
 python -m pip install --quiet pylint
 
 # Run lints on added/changed python files.


### PR DESCRIPTION
OSS tests have been failing, and it looks like it is due to an old version of setuptools.