### PR TITLE
Avoid custom_gradient warnings

### DIFF
--- a/tensorflow_probability/python/internal/custom_gradient.py
+++ b/tensorflow_probability/python/internal/custom_gradient.py
@@ -88,7 +88,7 @@ def custom_gradient(vjp_fwd=None, vjp_bwd=None, jvp_fn=None,
               args = args[1:]
           val, aux = vjp_fwd(*reconstruct_args, **kwargs)
 
-          def vjp_bwd_wrapped(*g, **kwargs):
+          def vjp_bwd_wrapped(*g):
             # We don't want to use an explicit `variables` arg, because TF will
             # complain if the wrapped function doesn't actually have variables
             # in it. TF will only specify this arg if there are variables.


### PR DESCRIPTION
python.interlnal.custom_gradient.custom_gradient generate warnings: "@custom_gradient grad_fn has 'variables' in signature, but no ResourceVariables were used on the forward pass.".

TF will specify not only arg 'variabels' but also **kwargs.
In 'f_wrapped', vjp_bwd can use kwargs even if vjp_bwd_wrapped does not have kwargs.