### PR TITLE
Fix GitHub Actions... again.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,8 +14,6 @@
 # ============================================================================
 name: Tests
 on: [push, pull_request]
-env:
-  TEST_VENV_PATH: ~/test_virtualenv
 jobs:
   lints:
     name: Lints
@@ -32,13 +30,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Setup virtualenv
-        run: |
-          sudo apt install virtualenv
-          virtualenv -p python${{ matrix.python-version }} ${TEST_VENV_PATH}
       - name: Lints
         run: |
-          source ${TEST_VENV_PATH}/bin/activate
           ./testing/run_github_lints.sh
   tests:
     name: Tests
@@ -48,7 +41,6 @@ jobs:
         python-version: [3.7]
         shard: [0, 1, 2, 3, 4]
     env:
-      TEST_VENV_PATH: ~/test_virtualenv
       SHARD: ${{ matrix.shard }}
       NUM_SHARDS: 5
     steps:
@@ -60,13 +52,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Setup virtualenv
-        run: |
-          sudo apt install virtualenv
-          virtualenv -p python${{ matrix.python-version }} ${TEST_VENV_PATH}
       - name: Tests
         run: |
-          source ${TEST_VENV_PATH}/bin/activate
           ./testing/run_github_tests.sh
       - name: Upload test logs
         if: failure()

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -173,11 +173,6 @@ install_jax() {
 }
 
 install_python_packages() {
-  # Ensure newer than 18.x pip version, which is necessary after tf-nightly
-  # switched to manylinux2010.
-  python -m pip install $PIP_FLAGS --upgrade 'pip>=19.2'
-  python -m pip install --upgrade setuptools
-
   install_tensorflow
   install_jax
 
@@ -193,6 +188,11 @@ install_python_packages() {
   python -m pip --version
   python -m pip list
 }
+
+# Ensure newer than 18.x pip version, which is necessary after tf-nightly
+# switched to manylinux2010.
+python -m pip install $PIP_FLAGS --upgrade 'pip>=19.2'
+python -m pip install --upgrade setuptools
 
 check_for_common_package_conflicts
 install_python_packages

--- a/testing/run_github_lints.sh
+++ b/testing/run_github_lints.sh
@@ -27,6 +27,7 @@ get_changed_py_files() {
   fi
 }
 
+python -m pip install --upgrade 'pip>=19.2'
 python -m pip install --upgrade setuptools
 python -m pip install --quiet pylint
 

--- a/testing/run_github_tests.sh
+++ b/testing/run_github_tests.sh
@@ -51,7 +51,7 @@ install_bazel() {
 }
 
 install_python_packages() {
-  ${DIR}/install_test_dependencies.sh
+  ${DIR}/install_test_dependencies.sh --user
 }
 
 # Only install bazel if not already present (useful for locally testing this
@@ -59,13 +59,16 @@ install_python_packages() {
 which bazel || install_bazel
 install_python_packages
 
+# You can alter this test_target to some smaller subset of TFP tests in case
+# you need to reproduce something on the CI workers.
+test_target="//tensorflow_probability/..."
 test_tags_to_skip="(gpu|requires-gpu-nvidia|notap|no-oss-ci|tfp_jax|tf2-broken|tf2-kokoro-broken)"
 
 # Given a test size (small, medium, large), a number of shards and a shard ID,
 # query and print a list of tests of the given size to run in the given shard.
 query_and_shard_tests_by_size() {
   size=$1
-  bazel_query="attr(size, ${size}, tests(//tensorflow_probability/...)) \
+  bazel_query="attr(size, ${size}, tests(${test_target})) \
                except \
                attr(tags, \"${test_tags_to_skip}\", \
                     tests(//tensorflow_probability/...))"
@@ -80,7 +83,8 @@ sharded_tests="$(query_and_shard_tests_by_size small)"
 sharded_tests="${sharded_tests} $(query_and_shard_tests_by_size medium)"
 sharded_tests="${sharded_tests} $(query_and_shard_tests_by_size large)"
 
-# Run tests using run_tfp_test.sh script.
+# Run tests using run_tfp_test.sh script. Don't bother if there are no tests
+# (bazel will error otherwise).
 if echo "${sharded_tests}" | grep ".*\w.*"; then
   echo "${sharded_tests}" \
     | xargs $DIR/run_tfp_test.sh


### PR DESCRIPTION
This time it appeared that pip was not installed correctly by virtualenv. I just removed virtualenv as a fix. As a matter of being more tidy, I also moved around the pip installation commands to happen before we invoke pip for various purposes. Lastly, in a mostly unrelated change, I made it clearer how to run a subset of tests inside run_github_tests.sh.