### PR TITLE
Update distribution_layer.py

### DIFF
--- a/tensorflow_probability/python/layers/distribution_layer.py
+++ b/tensorflow_probability/python/layers/distribution_layer.py
@@ -68,8 +68,11 @@ __all__ = [
     'VariationalGaussianProcess',
 ]
 
-
-tf.keras.__internal__.utils.register_symbolic_tensor_type(dtc._TensorCoercible)  # pylint: disable=protected-access
+try:
+  k_u = tf.keras.__internal__.utils
+except:
+  from keras.utils import tf_utils as k_u
+k_u.register_symbolic_tensor_type(dtc._TensorCoercible)  # pylint: disable=protected-access
 
 
 def _event_size(event_shape, name=None):


### PR DESCRIPTION
keras in TF 2.5.0 is not exposing the `tf.keras.__internal__` symbol for some reason, even though it's there in tf-nightly.