### PR TITLE
Autoregressive moving average [WIP]

### DIFF
--- a/tensorflow_probability/python/sts/__init__.py
+++ b/tensorflow_probability/python/sts/__init__.py
@@ -34,6 +34,7 @@ _allowed_symbols = [
     'AdditiveStateSpaceModel',
     'Autoregressive',
     'AutoregressiveStateSpaceModel',
+    'AutoregressiveMovingAverageStateSpaceModel',
     'ConstrainedSeasonalStateSpaceModel',
     'DynamicLinearRegression',
     'DynamicLinearRegressionStateSpaceModel',

--- a/tensorflow_probability/python/sts/components/BUILD
+++ b/tensorflow_probability/python/sts/components/BUILD
@@ -68,6 +68,32 @@ py_test(
 )
 
 py_library(
+    name = "autoregressive_moving_average",
+    srcs = ["autoregressive_moving_average.py"],
+    srcs_version = "PY3",
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:dtype_util",
+        "//tensorflow_probability/python/sts/internal",
+    ],
+)
+
+py_test(
+    name = "autoregressive_moving_average_test",
+    size = "medium",
+    srcs = ["autoregressive_moving_average_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:test_util",
+    ],
+)
+
+py_library(
     name = "dynamic_regression",
     srcs = ["dynamic_regression.py"],
     srcs_version = "PY3",

--- a/tensorflow_probability/python/sts/components/__init__.py
+++ b/tensorflow_probability/python/sts/components/__init__.py
@@ -18,6 +18,7 @@
 from tensorflow_probability.python.internal import all_util
 from tensorflow_probability.python.sts.components.autoregressive import Autoregressive
 from tensorflow_probability.python.sts.components.autoregressive import AutoregressiveStateSpaceModel
+from tensorflow_probability.python.sts.components.autoregressive_moving_average import AutoregressiveMovingAverageStateSpaceModel
 from tensorflow_probability.python.sts.components.dynamic_regression import DynamicLinearRegression
 from tensorflow_probability.python.sts.components.dynamic_regression import DynamicLinearRegressionStateSpaceModel
 from tensorflow_probability.python.sts.components.local_level import LocalLevel
@@ -41,6 +42,7 @@ _allowed_symbols = [
     'AdditiveStateSpaceModel',
     'Autoregressive',
     'AutoregressiveStateSpaceModel',
+    'AutoregressiveMovingAverageStateSpaceModel',
     'ConstrainedSeasonalStateSpaceModel',
     'DynamicLinearRegression',
     'DynamicLinearRegressionStateSpaceModel',

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
@@ -86,8 +86,8 @@ class AutoregressiveMovingAverageStateSpaceModel(tfd.LinearGaussianStateSpaceMod
     in the formal sense. Setting `observation_noise_scale` to a nonzero value
     corresponds to a latent ARMA(p, p-1) process observed under an iid noise model.
 
-    References: http://web.pdx.edu/~crkl/readings/Hamilton94.pdf
-
+    See the [Wikipedia article](http://web.pdx.edu/~crkl/readings/Hamilton94.pdf)
+    for details on the Hamilton state space formulation for ARMA(p, p-1) processes.
     """
 
     def __init__(self,

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
@@ -16,7 +16,6 @@
 # Dependency imports
 import tensorflow.compat.v2 as tf
 from tensorflow_probability.python import distributions as tfd
-from tensorflow_probability.python.internal import distribution_util as dist_util
 from tensorflow_probability.python.sts.components.autoregressive import make_ar_transition_matrix
 
 

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
@@ -219,7 +219,7 @@ class AutoregressiveMovingAverageStateSpaceModel(tfd.LinearGaussianStateSpaceMod
 
 
 def _pad_tensor_with_trailing_zeros(x, num_zeros):
-    pad = tf.zeros_like(x, dtype=x.dtype)[..., 0:1]
+    pad = tf.zeros_like(x[..., 0:1])
     pad = tf.repeat(pad, num_zeros, axis=-1)
     return tf.concat([x, pad], axis=-1)
 

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
@@ -113,7 +113,7 @@ class AutoregressiveMovingAverageStateSpaceModel(tfd.LinearGaussianStateSpaceMod
                 level[t-1] + ... + ar_coefficients[order-1] * level[t-order+1]`.
             ma_coefficients: `float` `Tensor` of shape `concat(batch_shape, [order])`
                 defining  the moving average coefficients. The ma_coefficients are defined
-                backwards in time: `noise[t] + ma_coefficients[1] * noise[t-1]
+                backwards in time: `noise[t] + ma_coefficients[0] * noise[t-1]
                 + ... + ma_coefficients[order-2] * noise[t-order+1]`.
             level_scale: Scalar (any additional dimensions are treated as batch
                 dimensions) `float` `Tensor` indicating the standard deviation of the

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
@@ -1,3 +1,17 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
 """Autoregressive Moving Average model."""
 # Dependency imports
 import tensorflow.compat.v2 as tf
@@ -5,106 +19,217 @@ from tensorflow_probability.python import distributions as tfd
 from tensorflow_probability.python.sts.components.autoregressive import make_ar_transition_matrix
 
 
+class AutoregressiveMovingAverageStateSpaceModel(tfd.LinearGaussianStateSpaceModel):
+    """State space model for an autoregressive moving average process.
 
-class ARMAStateSpaceModel(tfd.LinearGaussianStateSpaceModel):
-  """State space model for an autoregressive moving average process."""
+    A state space model (SSM) posits a set of latent (unobserved) variables that
+    evolve over time with dynamics specified by a probabilistic transition model
+    `p(z[t+1] | z[t])`. At each timestep, we observe a value sampled from an
+    observation model conditioned on the current state, `p(x[t] | z[t])`. The
+    special case where both the transition and observation models are Gaussians
+    with mean specified as a linear function of the inputs, is known as a linear
+    Gaussian state space model and supports tractable exact probabilistic
+    calculations; see `tfp.distributions.LinearGaussianStateSpaceModel` for
+    details.
 
-  def __init__(self,
-               num_timesteps,
-               ar_coefficients,
-               ma_coefficients,
-               level_scale,
-               initial_state_prior,
-               observation_noise_scale=0.,
-               name=None,
-               **linear_gaussian_ssm_kwargs):
-      """Build a state space model implementing an ARMA(p, p - 1) process.
+    In an autoregressive moving average (ARMA) process, the expected level at
+    each timestep is a linear function of previous levels, with added Gaussian
+    noise, and a linear function of previous Gaussian noise:
 
-      References:
-          http://web.pdx.edu/~crkl/readings/Hamilton94.pdf
+    ```python
+    level[t+1] = (sum(coefficients * levels[t:t-order:-1]) +
+    Normal(0., level_scale) +
+    sum(coefficients * noise[t:t-order:-1]))
+    ```
 
-      Hamilton Autoregressive Moving Average (ARMA) State Space Model (SSM):
-          (obs eqn)   y_t = Z * a_t
-          (state eqn) a_t+1 = T * a_t + e_t
+    The process is characterized by a vector `coefficients` whose size determines
+    the order of the process (how many previous values it looks at), and by
+    `level_scale`, the standard deviation of the noise added at each step.
 
-          T = [ phi[0], phi[1],     ..., phi[r]
-                1.,       0 ,       ..., 0.
-                0.,       1.,       ..., 0.
-                ...
-                0.,       0.,  ...,  1.,  0.   ]
-          Z = [1, theta[0], theta[1], ..., theta[r-1]]
-          e_t ~ N(loc=0., scale=diag([level_scale, 0., 0., ..., 0.])
+    This is formulated as a state space model by letting the latent state encode
+    the most recent values; see 'Mathematical Details' below.
 
-      Notes:
-          This representation is a ARMA(p, p - 1) process where q = p - 1.
-          Expects len(ar_coefficients) == len(ma_coefficients) + 1
+    The parameters `level_scale` and `observation_noise_scale` are each (a batch
+    of) scalars, and `coefficients` is a (batch) vector of size `[order]`. The
+    batch shape of this `Distribution` is the broadcast batch
+    shape of these parameters and of the `initial_state_prior`.
 
-      """
-      parameters = dict(locals())
-      parameters.update(linear_gaussian_ssm_kwargs)
-      del parameters['linear_gaussian_ssm_kwargs']
-      with tf.name_scope(name or 'ARMAStateSpaceModel') as name:
-          # The initial state prior determines the dtype of sampled values.
-          # Other model parameters must have the same dtype.
-          dtype = initial_state_prior.dtype
+    #### Mathematical Details
 
-          ar_coefficients = tf.convert_to_tensor(
-              value=ar_coefficients, name='ar_coefficients', dtype=dtype)
-          ma_coefficients = tf.convert_to_tensor(
-              value=ma_coefficients, name='ma_coefficients', dtype=dtype)
-          level_scale = tf.convert_to_tensor(
-              value=level_scale, name='level_scale', dtype=dtype)
-          observation_noise_scale = tf.convert_to_tensor(
-              value=observation_noise_scale,
-              name='observation_noise_scale', dtype=dtype)
+    The Hamilton autoregressive moving average model implements a
+    `tfp.distributions.LinearGaussianStateSpaceModel` with `latent_size = order`
+    and `observation_size = 1`. The latent state vector encodes the recent history
+    of the process, with the current value in the topmost dimension. At each
+    timestep, the transition sums the previous values to produce the new expected
+    value, shifts all other values down by a dimension, and adds noise to the
+    current value. This is formally encoded by the transition model:
 
-          p = tf.compat.dimension_value(ar_coefficients.shape[-1])
-          q = tf.compat.dimension_value(ma_coefficients.shape[-1])
+    ```
+    transition_matrix = [ phi[0], phi[1],     ..., phi[p]
+                          1.,       0 ,       ..., 0.
+                          0.,       1.,       ..., 0.
+                          ...
+                          0.,       0.,  ...,  1.,  0.   ]
 
-          if p is None or q is None:
-              raise ValueError('coefficients must have static shape.')
+    transition_noise ~ N(loc=0., scale=diag([level_scale, 0., 0., ..., 0.]))
+    ```
 
-          if p != q + 1:
-              raise ValueError("Only ARMA(p, p-1) representation supported.")
+    The observation model simply extracts the current (topmost) value,
+    sums the previous noise and optionally adds independent noise at each step:
 
-          self._order = p
-          self._ar_coefficients = ar_coefficients
-          self._ma_coefficients = ma_coefficients
-          self._level_scale = level_scale
+    ```
+    observation_matrix = [1, theta[0], theta[1], ..., theta[p-1]]
+    observation_noise ~ N(loc=0, scale=observation_noise_scale)
+    ```
 
-          super(ARMAStateSpaceModel, self).__init__(
-              num_timesteps=num_timesteps,
-              transition_matrix=make_ar_transition_matrix(ar_coefficients),
-              transition_noise=tfd.MultivariateNormalDiag(
-                  scale_diag=tf.stack([level_scale] +
-                                      [tf.zeros_like(level_scale)] * (
-                                              self.order - 1), axis=-1)),
-              observation_matrix=tf.concat(
-                  [tf.ones([1, 1], dtype=dtype),
-                   tf.reshape(ma_coefficients, (-1, 1))], axis=-1),
-              observation_noise=tfd.MultivariateNormalDiag(
-                  scale_diag=observation_noise_scale[..., tf.newaxis]),
-              initial_state_prior=initial_state_prior,
-              name=name,
-              **linear_gaussian_ssm_kwargs)
-          self._parameters = parameters
+    Models with `observation_noise_scale = 0.` are ARMA(p, p-1) processes
+    in the formal sense. Setting `observation_noise_scale` to a nonzero value
+    corresponds to a latent ARMA(p, p-1) process observed under an iid noise model.
 
-  @property
-  def order(self):
-      return self._order
+    References: http://web.pdx.edu/~crkl/readings/Hamilton94.pdf
 
-  @order.setter
-  def order(self, order):
-      self._order = order
+    """
 
-  @property
-  def ar_coefficients(self):
-      return self._ar_coefficients
+    def __init__(self,
+                 num_timesteps,
+                 ar_coefficients,
+                 ma_coefficients,
+                 level_scale,
+                 initial_state_prior,
+                 observation_noise_scale=0.,
+                 name=None,
+                 **linear_gaussian_ssm_kwargs):
+        """ Build a state space model implementing an ARMA(p, p - 1) process.
 
-  @property
-  def ma_coefficients(self):
-      return self._ma_coefficients
+        Args:
+            num_timesteps: Scalar `int` `Tensor` number of timesteps to model
+                with this distribution.
+            ar_coefficients: `float` `Tensor` of shape `concat(batch_shape, [order])`
+                defining  the autoregressive coefficients. The coefficients are defined
+                backwards in time: `coefficients[0] * level[t] + coefficients[1] *
+                level[t-1] + ... + coefficients[order-1] * level[t-order+1]`.
+            ma_coefficients: `float` `Tensor` of shape `concat(batch_shape, [order])`
+                defining  the moving average coefficients. The coefficients are defined
+                backwards in time: `coefficients[0] * noise[t] + coefficients[1] *
+                noise[t-1] + ... + coefficients[order-1] * noise[t-order+1]`.
+            level_scale: Scalar (any additional dimensions are treated as batch
+                dimensions) `float` `Tensor` indicating the standard deviation of the
+                transition noise at each step.
+            initial_state_prior: instance of `tfd.MultivariateNormal`
+                representing the prior distribution on latent states.  Must have
+                event shape `[order]`.
+            observation_noise_scale: Scalar (any additional dimensions are
+                treated as batch dimensions) `float` `Tensor` indicating the standard
+                deviation of the observation noise.
+                Default value: 0.
+            name: Python `str` name prefixed to ops created by this class.
+                Default value: "AutoregressiveStateSpaceModel".
+            **linear_gaussian_ssm_kwargs: Optional additional keyword arguments to
+                to the base `tfd.LinearGaussianStateSpaceModel` constructor.
 
-  @property
-  def level_scale(self):
-      return self._level_scale
+        Notes:
+            This representation is a ARMA(p, p - 1) process where q = p - 1.
+            If q + 1 != p, then either `ar_coefficients` or `ma_coefficients`
+            will be padded with zeros by the required amount to become a
+            ARMA(p, p - 1) process.
+        """
+        parameters = dict(locals())
+        parameters.update(linear_gaussian_ssm_kwargs)
+        del parameters['linear_gaussian_ssm_kwargs']
+        with tf.name_scope(name or 'ARMAStateSpaceModel') as name:
+            # The initial state prior determines the dtype of sampled values.
+            # Other model parameters must have the same dtype.
+            dtype = initial_state_prior.dtype
+
+            ar_coefficients = tf.convert_to_tensor(
+                value=ar_coefficients, name='ar_coefficients', dtype=dtype)
+            ma_coefficients = tf.convert_to_tensor(
+                value=ma_coefficients, name='ma_coefficients', dtype=dtype)
+            level_scale = tf.convert_to_tensor(
+                value=level_scale, name='level_scale', dtype=dtype)
+            observation_noise_scale = tf.convert_to_tensor(
+                value=observation_noise_scale,
+                name='observation_noise_scale', dtype=dtype)
+
+            p = tf.compat.dimension_value(ar_coefficients.shape[-1])
+            q = tf.compat.dimension_value(ma_coefficients.shape[-1])
+
+            if p is None or q is None:
+                raise ValueError('coefficients must have static shape.')
+
+            # if p != q + 1, then pad either of the arguments to ensure
+            # we end up fitting an ARMA(p, p-1) process.
+            if p > q + 1:
+                pad = tf.zeros([p - q - 1], dtype=dtype)
+                ma_coefficients = tf.concat([ma_coefficients, pad], axis=-1)
+            elif q + 1 > p:
+                pad = tf.zeros([q + 1 - p], dtype=dtype)
+                ar_coefficients = tf.concat([ar_coefficients, pad], axis=-1)
+
+            order = max(p, q + 1)
+            if order is None:
+                raise ValueError('coefficients must have static shape.')
+
+            self._order = order
+            self._ar_coefficients = ar_coefficients
+            self._ma_coefficients = ma_coefficients
+            self._level_scale = level_scale
+
+            super(AutoregressiveMovingAverageStateSpaceModel, self).__init__(
+                num_timesteps=num_timesteps,
+                transition_matrix=make_ar_transition_matrix(ar_coefficients),
+                transition_noise=tfd.MultivariateNormalDiag(
+                    scale_diag=tf.stack([level_scale] +
+                                        [tf.zeros_like(level_scale)] * (
+                                                self.order - 1), axis=-1)),
+                observation_matrix=make_ma_observation_matrix(ma_coefficients),
+                observation_noise=tfd.MultivariateNormalDiag(
+                    scale_diag=observation_noise_scale[..., tf.newaxis]),
+                initial_state_prior=initial_state_prior,
+                name=name,
+                **linear_gaussian_ssm_kwargs)
+            self._parameters = parameters
+
+    @property
+    def order(self):
+        return self._order
+
+    @order.setter
+    def order(self, order):
+        self._order = order
+
+    @property
+    def ar_coefficients(self):
+        return self._ar_coefficients
+
+    @property
+    def ma_coefficients(self):
+        return self._ma_coefficients
+
+    @property
+    def level_scale(self):
+        return self._level_scale
+
+
+def make_ma_observation_matrix(coefficients):
+    """Build observation matrix for an moving average StateSpaceModel.
+
+    When applied in the observation equation, this row vector extracts the
+    current (topmost) value and then takes a linear combination of previous
+    noise values that were added during previous recursive steps:
+
+    ```
+    observation_matrix = [1, theta[0], theta[1], ..., theta[p-1]]
+    ```
+
+    Args:
+        coefficients: float `Tensor` of shape `concat([batch_shape, [order - 1])`.
+
+    Returns:
+        ma_matrix: float `Tensor` with shape `concat([batch_shape, [order])`.
+    """
+    top_entry = tf.ones([1, 1], dtype=coefficients.dtype)
+    ma_matrix = tf.concat(
+        [top_entry, coefficients[..., tf.newaxis, :]], axis=-1
+    )
+    return ma_matrix

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average.py
@@ -1,0 +1,110 @@
+"""Autoregressive Moving Average model."""
+# Dependency imports
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python import distributions as tfd
+from tensorflow_probability.python.sts.components.autoregressive import make_ar_transition_matrix
+
+
+
+class ARMAStateSpaceModel(tfd.LinearGaussianStateSpaceModel):
+  """State space model for an autoregressive moving average process."""
+
+  def __init__(self,
+               num_timesteps,
+               ar_coefficients,
+               ma_coefficients,
+               level_scale,
+               initial_state_prior,
+               observation_noise_scale=0.,
+               name=None,
+               **linear_gaussian_ssm_kwargs):
+      """Build a state space model implementing an ARMA(p, p - 1) process.
+
+      References:
+          http://web.pdx.edu/~crkl/readings/Hamilton94.pdf
+
+      Hamilton Autoregressive Moving Average (ARMA) State Space Model (SSM):
+          (obs eqn)   y_t = Z * a_t
+          (state eqn) a_t+1 = T * a_t + e_t
+
+          T = [ phi[0], phi[1],     ..., phi[r]
+                1.,       0 ,       ..., 0.
+                0.,       1.,       ..., 0.
+                ...
+                0.,       0.,  ...,  1.,  0.   ]
+          Z = [1, theta[0], theta[1], ..., theta[r-1]]
+          e_t ~ N(loc=0., scale=diag([level_scale, 0., 0., ..., 0.])
+
+      Notes:
+          This representation is a ARMA(p, p - 1) process where q = p - 1.
+          Expects len(ar_coefficients) == len(ma_coefficients) + 1
+
+      """
+      parameters = dict(locals())
+      parameters.update(linear_gaussian_ssm_kwargs)
+      del parameters['linear_gaussian_ssm_kwargs']
+      with tf.name_scope(name or 'ARMAStateSpaceModel') as name:
+          # The initial state prior determines the dtype of sampled values.
+          # Other model parameters must have the same dtype.
+          dtype = initial_state_prior.dtype
+
+          ar_coefficients = tf.convert_to_tensor(
+              value=ar_coefficients, name='ar_coefficients', dtype=dtype)
+          ma_coefficients = tf.convert_to_tensor(
+              value=ma_coefficients, name='ma_coefficients', dtype=dtype)
+          level_scale = tf.convert_to_tensor(
+              value=level_scale, name='level_scale', dtype=dtype)
+          observation_noise_scale = tf.convert_to_tensor(
+              value=observation_noise_scale,
+              name='observation_noise_scale', dtype=dtype)
+
+          p = tf.compat.dimension_value(ar_coefficients.shape[-1])
+          q = tf.compat.dimension_value(ma_coefficients.shape[-1])
+
+          if p is None or q is None:
+              raise ValueError('coefficients must have static shape.')
+
+          if p != q + 1:
+              raise ValueError("Only ARMA(p, p-1) representation supported.")
+
+          self._order = p
+          self._ar_coefficients = ar_coefficients
+          self._ma_coefficients = ma_coefficients
+          self._level_scale = level_scale
+
+          super(ARMAStateSpaceModel, self).__init__(
+              num_timesteps=num_timesteps,
+              transition_matrix=make_ar_transition_matrix(ar_coefficients),
+              transition_noise=tfd.MultivariateNormalDiag(
+                  scale_diag=tf.stack([level_scale] +
+                                      [tf.zeros_like(level_scale)] * (
+                                              self.order - 1), axis=-1)),
+              observation_matrix=tf.concat(
+                  [tf.ones([1, 1], dtype=dtype),
+                   tf.reshape(ma_coefficients, (-1, 1))], axis=-1),
+              observation_noise=tfd.MultivariateNormalDiag(
+                  scale_diag=observation_noise_scale[..., tf.newaxis]),
+              initial_state_prior=initial_state_prior,
+              name=name,
+              **linear_gaussian_ssm_kwargs)
+          self._parameters = parameters
+
+  @property
+  def order(self):
+      return self._order
+
+  @order.setter
+  def order(self, order):
+      self._order = order
+
+  @property
+  def ar_coefficients(self):
+      return self._ar_coefficients
+
+  @property
+  def ma_coefficients(self):
+      return self._ma_coefficients
+
+  @property
+  def level_scale(self):
+      return self._level_scale

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
@@ -133,9 +133,10 @@ class _AutoregressiveMovingAverageStateSpaceModelTest(test_util.TestCase):
     level_scale = self._build_placeholder(
         np.exp(np.random.randn(*batch_shape)))
 
-    ssm = AutoregressiveStateSpaceModel(
+    ssm = AutoregressiveMovingAverageStateSpaceModel(
         num_timesteps=10,
-        coefficients=coefficients,
+        ar_coefficients=coefficients,
+        ma_coefficients=coefficients[..., :-1],
         level_scale=level_scale,
         initial_state_prior=tfd.MultivariateNormalDiag(
             scale_diag=self._build_placeholder(np.ones([order]))))

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
@@ -1,0 +1,192 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Autoregressive State Space Model Tests."""
+
+# Dependency imports
+import numpy as np
+import tensorflow.compat.v1 as tf1
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability import distributions as tfd
+from tensorflow_probability.python.internal import test_util
+from tensorflow_probability.python.sts import AutoregressiveStateSpaceModel
+from tensorflow_probability.python.sts import AutoregressiveMovingAverageStateSpaceModel
+
+
+def ar_explicit_logp(y, coefs, level_scale):
+  """Manual log-prob computation for an autoregressive process."""
+  num_coefs = len(coefs)
+  lp = 0.
+
+  # For the first few steps of y, where previous values
+  # are not available, we model them as zero-mean with
+  # stddev `prior_scale`.
+  for i in range(num_coefs):
+    zero_padded_y = np.zeros([num_coefs])
+    zero_padded_y[num_coefs - i:num_coefs] = y[:i]
+    pred_y = np.dot(zero_padded_y, coefs[::-1])
+    lp += tfd.Normal(pred_y, level_scale).log_prob(y[i])
+
+  for i in range(num_coefs, len(y)):
+    pred_y = np.dot(y[i - num_coefs:i], coefs[::-1])
+    lp += tfd.Normal(pred_y, level_scale).log_prob(y[i])
+
+  return lp
+
+
+class _AutoregressiveMovingAverageStateSpaceModelTest(test_util.TestCase):
+
+  def testEqualsAutoregressive(self):
+
+    # An ARMA(p, 0) process is just an AR(p) processes
+    num_timesteps = 10
+    observed_time_series = self._build_placeholder(
+        np.random.randn(num_timesteps, 1))
+
+    level_scale = self._build_placeholder(0.1)
+
+    # We'll test an AR1 process, and also (just for kicks) that the trivial
+    # embedding as an AR2 process gives the same model.
+    coefficients_order1 = np.array([1.]).astype(self.dtype)
+    coefficients_order2 = np.array([1., 1.]).astype(self.dtype)
+
+    ar1_ssm = AutoregressiveStateSpaceModel(
+        num_timesteps=num_timesteps,
+        coefficients=coefficients_order1,
+        level_scale=level_scale,
+        initial_state_prior=tfd.MultivariateNormalDiag(
+            scale_diag=[level_scale]))
+    ar2_ssm = AutoregressiveStateSpaceModel(
+        num_timesteps=num_timesteps,
+        coefficients=coefficients_order2,
+        level_scale=level_scale,
+        initial_state_prior=tfd.MultivariateNormalDiag(
+            scale_diag=[level_scale, 1.]))
+    arma1_ssm = AutoregressiveMovingAverageStateSpaceModel(
+        num_timesteps=num_timesteps,
+        ar_coefficients=coefficients_order1,
+        ma_coefficients=np.array([0.]).astype(self.dtype),
+        level_scale=level_scale,
+        initial_state_prior=tfd.MultivariateNormalDiag(
+            scale_diag=[level_scale, 1.]))
+    arma2_ssm = AutoregressiveMovingAverageStateSpaceModel(
+        num_timesteps=num_timesteps,
+        ar_coefficients=coefficients_order2,
+        ma_coefficients=np.array([0.]).astype(self.dtype),
+        level_scale=level_scale,
+        initial_state_prior=tfd.MultivariateNormalDiag(
+            scale_diag=[level_scale, 1.]))
+
+    ar1_lp, arma1_lp, ar2_lp, arma2_lp = self.evaluate(
+        (ar1_ssm.log_prob(observed_time_series),
+         arma1_ssm.log_prob(observed_time_series),
+         ar2_ssm.log_prob(observed_time_series),
+         arma2_ssm.log_prob(observed_time_series)
+         ))
+    self.assertAllClose(ar1_lp, arma1_lp)
+    self.assertAllClose(ar2_lp, arma2_lp)
+
+  # def testLogprobCorrectness(self):
+  #   # Compare the state-space model's log-prob to an explicit implementation.
+  #   num_timesteps = 10
+  #   observed_time_series_ = np.random.randn(num_timesteps)
+  #   coefficients_ = np.array([.7, -.1]).astype(self.dtype)
+  #   level_scale_ = 1.0
+  #
+  #   observed_time_series = self._build_placeholder(observed_time_series_)
+  #   level_scale = self._build_placeholder(level_scale_)
+  #
+  #   expected_logp = ar_explicit_logp(
+  #       observed_time_series_, coefficients_, level_scale_)
+  #
+  #   ssm = AutoregressiveStateSpaceModel(
+  #       num_timesteps=num_timesteps,
+  #       coefficients=coefficients_,
+  #       level_scale=level_scale,
+  #       initial_state_prior=tfd.MultivariateNormalDiag(
+  #           scale_diag=[level_scale, 0.]))
+  #
+  #   lp = ssm.log_prob(observed_time_series[..., tf.newaxis])
+  #   self.assertAllClose(self.evaluate(lp), expected_logp)
+
+  def testBatchShape(self):
+    # Check that the model builds with batches of parameters.
+    order = 3
+    batch_shape = [4, 2]
+
+    # No `_build_placeholder`, because coefficients must have static shape.
+    coefficients = np.random.randn(*(batch_shape + [order])).astype(self.dtype)
+
+    level_scale = self._build_placeholder(
+        np.exp(np.random.randn(*batch_shape)))
+
+    ssm = AutoregressiveStateSpaceModel(
+        num_timesteps=10,
+        coefficients=coefficients,
+        level_scale=level_scale,
+        initial_state_prior=tfd.MultivariateNormalDiag(
+            scale_diag=self._build_placeholder(np.ones([order]))))
+    if self.use_static_shape:
+      self.assertAllEqual(ssm.batch_shape.as_list(), batch_shape)
+    else:
+      self.assertAllEqual(self.evaluate(ssm.batch_shape_tensor()), batch_shape)
+
+    y = ssm.sample()
+    if self.use_static_shape:
+      self.assertAllEqual(y.shape.as_list()[:-2], batch_shape)
+    else:
+      self.assertAllEqual(self.evaluate(tf.shape(y))[:-2], batch_shape)
+
+  def _build_placeholder(self, ndarray):
+    """Convert a numpy array to a TF placeholder.
+
+    Args:
+      ndarray: any object convertible to a numpy array via `np.asarray()`.
+
+    Returns:
+      placeholder: a TensorFlow `placeholder` with default value given by the
+      provided `ndarray`, dtype given by `self.dtype`, and shape specified
+      statically only if `self.use_static_shape` is `True`.
+    """
+
+    ndarray = np.asarray(ndarray).astype(self.dtype)
+    return tf1.placeholder_with_default(
+        ndarray, shape=ndarray.shape if self.use_static_shape else None)
+
+
+@test_util.test_all_tf_execution_regimes
+class AutoregressiveMovingAverageStateSpaceModelTestStaticShape32(
+    _AutoregressiveMovingAverageStateSpaceModelTest):
+  dtype = np.float32
+  use_static_shape = True
+
+
+@test_util.test_all_tf_execution_regimes
+class AutoregressiveMovingAverageStateSpaceModelTestDynamicShape32(
+    _AutoregressiveMovingAverageStateSpaceModelTest):
+  dtype = np.float32
+  use_static_shape = False
+
+
+@test_util.test_all_tf_execution_regimes
+class AutoregressiveMovingAverageStateSpaceModelTestStaticShape64(
+    _AutoregressiveMovingAverageStateSpaceModelTest):
+  dtype = np.float64
+  use_static_shape = True
+
+del _AutoregressiveMovingAverageStateSpaceModelTest  # Don't run tests for the base class.
+
+if __name__ == "__main__":
+  test_util.main()

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Probability Authors.
+# Copyright 2021 The TensorFlow Probability Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
+++ b/tensorflow_probability/python/sts/components/autoregressive_moving_average_test.py
@@ -98,6 +98,7 @@ class _AutoregressiveMovingAverageStateSpaceModelTest(test_util.TestCase):
     self.assertAllClose(ar1_lp, arma1_lp)
     self.assertAllClose(ar2_lp, arma2_lp)
 
+    # TODO: Implement this test
   # def testLogprobCorrectness(self):
   #   # Compare the state-space model's log-prob to an explicit implementation.
   #   num_timesteps = 10

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -133,9 +133,11 @@ check_for_common_package_conflicts() {
     exit 1
   fi
 }
+python -m pip install tf-nightly-cpu
+python -m pip uninstall tensorflow-io-gcs-filesystem 0.22.0
 
 install_python_packages() {
-  install_tensorflow "${TF_NIGHTLY_PACKAGE}" "${PIP_FLAGS}"
+#  install_tensorflow "${TF_NIGHTLY_PACKAGE}" "${PIP_FLAGS}"
   install_jax "${PIP_FLAGS}"
   install_common_packages "${PIP_FLAGS}"
   install_test_only_packages "${PIP_FLAGS}"

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -133,11 +133,9 @@ check_for_common_package_conflicts() {
     exit 1
   fi
 }
-python -m pip install tf-nightly-cpu
-python -m pip uninstall tensorflow-io-gcs-filesystem 0.22.0
 
 install_python_packages() {
-#  install_tensorflow "${TF_NIGHTLY_PACKAGE}" "${PIP_FLAGS}"
+  install_tensorflow "${TF_NIGHTLY_PACKAGE}" "${PIP_FLAGS}"
   install_jax "${PIP_FLAGS}"
   install_common_packages "${PIP_FLAGS}"
   install_test_only_packages "${PIP_FLAGS}"


### PR DESCRIPTION
Implements a Hamilton ARMA(p, p-1) as referenced in [this issue](https://github.com/tensorflow/probability/issues/677).

Two tests are completed (batch shape and AR(p) equivalence), manual ARMA log_prob calculation is still WIP.

Since we need ARMA(p, p-1) to get correct shapes for `tfd.LinearGaussianStateSpaceModel`, I think the best design is to automatically pad either the `ar_coefficients` or `ma_coefficients` to meet this requirement (i.e. `ar=[1, 1, 1]`, `ma=[1, 1, 1]` becomes `ar=[1, 1, 1, 0]`, `ma=[1, 1, 1]`. Thus enabling users access to the general ARMA(p, q) formulation without too much complaining from the api. This might lead to unexpected behavior for `initial_state_prior` since this argument will need to be of shape `[batch, max(p, q + 1)]` which might be mentioned as a gotcha in the documentation.

Code was compared against [this statsmodel example](https://www.statsmodels.org/dev/examples/notebooks/generated/statespace_sarimax_internet.html) up to ARMA(2, 2) models:

``` python
import pytest
import pandas as pd
import statsmodels.api as sm
from autotsml.layers.probabilistic import ARMAStateSpaceModel
import tensorflow_probability as tfp
import tensorflow as tf
import numpy as np
import warnings

warnings.simplefilter('ignore')

tfd = tfp.distributions

import requests
from io import BytesIO
from zipfile import ZipFile

MAX_STEP = 5
E = 0.05

# Download the dataset
dk = requests.get('http://www.ssfpack.com/files/DK-data.zip').content
f = BytesIO(dk)
zipped = ZipFile(f)
df = pd.read_table(
    BytesIO(zipped.read('internet.dat')),
    skiprows=1, header=None, sep='\s+', engine='python',
    names=['internet', 'dinternet']
)
# Get the basic series
dta_full = df.dinternet[1:].values
x = dta_full.reshape(-1, 1)
dta_miss = dta_full.copy()

# Remove datapoints
missing = np.r_[6, 16, 26, 36, 46, 56, 66, 72, 73, 74, 75, 76, 86, 96] - 1
dta_miss[missing] = np.nan

optimizer = tf.keras.optimizers.Adam(learning_rate=0.1)

@pytest.mark.parametrize("p", [1, 2])
@pytest.mark.parametrize("q", [1, 2])
def test_arma_statsmodel(p, q):
    """https://www.statsmodels.org/dev/examples/notebooks/generated/statespace_sarimax_internet.html"""
    model = sm.tsa.statespace.SARIMAX(
        x, order=(p, 0, q),
        hamilton_representation=True,
        enforce_invertibility=False).fit()

    # warm start tfp since this problem is non-linear and highly sensitive to
    # the initial parameter configurations
    ar_init = model.arparams + tf.random.normal(model.arparams.shape, stddev=E)
    ma_init = model.maparams + tf.random.normal(model.maparams.shape, stddev=E)

    # instantiate the parameters for the ARMA model
    ar_params = tf.Variable(ar_init, trainable=True, name='ar')
    ma_params = tf.Variable(ma_init, trainable=True, name='ma')
    scale_params = tf.Variable(1., trainable=True, name='scale')

    def make_arma_model():
        return ARMAStateSpaceModel(
            num_timesteps=len(x),
            ar_coefficients=ar_params,
            ma_coefficients=ma_params,
            level_scale=scale_params,
            initial_state_prior=tfd.MultivariateNormalDiag(
                scale_diag=[1.] * max(p, q + 1))
        )

    def nll():
        return -make_arma_model().log_prob(x)

    @tf.function(autograph=False)
    def train_op():
        with tf.GradientTape() as tape:
            loss = nll()
        grads = tape.gradient(
            loss, make_arma_model().trainable_variables)
        optimizer.apply_gradients(
            zip(grads, make_arma_model().trainable_variables))
        return loss, make_arma_model().trainable_variables

    for step in range(MAX_STEP):
        loss, vars = train_op()
        vars = [i.numpy() for i in vars]
        if step % 20 == 0:
            print("step {}: log prob {}: vars {}".format(step, loss, vars))

    np.testing.assert_allclose(model.arparams, ar_params.numpy(), atol=0.5)
    np.testing.assert_allclose(model.maparams, ma_params.numpy(), atol=0.5)
```

But was omitted since this test does not qualify as lightweight (which was requested).

The author and devs of statsmodel both note that parameter estimation becomes unstable with higher order models, I see this begins at order 3 (i.e. ARMA(3, 3))