### PR TITLE
Fix Multivariate Student's t-distribution docstring

### DIFF
--- a/tensorflow_probability/python/distributions/multivariate_student_t.py
+++ b/tensorflow_probability/python/distributions/multivariate_student_t.py
@@ -103,7 +103,6 @@ class MultivariateStudentTLinearOperator(
   # Compute the pdf of an`R^3` observation; return a scalar.
   mvt.prob([-1., 0, 1])  # shape: []
   ```
-
   """
 
   def __init__(self,

--- a/tensorflow_probability/python/distributions/multivariate_student_t.py
+++ b/tensorflow_probability/python/distributions/multivariate_student_t.py
@@ -102,6 +102,8 @@ class MultivariateStudentTLinearOperator(
 
   # Compute the pdf of an`R^3` observation; return a scalar.
   mvt.prob([-1., 0, 1])  # shape: []
+  
+  ```
 
   """
 

--- a/tensorflow_probability/python/distributions/multivariate_student_t.py
+++ b/tensorflow_probability/python/distributions/multivariate_student_t.py
@@ -102,7 +102,6 @@ class MultivariateStudentTLinearOperator(
 
   # Compute the pdf of an`R^3` observation; return a scalar.
   mvt.prob([-1., 0, 1])  # shape: []
-  
   ```
 
   """


### PR DESCRIPTION
Python example within the docstring was not closed and hence the TF page was not rendered correctly