### PR TITLE
TensorFlow Probability: import tensorflow.compat.v2

### DIFF
--- a/tensorflow_probability/g3doc/_index.ipynb
+++ b/tensorflow_probability/g3doc/_index.ipynb
@@ -113,10 +113,10 @@
       },
       "cell_type": "code",
       "source": [
-        "import tensorflow as tf\n",
+        "import tensorflow.compat.v2 as tf\n",
         "import tensorflow_probability as tfp\n",
         "\n",
-        "tf.enable_eager_execution()\n",
+        "tf.enable_v2_behavior()\n",
         "\n",
         "print(tf.__version__)"
       ],


### PR DESCRIPTION
Use compat v2 import similarly to other tfp notebooks E.g (https://github.com/tensorflow/probability/blob/main/tensorflow_probability/examples/jupyter_notebooks/Structural_Time_Series_Modeling_Case_Studies_Atmospheric_CO2_and_Electricity_Demand.ipynb)

Current error with Tensorflow 2:

![image](https://user-images.githubusercontent.com/44556562/161998337-edb6c613-a201-445a-9ac0-643d364d298d.png)

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[<ipython-input-1-188fac1083eb>](https://localhost:8080/#) in <module>()
      2 import tensorflow_probability as tfp
      3 
----> 4 tf.enable_eager_execution()
      5 
      6 print(tf.__version__)

```
AttributeError: module 'tensorflow' has no attribute 'enable_eager_execution'
