### PR TITLE
BUG: fix polyval() for jax v0.2.20

### DIFF
--- a/tensorflow_probability/python/internal/backend/numpy/numpy_math.py
+++ b/tensorflow_probability/python/internal/backend/numpy/numpy_math.py
@@ -789,7 +789,7 @@ polygamma = utils.copy_docstring(
 
 polyval = utils.copy_docstring(
     'tf.math.polyval',
-    lambda coeffs, x, name=None: np.polyval(coeffs, x))
+    lambda coeffs, x, name=None: np.polyval(np.asarray(coeffs), np.asarray(x)))
 
 pow = utils.copy_docstring(  # pylint: disable=redefined-builtin
     'tf.math.pow',


### PR DESCRIPTION
Why? This fixes breakages due to https://github.com/google/jax/pull/7732