### PR TITLE
modified SplineParams example for improved clarity

### DIFF
--- a/tensorflow_probability/python/bijectors/rational_quadratic_spline.py
+++ b/tensorflow_probability/python/bijectors/rational_quadratic_spline.py
@@ -73,8 +73,13 @@ class RationalQuadraticSpline(bijector.AutoCompositeTensorBijector):
 
   class SplineParams(tf.Module):
 
-    def __init__(self, nbins=32):
+    def __init__(self, nbins=32, interval_width=2, range_min=-1,
+                 min_bin_width=1e-3, min_slope=1e-3):
       self._nbins = nbins
+      self._interval_width = interval_width
+      self._range_min = range_min
+      self._min_bin_width = min_bin_width
+      self._min_slope = min_slope
       self._built = False
       self._bin_widths = None
       self._bin_heights = None
@@ -85,26 +90,29 @@ class RationalQuadraticSpline(bijector.AutoCompositeTensorBijector):
         def _bin_positions(x):
           out_shape = tf.concat((tf.shape(x)[:-1], (nunits, self._nbins)), 0)
           x = tf.reshape(x, out_shape)
-          return tf.math.softmax(x, axis=-1) * (2 - self._nbins * 1e-2) + 1e-2
+          return tf.math.softmax(x, axis=-1) * (
+                self._interval_width - self._nbins * self._min_bin_width) + \
+                 self._min_bin_width
 
         def _slopes(x):
           out_shape = tf.concat((
             tf.shape(x)[:-1], (nunits, self._nbins - 1)), 0)
           x = tf.reshape(x, out_shape)
-          return tf.math.softplus(x) + 1e-2
+          return tf.math.softplus(x) + self._min_slope
 
         self._bin_widths = tf.keras.layers.Dense(
-            nunits * self._nbins, activation=_bin_positions, name='w')
+          nunits * self._nbins, activation=_bin_positions, name='w')
         self._bin_heights = tf.keras.layers.Dense(
-            nunits * self._nbins, activation=_bin_positions, name='h')
+          nunits * self._nbins, activation=_bin_positions, name='h')
         self._knot_slopes = tf.keras.layers.Dense(
-            nunits * (self._nbins - 1), activation=_slopes, name='s')
+          nunits * (self._nbins - 1), activation=_slopes, name='s')
         self._built = True
 
       return tfb.RationalQuadraticSpline(
-          bin_widths=self._bin_widths(x),
-          bin_heights=self._bin_heights(x),
-          knot_slopes=self._knot_slopes(x))
+        bin_widths=self._bin_widths(x),
+        bin_heights=self._bin_heights(x),
+        knot_slopes=self._knot_slopes(x),
+        range_min=self._range_min)
 
   xs = np.random.randn(3, 15).astype(np.float32)  # Keras won't Dense(.)(vec).
   splines = [SplineParams() for _ in range(nsplits)]

--- a/tensorflow_probability/python/bijectors/rational_quadratic_spline.py
+++ b/tensorflow_probability/python/bijectors/rational_quadratic_spline.py
@@ -76,10 +76,10 @@ class RationalQuadraticSpline(bijector.AutoCompositeTensorBijector):
     def __init__(self, nbins=32, interval_width=2, range_min=-1,
                  min_bin_width=1e-3, min_slope=1e-3):
       self._nbins = nbins
-      self._interval_width = interval_width
-      self._range_min = range_min
-      self._min_bin_width = min_bin_width
-      self._min_slope = min_slope
+      self._interval_width = interval_width # Sum of bin widths.
+      self._range_min = range_min # Position of first knot.
+      self._min_bin_width = min_bin_width # Bin width lower bound.
+      self._min_slope = min_slope # Lower bound for slopes at internal knots.
       self._built = False
       self._bin_widths = None
       self._bin_heights = None
@@ -91,8 +91,8 @@ class RationalQuadraticSpline(bijector.AutoCompositeTensorBijector):
           out_shape = tf.concat((tf.shape(x)[:-1], (nunits, self._nbins)), 0)
           x = tf.reshape(x, out_shape)
           return tf.math.softmax(x, axis=-1) * (
-                self._interval_width - self._nbins * self._min_bin_width) + \
-                 self._min_bin_width
+                self._interval_width - self._nbins * self._min_bin_width
+                ) + self._min_bin_width
 
         def _slopes(x):
           out_shape = tf.concat((


### PR DESCRIPTION
When using SplineParams as in the example, it was not clear to me how to set the interval width and height B as defined in the Neural Splines Flow paper. I have modified the example by adding parameters that the user can specify: the interval width, the smallest knot position, the minimum width/height of the bins (assuming that they will be equal) and the minimum slope. The default values for `min_bin_width` and `min_slope` are set as they are in the official pytorch implementation https://github.com/bayesiains/nflows/blob/master/nflows/transforms/splines/rational_quadratic.py

I believe that some comments might be needed to clarify what `nunits` is and why it is given as argument to `__call__`, as it was quite confusing to me and it's specific to using the splines with RealNVP. Otherwise, an additional example using the splines with MaskedAutoregressiveFlow might also be helpful.