### PR TITLE
Correctly rendering iterated_filter by correcting backticks

### DIFF
--- a/tensorflow_probability/python/experimental/sequential/iterated_filter.py
+++ b/tensorflow_probability/python/experimental/sequential/iterated_filter.py
@@ -773,7 +773,7 @@ class IteratedFilter(object):
     Args:
       observations: observed `Tensor` value(s) on which to condition the
         parameter estimate.
-      num_iterations: `int `Tensor` number of filtering iterations to run.
+      num_iterations: int `Tensor` number of filtering iterations to run.
       num_particles: scalar int `Tensor` number of particles to use.
       initial_perturbation_scale: scalar float `Tensor`, or any structure of
         float `Tensor`s broadcasting to the same shape as the (unconstrained)

--- a/tensorflow_probability/python/optimizer/differential_evolution.py
+++ b/tensorflow_probability/python/optimizer/differential_evolution.py
@@ -144,7 +144,7 @@ def one_step(
       population is a `Tensor` of shape [n]. If the population is a python
       list of `Tensor`s then each `Tensor` in the list should have the first
       axis of a common size, say `n` and `objective_function(*population)`
-      should return a `Tensor of shape [n]. The population must have at least
+      should return a `Tensor` of shape [n]. The population must have at least
       4 members for the algorithm to work correctly.
     population_values: A `Tensor` of rank 1 and real dtype. The result of
       applying `objective_function` to the `population`. If not supplied it is


### PR DESCRIPTION
Backtics are not formatted well which is resulting in rendering issues. This PR updates those backticks.