### PR TITLE
Empirical distributions quantiles

### DIFF
--- a/tensorflow_probability/python/distributions/empirical.py
+++ b/tensorflow_probability/python/distributions/empirical.py
@@ -219,12 +219,6 @@ class Empirical(distribution.AutoCompositeTensorDistribution):
     return tf.sqrt(var)
   
   def _quantile(self, value, samples=None, **kwargs):
-    if value > 1 or value < 0:
-      raise ValueError(
-        "Quantile values in tensorflow_probability."
-        "distributions.Empirical.quantile must be between 0 and 1."
-      )
-
     if samples is None:
       samples = tf.convert_to_tensor(self._samples)
 

--- a/tensorflow_probability/python/distributions/empirical.py
+++ b/tensorflow_probability/python/distributions/empirical.py
@@ -25,7 +25,7 @@ from tensorflow_probability.python.internal import reparameterization
 from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensor_util
 from tensorflow_probability.python.internal import tensorshape_util
-from tensorflow_probability.python.stats import percentile
+from tensorflow_probability.python import stats
 
 __all__ = [
     'Empirical'
@@ -228,7 +228,7 @@ class Empirical(distribution.AutoCompositeTensorDistribution):
     if samples is None:
       samples = tf.convert_to_tensor(self._samples)
 
-    return percentile(x=samples, q=value * 100, axis=self._samples_axis, **kwargs)
+    return stats.percentile(x=samples, q=value * 100, axis=self._samples_axis, **kwargs)
 
   def _sample_n(self, n, seed=None):
     samples = tf.convert_to_tensor(self._samples)

--- a/tensorflow_probability/python/distributions/empirical.py
+++ b/tensorflow_probability/python/distributions/empirical.py
@@ -217,12 +217,14 @@ class Empirical(distribution.AutoCompositeTensorDistribution):
     r = samples - tf.expand_dims(self._mean(samples), axis=axis)
     var = tf.reduce_mean(tf.square(r), axis=axis)
     return tf.sqrt(var)
-  
+
   def _quantile(self, value, samples=None, **kwargs):
     if samples is None:
       samples = tf.convert_to_tensor(self._samples)
 
-    return stats.percentile(x=samples, q=value * 100, axis=self._samples_axis, **kwargs)
+    return stats.percentile(
+      x=samples, q=value * 100, axis=self._samples_axis, **kwargs
+    )
 
   def _sample_n(self, n, seed=None):
     samples = tf.convert_to_tensor(self._samples)

--- a/tensorflow_probability/python/distributions/empirical.py
+++ b/tensorflow_probability/python/distributions/empirical.py
@@ -25,7 +25,7 @@ from tensorflow_probability.python.internal import reparameterization
 from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensor_util
 from tensorflow_probability.python.internal import tensorshape_util
-
+from tensorflow_probability.python.stats import percentile
 
 __all__ = [
     'Empirical'
@@ -217,6 +217,18 @@ class Empirical(distribution.AutoCompositeTensorDistribution):
     r = samples - tf.expand_dims(self._mean(samples), axis=axis)
     var = tf.reduce_mean(tf.square(r), axis=axis)
     return tf.sqrt(var)
+  
+  def _quantile(self, value, samples=None, **kwargs):
+    if value > 1 or value < 0:
+      raise ValueError(
+        "Quantile values in tensorflow_probability."
+        "distributions.Empirical.quantile must be between 0 and 1."
+      )
+
+    if samples is None:
+      samples = tf.convert_to_tensor(self._samples)
+
+    return percentile(x=samples, q=value * 100, axis=self._samples_axis, **kwargs)
 
   def _sample_n(self, n, seed=None):
     samples = tf.convert_to_tensor(self._samples)

--- a/tensorflow_probability/python/distributions/empirical_test.py
+++ b/tensorflow_probability/python/distributions/empirical_test.py
@@ -265,6 +265,23 @@ class EmpiricalScalarTest(test_util.VectorDistributionTestHelpers):
       self.assertAllClose(self.evaluate(dist.stddev()),
                           np.sqrt(expected_variance))
 
+  def test_empirical_quantiles(self):
+    samples = [
+      [1, 1, 1, 2, 3, 3, 3],
+      [[1.0, 1.1, 1.2, 1.3, 1.4], [2.0, 2.1, 2.2, 2.3, 2.4]],
+    ]
+
+    expected_quantiles = {0.5: [2, [1.2, 2.2]], 0.75: [3, 1.3, 2.3]}
+
+    for q, q_val in expected_quantiles.items():
+      for i in range(len(samples)):
+        input_ = tf.convert_to_tensor(value=samples[i], dtype=np.float32)
+        input_ph = tf1.placeholder_with_default(
+          input_, shape=input_.shape if self.static_shape else None
+        )
+        dist = tfd.Empirical(samples=input_ph, validate_args=True)
+        self.assertAllClose(self.evaluate(dist.quantile(q)), q_val)
+
 
 @test_util.test_all_tf_execution_regimes
 class EmpiricalVectorTest(test_util.VectorDistributionTestHelpers):

--- a/tensorflow_probability/python/distributions/empirical_test.py
+++ b/tensorflow_probability/python/distributions/empirical_test.py
@@ -281,6 +281,12 @@ class EmpiricalScalarTest(test_util.VectorDistributionTestHelpers):
         )
         dist = tfd.Empirical(samples=input_ph, validate_args=True)
         self.assertAllClose(self.evaluate(dist.quantile(q)), q_val)
+    
+    invalid_value = 1.5
+    with self.assertRaises(ValueError):
+      dist = tfd.Empirical(
+        samples=sample, validate_args=True
+      ).quantile(invalid_value)
 
 
 @test_util.test_all_tf_execution_regimes

--- a/tensorflow_probability/python/distributions/empirical_test.py
+++ b/tensorflow_probability/python/distributions/empirical_test.py
@@ -281,12 +281,6 @@ class EmpiricalScalarTest(test_util.VectorDistributionTestHelpers):
         )
         dist = tfd.Empirical(samples=input_ph, validate_args=True)
         self.assertAllClose(self.evaluate(dist.quantile(q)), q_val)
-    
-    invalid_value = 1.5
-    with self.assertRaises(ValueError):
-      dist = tfd.Empirical(
-        samples=sample, validate_args=True
-      ).quantile(invalid_value)
 
 
 @test_util.test_all_tf_execution_regimes


### PR DESCRIPTION
Fixes #1549

Implemented the quantile method for the Empirical distribution class by interfacing the `tfp.stats.percentile` method and scaling the input appropriately. I think that the tests pass locally. I've tested using the command below: 
`bazel test -c opt tensorflow_probability/python/distributions:normal_test \
    --test_arg=--test_regex=EmpiricalScalarTest`

Let me know if I need to add more tests in the `EmpiricalNdTest` and the `EmpiricalVectorTest` classes. 

Thanks! 