### PR TITLE
BUG FIX: prefer static shapes in cholesky update

### DIFF
--- a/tensorflow_probability/python/math/linalg.py
+++ b/tensorflow_probability/python/math/linalg.py
@@ -150,7 +150,7 @@ def cholesky_update(chol, update_vector, multiplier=1., name=None):
             ps.shape(chol)[:-2],
             ps.shape(update_vector)[:-1]), ps.shape(multiplier))
     chol = tf.broadcast_to(
-        chol, ps.concat([batch_shape, tf.shape(chol)[-2:]], axis=0))
+        chol, ps.concat([batch_shape, ps.shape(chol)[-2:]], axis=0))
     update_vector = tf.broadcast_to(
         update_vector,
         ps.concat([batch_shape, ps.shape(update_vector)[-1:]], axis=0))
@@ -196,7 +196,7 @@ def cholesky_update(chol, update_vector, multiplier=1., name=None):
 
     new_diag, new_chol, _, _ = tf.scan(
         fn=compute_new_column,
-        elems=(tf.range(0, tf.shape(chol)[0]), chol_diag, chol),
+        elems=(tf.range(0, ps.shape(chol)[0]), chol_diag, chol),
         initializer=(
             tf.zeros_like(multiplier),
             tf.zeros_like(chol[0, ...]),

--- a/tensorflow_probability/python/math/linalg_test.py
+++ b/tensorflow_probability/python/math/linalg_test.py
@@ -142,8 +142,16 @@ class PushApartTest(test_util.TestCase):
 
 
 class _CholeskyUpdate(test_util.TestCase):
+  def testCholeskyUpdateXLA(self):
+    self.skip_if_no_xla()
+    cholesky_update_fun = tf.function(tfp.math.cholesky_update, jit_compile=True)
+    self._testCholeskyUpdate(cholesky_update_fun)
 
   def testCholeskyUpdate(self):
+    self.skip_if_no_xla()
+    self._testCholeskyUpdate(tfp.math.cholesky_update)
+
+  def _testCholeskyUpdate(self, cholesky_update_fun):
     rng = test_util.test_np_rng()
     xs = rng.random_sample(7).astype(self.dtype)[:, tf.newaxis]
     xs = tf1.placeholder_with_default(
@@ -158,7 +166,7 @@ class _CholeskyUpdate(test_util.TestCase):
 
     new_chol_expected = tf.linalg.cholesky(
         mat + tf.linalg.matmul(u, u, transpose_b=True))
-    new_chol = tfp.math.cholesky_update(chol, tf.squeeze(u, axis=-1))
+    new_chol = cholesky_update_fun(chol, tf.squeeze(u, axis=-1))
     self.assertAllClose(new_chol_expected, new_chol, rtol=1e-5, atol=2e-5)
 
   def testCholeskyUpdateBatches(self):
@@ -224,6 +232,7 @@ class _CholeskyUpdate(test_util.TestCase):
 
     new_chol = tfp.math.cholesky_update(chol, u, multiplier=multiplier)
     self.assertAllClose(new_chol_expected, new_chol, rtol=1e-5, atol=2e-5)
+
 
 
 @test_util.test_all_tf_execution_regimes

--- a/tensorflow_probability/python/math/linalg_test.py
+++ b/tensorflow_probability/python/math/linalg_test.py
@@ -144,7 +144,8 @@ class PushApartTest(test_util.TestCase):
 class _CholeskyUpdate(test_util.TestCase):
   def testCholeskyUpdateXLA(self):
     self.skip_if_no_xla()
-    cholesky_update_fun = tf.function(tfp.math.cholesky_update, jit_compile=True)
+    cholesky_update_fun = tf.function(tfp.math.cholesky_update,
+                                      jit_compile=True)
     self._testCholeskyUpdate(cholesky_update_fun)
 
   def testCholeskyUpdate(self):

--- a/tensorflow_probability/python/math/linalg_test.py
+++ b/tensorflow_probability/python/math/linalg_test.py
@@ -234,7 +234,6 @@ class _CholeskyUpdate(test_util.TestCase):
     self.assertAllClose(new_chol_expected, new_chol, rtol=1e-5, atol=2e-5)
 
 
-
 @test_util.test_all_tf_execution_regimes
 class CholeskyUpdate32Static(_CholeskyUpdate):
   dtype = np.float32


### PR DESCRIPTION
This is to fix https://github.com/tensorflow/probability/issues/1421

I am not sure the way I tested it is the preferred way, but this substrates testing is a bit fuzzy to me, so feel free to edit it (I left edits open for maintainers).