### PR TITLE
Implemention of Mean Method in distributions.Categorical

### DIFF
--- a/tensorflow_probability/python/distributions/categorical.py
+++ b/tensorflow_probability/python/distributions/categorical.py
@@ -321,6 +321,12 @@ class Categorical(distribution.AutoCompositeTensorDistribution):
         tf.math.multiply_no_nan(masked_logits, tf.math.exp(logits)),
         axis=-1) / tf.math.exp(lse_logits)
 
+  def _mean(self):
+    x = self._probs if self._logits is None else self._logits
+    mean = tf.cast(tf.reduce_mean(x, axis=-1), self.dtype)
+    tensorshape_util.set_shape(mean, x.shape[:-1])
+    return mean      
+
   def _mode(self):
     x = self._probs if self._logits is None else self._logits
     mode = tf.cast(tf.argmax(x, axis=-1), self.dtype)


### PR DESCRIPTION
## Proposition for correcting issue #685 Error with Implementation of Mean Method in distributions.Categorical

> NotImplementedError: mean is not implemented: Categorical


```py
import tensorflow_probability as tfp

prob_dist = tfp.distributions.Categorical(probs=[1.0])
print(prob_dist.mean())

```


Defined a `_mean` method for implementing mean