### PR TITLE
Add implicit reparameterization gradient to tfd.TwoPieceNormal

### DIFF
--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -3956,7 +3956,6 @@ multi_substrate_py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
-        "//tensorflow_probability/python/internal:prefer_static",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )

--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -2165,6 +2165,7 @@ multi_substrate_py_library(
         "//tensorflow_probability/python/bijectors:identity",
         "//tensorflow_probability/python/bijectors:softplus",
         "//tensorflow_probability/python/internal:assert_util",
+        "//tensorflow_probability/python/internal:custom_gradient",
         "//tensorflow_probability/python/internal:dtype_util",
         "//tensorflow_probability/python/internal:parameter_properties",
         "//tensorflow_probability/python/internal:prefer_static",

--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -3956,6 +3956,7 @@ multi_substrate_py_test(
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",
+        "//tensorflow_probability/python/internal:prefer_static",
         "//tensorflow_probability/python/internal:test_util",
     ],
 )

--- a/tensorflow_probability/python/distributions/two_piece_normal.py
+++ b/tensorflow_probability/python/distributions/two_piece_normal.py
@@ -221,9 +221,7 @@ class TwoPieceNormal(distribution.AutoCompositeTensorDistribution):
           skewness, dtype=dtype, name='skewness')
       super().__init__(
           dtype=dtype,
-          # skewness contributes to a discrete choice. The other two variables
-          # are fine.
-          reparameterization_type=reparameterization.NOT_REPARAMETERIZED,
+          reparameterization_type=reparameterization.FULLY_REPARAMETERIZED,
           validate_args=validate_args,
           allow_nan_stats=allow_nan_stats,
           parameters=parameters,

--- a/tensorflow_probability/python/distributions/two_piece_normal.py
+++ b/tensorflow_probability/python/distributions/two_piece_normal.py
@@ -601,11 +601,11 @@ def _two_piece_normal_sample_bwd(_, aux, dy):
   grad = dy * _two_piece_normal_sample_gradient(broadcast_skewness, samples)
   # Sum over the sample dimensions. Assume that they are always the first
   # ones.
-  num_sample_dimensions = (tf.rank(broadcast_skewness) -
-                           tf.rank(skewness))
+  num_sample_dimensions = (ps.rank(broadcast_skewness) -
+                           ps.rank(skewness))
 
   # None gradients for seed
-  return tf.reduce_sum(grad, axis=tf.range(num_sample_dimensions)), None
+  return tf.reduce_sum(grad, axis=ps.range(num_sample_dimensions)), None
 
 
 def _two_piece_normal_sample_jvp(shape, primals, tangents):


### PR DESCRIPTION
Add implicit reparameterization gradient w.r.t. `skewness`, making the distribution `tfd.TwoPieceNormal` fully reparameterized. The applied approach to compute the implicit gradient was proposed by Figurnov, Mohamed, and Mnih (2018)[1].

In addition to implementing the implicit gradient described above, this PR makes the following changes:
* In the file `tensorflow_probability/python/distributions/BUILD`:
    * Add a new dependency
* In the file `tensorflow_probability/python/distributions/two_piece_normal.py`:
    * Reorganize the file, putting all functions below the class definition
    * Run all Tensor args through `tf.convert_to_tensor` in the functions `standardize`, `cdf`, and `quantile`, making them consistent with `random_two_piece_normal`
* In the file `tensorflow_probability/python/distributions/two_piece_normal_test.py`:
    * Improve `testSample`, testing different sample shapes
    * Add `testDifferentiableSampleNumerically` and `testDifferentiableSampleAnalytically`, testing the gradients of the samples w.r.t. `loc`, `scale`, and `skewness`

#### Reference

[1] Michael Figurnov, Shakir Mohamed, and Andriy Mnih. Implicit Reparameterization Gradients. In _Advances in Neural Information Processing Systems_, 31, 2018.
https://arxiv.org/abs/1805.08498