### PR TITLE
Issue 1408: bnn example seaborn errors corrections

### DIFF
--- a/tensorflow_probability/examples/bayesian_neural_network.py
+++ b/tensorflow_probability/examples/bayesian_neural_network.py
@@ -109,14 +109,14 @@ def plot_weight_posteriors(names, qm_vals, qs_vals, fname):
 
   ax = fig.add_subplot(1, 2, 1)
   for n, qm in zip(names, qm_vals):
-    sns.distplot(tf.reshape(qm, shape=[-1]), ax=ax, label=n)
+    sns.distplot(tf.reshape(qm, shape=[-1]).numpy(), ax=ax, label=n)
   ax.set_title('weight means')
   ax.set_xlim([-1.5, 1.5])
   ax.legend()
 
   ax = fig.add_subplot(1, 2, 2)
   for n, qs in zip(names, qs_vals):
-    sns.distplot(tf.reshape(qs, shape=[-1]), ax=ax)
+    sns.distplot(tf.reshape(qs, shape=[-1]).numpy(), ax=ax)
   ax.set_title('weight stddevs')
   ax.set_xlim([0, 1.])
 
@@ -147,12 +147,12 @@ def plot_heldout_prediction(input_vals, probs,
 
     ax = fig.add_subplot(n, 3, 3*i + 2)
     for prob_sample in probs:
-      sns.barplot(np.arange(10), prob_sample[i, :], alpha=0.1, ax=ax)
+      sns.barplot(np.arange(10), prob_sample[i, :].numpy(), alpha=0.1, ax=ax)
       ax.set_ylim([0, 1])
     ax.set_title('posterior samples')
 
     ax = fig.add_subplot(n, 3, 3*i + 3)
-    sns.barplot(np.arange(10), tf.reduce_mean(probs[:, i, :], axis=0), ax=ax)
+    sns.barplot(np.arange(10), tf.reduce_mean(probs[:, i, :], axis=0).numpy(), ax=ax)
     ax.set_ylim([0, 1])
     ax.set_title('predictive probs')
   fig.suptitle(title)


### PR DESCRIPTION
Proposition for correcting issue #1408 Error with seaborn in examples/bayesian_neural_network.py (2)

Convert tensorflow tensors in numpy array just before calling seaborn function.

 It seems certain operations that numpy propose is not available yet on tf tensors.