### PR TITLE
Fix ContinuousBernoulli numerical stability

### DIFF
--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -320,6 +320,12 @@ class ContinuousBernoulli(distribution.AutoCompositeTensorDistribution):
     # 1 / x + 1 / 2 + x / 12 - x**3 / 720 + x**5 / 30240 + O(x**7).
     # Thus we get the pole at zero canceling out with the second term.
 
+    # For large negative logits, the denominator (1 - exp(-logits)) in
+    # the first term yields inf values. Whilst the ratio still returns
+    # zero as it should, the gradients of this ratio become nan.
+    # Thus, noting that 1 / (1 - exp(-logits)) quickly tends towards 0
+    # for large negative logits, the mean tends towards - 1 / logits.
+
     dtype = dtype_util.as_numpy_dtype(self.dtype)
     eps = np.finfo(dtype).eps
 
@@ -329,14 +335,23 @@ class ContinuousBernoulli(distribution.AutoCompositeTensorDistribution):
     small_cutoff = np.power(eps * 30240, 1 / 5.)
     result = dtype(0.5) + logits / 12. - logits * tf.math.square(logits) / 720
 
-    safe_logits_large = tf.where(
-        tf.math.abs(logits) > small_cutoff, logits, dtype(1.))
-    return tf.where(
-        tf.math.abs(logits) > small_cutoff,
-        -(tf.math.reciprocal(
-            tf.math.expm1(-safe_logits_large)) +
-          tf.math.reciprocal(safe_logits_large)),
-        result)
+    large_cutoff = -np.log(eps)
+
+    safe_logits_mask = ((tf.math.abs(logits) > small_cutoff)
+                       & (logits > -large_cutoff))
+    safe_logits = tf.where(safe_logits_mask, logits, dtype(1.))
+    result = tf.where(
+                safe_logits_mask,
+                -(tf.math.reciprocal(
+                    tf.math.expm1(-safe_logits)) +
+                  tf.math.reciprocal(safe_logits)),
+                result)
+
+    large_neg_mask = logits <= -large_cutoff
+    logits_large_neg = tf.where(large_neg_mask, logits, 1.)
+    return tf.where(large_neg_mask,
+                    -tf.math.reciprocal(logits_large_neg),
+                    result)
 
   def _variance(self):
     # The variance is var = probs (probs - 1) / (2 * probs - 1)**2 +

--- a/tensorflow_probability/python/distributions/continuous_bernoulli.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli.py
@@ -59,7 +59,7 @@ def _log_xexp_ratio(x):
 
     x_squared = tf.math.square(x)
 
-    result = (dtype(np.log(2.)) + x_squared / 112. -
+    result = (dtype(np.log(2.)) + x_squared / 12. -
               7 * tf.math.square(x_squared) / 1440.)
     middle_region = (x > small_cutoff) & (x < large_cutoff)
     safe_x_medium = tf.where(middle_region, x, dtype(1.))
@@ -200,9 +200,9 @@ class ContinuousBernoulli(distribution.AutoCompositeTensorDistribution):
     # The normalizer is 2 * atanh(1 - 2 * probs) / (1 - 2 * probs), with the
     # removable singularity at probs = 0.5 removed (and replaced with 2).
     # We do this computation in logit space to be more numerically stable.
-    # Note that 2 * atanh(1 - 2 / (1 + exp(-logits))) = logits.
+    # Note that 2 * atanh(1 - 2 / (1 + exp(-logits))) = -logits.
     # Thus we end up with
-    # logits / (1 - 2 / (1 + exp(-logits))) =
+    # -logits / (1 - 2 / (1 + exp(-logits))) =
     # logits / ((-exp(-logits) + 1) / (exp(-logits) + 1)) =
     # (exp(-logits) + 1) * logits / (-exp(-logits) + 1) =
     # (1 + exp(logits)) * logits / (exp(logits) - 1)
@@ -312,7 +312,7 @@ class ContinuousBernoulli(distribution.AutoCompositeTensorDistribution):
     # 1 / (1 + exp(-logits)) / (2 / (1 + exp(-logits)) - 1) =
     # 1 / (2 - 1 - exp(-logits)) =
     # 1 / (1 - exp(-logits))
-    # The second term becomes 1 / logits.
+    # The second term becomes - 1 / logits.
     # Thus we have mean = 1 / (1 - exp(-logits)) - 1 / logits.
 
     # When logits is close to zero, we can compute the Laurent series for the

--- a/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
+++ b/tensorflow_probability/python/distributions/continuous_bernoulli_test.py
@@ -356,6 +356,13 @@ class ContinuousBernoulliTest(test_util.TestCase):
     self.assertFalse(np.any(np.isinf(mean_)))
     self.assertFalse(np.any(np.isnan(mean_)))
 
+  @test_util.numpy_disable_gradient_test
+  def testMeanGradsAreNotNaN(self):
+    logits = np.linspace(-100, 100, 20)[..., np.newaxis].astype(np.float32)
+    _, grad_logits = tfp.math.value_and_gradient(
+        lambda x: tfd.ContinuousBernoulli(logits=x).mean(), logits)
+    self.assertAllNotNan(self.evaluate(grad_logits))
+
   def testVarianceAndStd(self):
     prob = [[0.2, 0.7], [0.8, 0.4]]
     dist = tfd.ContinuousBernoulli(probs=prob, validate_args=True)


### PR DESCRIPTION
Fixes a typo in the Taylor approximation of the log-normalising constant https://github.com/tensorflow/probability/issues/1511, which yielded negative KL values.

Also fixes the stability of the gradients of the mean (and thus the KL). The existing implementation was not stable for large negative logits:
```python
import numpy as np
import tensorflow_probability as tfp
logits = np.linspace(-100, 100, 20)[..., np.newaxis].astype(np.float32)
_, grad_logits = tfp.math.value_and_gradient(lambda x: tfp.distributions.ContinuousBernoulli(logits=x).mean(), logits)
grad_logits
# <tf.Tensor: shape=(20, 1), dtype=float32, numpy=array([[          nan], [          nan], [1.6044446e-04], [2.1360947e-04], [2.9834712e-04], [4.4567912e-04], [7.3673454e-04], [1.4439999e-03], [4.0109721e-03], [3.0867012e-02], [3.0867014e-02], [4.0109721e-03], [1.4439999e-03], [7.3673454e-04], [4.4567912e-04], [2.9834712e-04], [2.1360947e-04], [1.6044446e-04], [1.2491349e-04], [9.9999997e-05]], dtype=float32)>
```

And here's the same output from the new implementation:
```python
import numpy as np
import tensorflow_probability as tfp
logits = np.linspace(-100, 100, 20)[..., np.newaxis].astype(np.float32)
_, grad_logits = tfp.math.value_and_gradient(lambda x: tfp.distributions.ContinuousBernoulli(logits=x).mean(), logits)
grad_logits
# <tf.Tensor: shape=(20, 1), dtype=float32, numpy=array([[9.9999997e-05], [1.2491349e-04], [1.6044446e-04], [2.1360947e-04], [2.9834712e-04], [4.4567912e-04], [7.3673454e-04], [1.4439999e-03], [4.0109721e-03], [3.0867012e-02], [3.0867014e-02], [4.0109721e-03], [1.4439999e-03], [7.3673454e-04], [4.4567912e-04], [2.9834712e-04], [2.1360947e-04], [1.6044446e-04], [1.2491349e-04], [9.9999997e-05]], dtype=float32)>
```
