### PR TITLE
:memo: Fix href-markdown problems

### DIFF
--- a/tensorflow_probability/python/stats/moving_stats.py
+++ b/tensorflow_probability/python/stats/moving_stats.py
@@ -47,10 +47,10 @@ def assign_moving_mean_variance(value, moving_mean, moving_variance=None,
   and also uses the `assign_add` op to allow concurrent lockless updates to the
   supplied variables.
 
-  For additional references see [this John D. Cook blog post][
-  https://www.johndcook.com/blog/standard_deviation/]
-  (whereas we use `1 - decay = 1 / k`) and
-  [Finch (2009; Eq.  143)][2] (whereas we use `1 - decay = alpha`).
+  For additional references see 
+  [John D. Cook's Blog](https://www.johndcook.com/blog/standard_deviation), 
+  whereas we use `1 - decay = 1 / k`, and
+  [Finch (2009; Eq.  143)][2], whereas we use `1 - decay = alpha`.
 
   Since variables that are initialized to a `0` value will be `0` biased,
   providing `zero_debias_count` triggers scaling the `moving_mean` and


### PR DESCRIPTION
The current documentation was wrongly parsed as markdown links, making the changes within the `()` invisible in the deployed docs, and instead showing broken links.

Changes: I removed unneeded brackets which provides a (subjectively) smoother read and also fixes the above mentioned markdown problems. I also renamed the reference to John D. Cook's Blog.