### PR TITLE
Fix typo in LaTeX definition of Gaussian mixture

### DIFF
--- a/tensorflow_probability/examples/jupyter_notebooks/Factorial_Mixture.ipynb
+++ b/tensorflow_probability/examples/jupyter_notebooks/Factorial_Mixture.ipynb
@@ -69,7 +69,7 @@
       },
       "source": [
         "In this notebook we show how to use [TensorFlow Probability](https://github.com/tensorflow/probability) (TFP) to sample from a factorial Mixture of Gaussians distribution defined as:\n",
-        "$$p(x_1, ..., x_n) = \\prod_i p_i(x_i)$$ where: $$\\begin{align*} p_i &\\equiv \\frac{1}{K}\\sum_{i=1}^K \\pi_{ik}\\,\\text{Normal}\\left(\\text{loc}=\\mu_{ik},\\, \\text{scale}=\\sigma_{ik}\\right)\\\\1&=\\sum_{k=1}^K\\pi_{ik}, \\forall i.\\hphantom{MMMMMMMMMMM}\\end{align*}$$\n",
+        "$$p(x_1, ..., x_n) = \\prod_i p_i(x_i)$$ where: $$\\begin{align*} p_i &\\equiv \\frac{1}{K}\\sum_{k=1}^K \\pi_{ik}\\,\\text{Normal}\\left(\\text{loc}=\\mu_{ik},\\, \\text{scale}=\\sigma_{ik}\\right)\\\\1&=\\sum_{k=1}^K\\pi_{ik}, \\forall i.\\hphantom{MMMMMMMMMMM}\\end{align*}$$\n",
         "\n",
         "Each variable $x_i$ is modeled as a mixture of Gaussians, and the joint distribution over all $n$ variables is a product of these densities.\n",
         "\n",


### PR DESCRIPTION
I'm pretty sure this summation is supposed to happen over the mixtures _k_, not the covariates _i_:

![image](https://user-images.githubusercontent.com/908970/123332784-f9139280-d50e-11eb-9b36-523f9b90064e.png)
