### PR TITLE
Improve the partial derivatives of tfp_math.betainc

### DIFF
--- a/tensorflow_probability/python/math/BUILD
+++ b/tensorflow_probability/python/math/BUILD
@@ -485,6 +485,7 @@ multi_substrate_py_test(
     shard_count = 6,
     deps = [
         # absl/testing:parameterized dep,
+        # mpmath dep,
         # numpy dep,
         # tensorflow dep,
         "//tensorflow_probability",

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -107,7 +107,7 @@ def _betainc_naive(a, b, x):
 def _betainc_even_partial_numerator(iteration, a, b, x, dtype):
   """Even partial numerator used in the continued fraction for betainc."""
   # This function computes the partial numerator d_{2m} that is specified
-  # here: https://dlmf.nist.gov/8.17#E23
+  # here: https://dlmf.nist.gov/8.17.E23
   one = tf.constant(1., dtype=dtype)
   two = tf.constant(2., dtype=dtype)
 
@@ -126,7 +126,7 @@ def _betainc_even_partial_numerator(iteration, a, b, x, dtype):
 def _betainc_odd_partial_numerator(iteration, a, b, x, dtype):
   """Odd partial numerator used in the continued fraction for betainc."""
   # This function computes the partial numerator d_{2m + 1} that is specified
-  # here: https://dlmf.nist.gov/8.17#E23
+  # here: https://dlmf.nist.gov/8.17.E23
   one = tf.constant(1., dtype=dtype)
   two = tf.constant(2., dtype=dtype)
 
@@ -283,7 +283,7 @@ def _betainc_der_continued_fraction(a, b, x, dtype, use_continued_fraction):
   # This continued fraction expansion of betainc converges rapidly
   # for x < (a - 1) / (a + b - 2). For x >= (a - 1) / (a + b - 2),
   # we can obtain an equivalent computation by using the symmetry
-  # relation given here: https://dlmf.nist.gov/8.17#E4
+  # relation given here: https://dlmf.nist.gov/8.17.E4
   #   betainc(a, b, x) = 1 - betainc(b, a, 1 - x)
   use_symmetry_relation = (x >= (a - one) / (a + b - two))
   a_orig = a
@@ -317,7 +317,7 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
   """Returns the partial derivatives of betainc with respect to a and b."""
   # This function evaluates betainc(a, b, x) by its series representation:
   #   x ** a * 2F1(a, 1 - b; a + 1; x) / (a * B(a, b)) ,
-  # where 2F1 is defined here: http://dlmf.nist.gov/15.2.i
+  # where 2F1 is the Gauss series as defined here: http://dlmf.nist.gov/15.2.i
   # We apply this function when the input (a, b, x) satisfies at least one
   # of the following conditions:
   #   C1: (x < a / (a + b)) & (b * x <= 1) & (x <= 0.95)
@@ -334,7 +334,7 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
   safe_x = tf.where(use_power_series, x, half)
 
   # When the condition C1 is false, we apply the symmetry relation given
-  # here: https://dlmf.nist.gov/8.17#E4
+  # here: https://dlmf.nist.gov/8.17.E4
   #   betainc(a, b, x) = 1 - betainc(b, a, 1 - x)
   use_symmetry_relation = (safe_x >= safe_a / (safe_a + safe_b))
   safe_a_orig = safe_a

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -240,11 +240,11 @@ def _betainc_der_continued_fraction(a, b, x, dtype, where):
   # for x < (a - 1) / (a + b - 2). For x >= (a - 1) / (a + b - 2),
   # we can obtain an equivalent computation by using the symmetry
   # relation given here: https://dlmf.nist.gov/8.17#E4
-  apply_symmetry = (x >= (a - one) / (a + b - two))
+  use_symmetry_relation = (x >= (a - one) / (a + b - two))
   a_orig = a
-  a = tf.where(apply_symmetry, b, a)
-  b = tf.where(apply_symmetry, a_orig, b)
-  x = tf.where(apply_symmetry, one - x, x)
+  a = tf.where(use_symmetry_relation, b, a)
+  b = tf.where(use_symmetry_relation, a_orig, b)
+  x = tf.where(use_symmetry_relation, one - x, x)
 
   cf, cf_grad_a, cf_grad_b = _betainc_modified_lentz_method(
       a, b, x, dtype, where)
@@ -262,8 +262,8 @@ def _betainc_der_continued_fraction(a, b, x, dtype, where):
   # If we are taking advantage of the symmetry relation, then we have to
   # adjust grad_a and grad_b.
   grad_a_orig = grad_a
-  grad_a = tf.where(apply_symmetry, -grad_b, grad_a)
-  grad_b = tf.where(apply_symmetry, -grad_a_orig, grad_b)
+  grad_a = tf.where(use_symmetry_relation, -grad_b, grad_a)
+  grad_b = tf.where(use_symmetry_relation, -grad_a_orig, grad_b)
 
   return grad_a, grad_b
 
@@ -290,11 +290,11 @@ def _betainc_der_power_series(a, b, x, dtype, where):
 
   # When the condition C1 is false, we apply the symmetry relation given
   # here: http://dlmf.nist.gov/8.17.E4
-  apply_symmetry = (safe_x >= safe_a / (safe_a + safe_b))
+  use_symmetry_relation = (safe_x >= safe_a / (safe_a + safe_b))
   safe_a_orig = safe_a
-  safe_a = tf.where(apply_symmetry, safe_b, safe_a)
-  safe_b = tf.where(apply_symmetry, safe_a_orig, safe_b)
-  safe_x = tf.where(apply_symmetry, one - safe_x, safe_x)
+  safe_a = tf.where(use_symmetry_relation, safe_b, safe_a)
+  safe_b = tf.where(use_symmetry_relation, safe_a_orig, safe_b)
+  safe_x = tf.where(use_symmetry_relation, one - safe_x, safe_x)
 
   # max_iterations was set by experimentation and tolerance was taken from
   # Cephes.
@@ -356,8 +356,8 @@ def _betainc_der_power_series(a, b, x, dtype, where):
   # If we are taking advantage of the symmetry relation, then we have to
   # adjust grad_a and grad_b.
   grad_a_orig = grad_a
-  grad_a = tf.where(apply_symmetry, -grad_b, grad_a)
-  grad_b = tf.where(apply_symmetry, -grad_a_orig, grad_b)
+  grad_a = tf.where(use_symmetry_relation, -grad_b, grad_a)
+  grad_b = tf.where(use_symmetry_relation, -grad_a_orig, grad_b)
 
   return grad_a, grad_b
 

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -317,7 +317,7 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
   """Returns the partial derivatives of betainc with respect to a and b."""
   # This function evaluates betainc(a, b, x) by its series representation:
   #   x ** a * 2F1(a, 1 - b; a + 1; x) / (a * B(a, b)) ,
-  # where 2F1 is the Gauss series as defined here: http://dlmf.nist.gov/15.2.i
+  # where 2F1 is the Gaussian hypergeometric function.
   # We apply this function when the input (a, b, x) satisfies at least one
   # of the following conditions:
   #   C1: (x < a / (a + b)) & (b * x <= 1) & (x <= 0.95)
@@ -333,8 +333,8 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
   safe_b = tf.where(use_power_series, b, half)
   safe_x = tf.where(use_power_series, x, half)
 
-  # When the condition C1 is false, we apply the symmetry relation given
-  # here: https://dlmf.nist.gov/8.17.E4
+  # When x >= a / (a + b), we must apply the symmetry relation given here:
+  # https://dlmf.nist.gov/8.17.E4
   #   betainc(a, b, x) = 1 - betainc(b, a, 1 - x)
   use_symmetry_relation = (safe_x >= safe_a / (safe_a + safe_b))
   safe_a_orig = safe_a
@@ -427,13 +427,13 @@ def _betainc_partials(a, b, x):
   x = tf.broadcast_to(x, broadcast_shape)
 
   # The partial derivative of betainc with respect to x can be obtained
-  # directly using the expression given here:
+  # directly by using the expression given here:
   # http://functions.wolfram.com/06.21.20.0001.01
   grad_x = tf.math.exp(
       tf.math.xlogy(a - one, x) + tf.math.xlog1py(b - one, -x) - lbeta(a, b))
 
   # The partial derivatives of betainc with respect to a and b are computed
-  # using forward mode.
+  # by using forward mode.
   use_power_series = ((x < a / (a + b)) & (b * x <= 1.) & (x <= 0.95) |
       ((x >= a / (a + b)) & (a * (1. - x) <= 1.) & (x >= 0.05)))
   ps_grad_a, ps_grad_b = _betainc_der_power_series(

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -179,7 +179,7 @@ def _betainc_modified_lentz_method(a, b, x, dtype, where):
     delta = new_c * new_d
     new_f = f * delta
 
-    new_c_grad = (numerator_grad * c - numerator * c_grad) / (c * c)
+    new_c_grad = (numerator_grad * c - numerator * c_grad) / tf.math.square(c)
     new_d_grad = -new_d * new_d * (numerator_grad * d + numerator * d_grad)
     new_f_grad = f_grad * delta + (f * new_c_grad * new_d) + (
         f * new_d_grad * new_c)
@@ -204,7 +204,7 @@ def _betainc_modified_lentz_method(a, b, x, dtype, where):
   initial_f = initial_d
   initial_values = (initial_c, initial_d, initial_f)
 
-  initial_d_grad = tf.concat([one - b, ap1], axis=-1) * x / tf.square(
+  initial_d_grad = tf.concat([one - b, ap1], axis=-1) * x / tf.math.square(
       x * apb - ap1)
   initial_c_grad = tf.zeros_like(initial_d_grad)
   initial_f_grad = initial_d_grad
@@ -314,7 +314,7 @@ def _betainc_der_power_series(a, b, x, dtype, where):
     new_product = product * factor
     term = new_product / apn
     new_dpdb = factor * dpdb - product * x_div_n
-    new_da = da - new_product / (apn * apn)
+    new_da = da - new_product / tf.math.square(apn)
     new_db = db + new_dpdb / apn
 
     values = n + one, new_product, series_sum + term
@@ -328,7 +328,7 @@ def _betainc_der_power_series(a, b, x, dtype, where):
   initial_values = (n, product, series_sum)
 
   dpdb = tf.zeros_like(safe_b)
-  da = -tf.math.reciprocal(safe_a * safe_a)
+  da = -tf.math.reciprocal(tf.math.square(safe_a))
   db = dpdb
   initial_gradients = (dpdb, da, db)
 

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -434,8 +434,9 @@ def _betainc_partials(a, b, x):
 
   # The partial derivatives of betainc with respect to a and b are computed
   # by using forward mode.
-  use_power_series = ((x < a / (a + b)) & (b * x <= 1.) & (x <= 0.95) |
-      ((x >= a / (a + b)) & (a * (1. - x) <= 1.) & (x >= 0.05)))
+  use_power_series = (
+      ((x < a / (a + b)) & (b * x <= one) & (x <= 0.95)) | (
+      (x >= a / (a + b)) & (a * (one - x) <= one) & (x >= 0.05)))
   ps_grad_a, ps_grad_b = _betainc_der_power_series(
       a, b, x, dtype, use_power_series)
   cf_grad_a, cf_grad_b = _betainc_der_continued_fraction(

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -241,6 +241,7 @@ def _betainc_der_continued_fraction(a, b, x, dtype, use_continued_fraction):
   # for x < (a - 1) / (a + b - 2). For x >= (a - 1) / (a + b - 2),
   # we can obtain an equivalent computation by using the symmetry
   # relation given here: https://dlmf.nist.gov/8.17#E4
+  #   betainc(a, b, x) = 1 - betainc(b, a, 1 - x)
   use_symmetry_relation = (x >= (a - one) / (a + b - two))
   a_orig = a
   a = tf.where(use_symmetry_relation, b, a)
@@ -290,7 +291,8 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
   safe_x = tf.where(use_power_series, x, half)
 
   # When the condition C1 is false, we apply the symmetry relation given
-  # here: http://dlmf.nist.gov/8.17.E4
+  # here: https://dlmf.nist.gov/8.17#E4
+  #   betainc(a, b, x) = 1 - betainc(b, a, 1 - x)
   use_symmetry_relation = (safe_x >= safe_a / (safe_a + safe_b))
   safe_a_orig = safe_a
   safe_a = tf.where(use_symmetry_relation, safe_b, safe_a)

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -215,11 +215,11 @@ def _betainc_modified_lentz_method(a, b, x, dtype, use_continued_fraction):
     # We run two steps of modified Lentz's method per iteration.
     # First step of the iteration: the even one.
     new_values, new_gradients, _ = continued_fraction_step(
-      iteration, values, gradients, _betainc_even_partial_numerator)
+        iteration, values, gradients, _betainc_even_partial_numerator)
 
     # Second step of the iteration: the odd one.
     new_values, new_gradients, delta = continued_fraction_step(
-      iteration, new_values, new_gradients, _betainc_odd_partial_numerator)
+        iteration, new_values, new_gradients, _betainc_odd_partial_numerator)
 
     should_stop = should_stop | (tf.math.abs(delta - one) < tolerance)
 
@@ -420,7 +420,7 @@ def _betainc_partials(a, b, x):
   x = tf.convert_to_tensor(x, dtype=dtype)
 
   broadcast_shape = functools.reduce(
-    ps.broadcast_shape, [ps.shape(a), ps.shape(b), ps.shape(x)])
+      ps.broadcast_shape, [ps.shape(a), ps.shape(b), ps.shape(x)])
 
   a = tf.broadcast_to(a, broadcast_shape)
   b = tf.broadcast_to(b, broadcast_shape)

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -249,14 +249,14 @@ def _betainc_der_continued_fraction(a, b, x, dtype, where):
   cf, cf_grad_a, cf_grad_b = _betainc_modified_lentz_method(
       a, b, x, dtype, where)
 
-  more_terms = tf.math.exp(
+  normalization = tf.math.exp(
       tf.math.xlogy(a, x) + tf.math.xlog1py(b, -x) -
       tf.math.log(a) - lbeta(a, b))
 
   digamma_apb = tf.math.digamma(a + b)
-  grad_a = more_terms * (cf_grad_a + cf * (tf.math.log(x) -
+  grad_a = normalization * (cf_grad_a + cf * (tf.math.log(x) -
       tf.math.reciprocal(a) + digamma_apb - tf.math.digamma(a)))
-  grad_b = more_terms * (cf_grad_b + cf * (tf.math.log1p(-x) +
+  grad_b = normalization * (cf_grad_b + cf * (tf.math.log1p(-x) +
       digamma_apb - tf.math.digamma(b)))
 
   # If we are taking advantage of the symmetry relation, then we have to
@@ -344,13 +344,13 @@ def _betainc_der_power_series(a, b, x, dtype, where):
   _, _, series_sum = values
   _, series_grad_a, series_grad_b = gradients
 
-  more_terms = tf.math.exp(
+  normalization = tf.math.exp(
       tf.math.xlogy(safe_a, safe_x) - lbeta(safe_a, safe_b))
 
   digamma_apb = tf.math.digamma(safe_a + safe_b)
-  grad_a = more_terms * (series_grad_a + series_sum * (
+  grad_a = normalization * (series_grad_a + series_sum * (
       digamma_apb - tf.math.digamma(safe_a) + tf.math.log(safe_x)))
-  grad_b = more_terms * (series_grad_b + series_sum * (
+  grad_b = normalization * (series_grad_b + series_sum * (
       digamma_apb - tf.math.digamma(safe_b)))
 
   # If we are taking advantage of the symmetry relation, then we have to

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -351,7 +351,7 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
   #   2F1(a, 1 - b; a + 1; x) / a
   def power_series_evaluation(should_stop, values, gradients):
     n, product, series_sum = values
-    dpdb, da, db = gradients
+    product_grad_b, da, db = gradients
 
     x_div_n = safe_x / n
     factor = (n - safe_b) * x_div_n
@@ -359,24 +359,24 @@ def _betainc_der_power_series(a, b, x, dtype, use_power_series):
 
     new_product = product * factor
     term = new_product / apn
-    new_dpdb = factor * dpdb - product * x_div_n
+    new_product_grad_b = factor * product_grad_b - product * x_div_n
     new_da = da - new_product / tf.math.square(apn)
-    new_db = db + new_dpdb / apn
+    new_db = db + new_product_grad_b / apn
 
     values = n + one, new_product, series_sum + term
-    gradients = new_dpdb, new_da, new_db
+    gradients = new_product_grad_b, new_da, new_db
 
     return should_stop | (tf.math.abs(term) <= tolerance), values, gradients
 
-  n = one
-  product = tf.ones_like(safe_a)
-  series_sum = one / safe_a
-  initial_values = (n, product, series_sum)
+  initial_n = one
+  initial_product = tf.ones_like(safe_a)
+  initial_series_sum = one / safe_a
+  initial_values = (initial_n, initial_product, initial_series_sum)
 
-  dpdb = tf.zeros_like(safe_b)
-  da = -tf.math.reciprocal(tf.math.square(safe_a))
-  db = dpdb
-  initial_gradients = (dpdb, da, db)
+  initial_product_grad_b = tf.zeros_like(safe_b)
+  initial_da = -tf.math.reciprocal(tf.math.square(safe_a))
+  initial_db = initial_product_grad_b
+  initial_gradients = (initial_product_grad_b, initial_da, initial_db)
 
   (_, values, gradients) = tf.while_loop(
       cond=lambda stop, *_: tf.reduce_any(~stop),

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -388,13 +388,14 @@ def _betainc_partials(a, b, x):
 
   # The partial derivatives of betainc with respect to a and b are computed
   # using forward mode.
-  region_ps = ((x < a / (a + b)) & (b * x <= 1.) & (x <= 0.95) |
+  use_power_series = ((x < a / (a + b)) & (b * x <= 1.) & (x <= 0.95) |
       ((x >= a / (a + b)) & (a * (1. - x) <= 1.) & (x >= 0.05)))
-  ps_grad_a, ps_grad_b = _betainc_der_power_series(a, b, x, dtype, region_ps)
+  ps_grad_a, ps_grad_b = _betainc_der_power_series(
+      a, b, x, dtype, use_power_series)
   cf_grad_a, cf_grad_b = _betainc_der_continued_fraction(
-      a, b, x, dtype, ~region_ps)
-  grad_a = tf.where(region_ps, ps_grad_a, cf_grad_a)
-  grad_b = tf.where(region_ps, ps_grad_b, cf_grad_b)
+      a, b, x, dtype, ~use_power_series)
+  grad_a = tf.where(use_power_series, ps_grad_a, cf_grad_a)
+  grad_b = tf.where(use_power_series, ps_grad_b, cf_grad_b)
 
   # According to the code accompanying [1], grad_a = grad_b = 0 when x is
   # equal to 0 or 1. Under the same condition, grad_x = 0 by its expression.

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -341,7 +341,7 @@ class BetaincTest(test_util.TestCase):
     x = self.evaluate(x)
 
     self._testBetaincDerivative(
-        a, b, x, rtol_a=6e-3, rtol_b=4e-3, rtol_x=1e-5)
+        a, b, x, rtol_a=0.05, rtol_b=0.05, rtol_x=1e-5)
 
   @test_util.numpy_disable_gradient_test
   def testBetaincDerivativeSmallFloat(self):
@@ -357,9 +357,7 @@ class BetaincTest(test_util.TestCase):
     x = self.evaluate(x)
 
     self._testBetaincDerivative(
-        a, b, x,
-        atol_a=4e-5, atol_b=2e-4, atol_x=2e-4,
-        rtol_a=1e-5, rtol_b=1e-5, rtol_x=1e-5)
+        a, b, x, atol_a=1e-3, atol_b=1e-3, atol_x=0.01)
 
   @test_util.numpy_disable_gradient_test
   def testBetaincDerivativeFloat(self):
@@ -375,9 +373,7 @@ class BetaincTest(test_util.TestCase):
     x = self.evaluate(x)
 
     self._testBetaincDerivative(
-        a, b, x,
-        atol_a=7e-6, atol_b=9e-5, atol_x=4e-4,
-        rtol_a=1e-5, rtol_b=1e-5, rtol_x=1e-5)
+        a, b, x, atol_a=1e-3, atol_b=1e-3, atol_x=1e-3)
 
   @test_util.numpy_disable_gradient_test
   def testBetaincDerivativeVerySmallDouble(self):
@@ -392,7 +388,8 @@ class BetaincTest(test_util.TestCase):
         high=np.float64(1.)).sample(100, strm())
     x = self.evaluate(x)
 
-    self._testBetaincDerivative(a, b, x)
+    self._testBetaincDerivative(
+        a, b, x, rtol_a=1e-11, rtol_b=1e-11, rtol_x=1e-13)
 
   @test_util.numpy_disable_gradient_test
   def testBetaincDerivativeSmallDouble(self):
@@ -407,7 +404,8 @@ class BetaincTest(test_util.TestCase):
         high=np.float64(1.)).sample(100, strm())
     x = self.evaluate(x)
 
-    self._testBetaincDerivative(a, b, x)
+    self._testBetaincDerivative(
+        a, b, x, atol_a=1e-12, atol_b=1e-12, atol_x=1e-11)
 
   @test_util.numpy_disable_gradient_test
   def testBetaincDerivativeDouble(self):
@@ -422,7 +420,8 @@ class BetaincTest(test_util.TestCase):
         high=np.float64(1.)).sample(100, strm())
     x = self.evaluate(x)
 
-    self._testBetaincDerivative(a, b, x)
+    self._testBetaincDerivative(
+        a, b, x, atol_a=1e-12, atol_b=1e-12, atol_x=1e-10)
 
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -200,10 +200,7 @@ class BetaincTest(test_util.TestCase):
     space = np.logspace(-2., 2., 10).tolist()
     space_x = np.linspace(0.01, 0.99, 10).tolist()
     a, b, x = zip(*list(itertools.product(space, space, space_x)))
-
-    a = np.array(a, dtype=dtype)
-    b = np.array(b, dtype=dtype)
-    x = np.array(x, dtype=dtype)
+    a, b, x = [np.array(z, dtype=dtype) for z in [a, b, x]]
 
     # Wrap in tf.function and compile for faster computations.
     betainc = tf.function(tfp_math.betainc, autograph=False, jit_compile=True)
@@ -232,10 +229,7 @@ class BetaincTest(test_util.TestCase):
     space = np.logspace(np.log10(eps), 5.).tolist()
     space_x = np.linspace(eps, 1. - eps).tolist()
     a, b, x = zip(*list(itertools.product(space, space, space_x)))
-
-    a = np.array(a, dtype=dtype)
-    b = np.array(b, dtype=dtype)
-    x = np.array(x, dtype=dtype)
+    a, b, x = [np.array(z, dtype=dtype) for z in [a, b, x]]
 
     def betainc_partials(a, b, x):
       return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
@@ -439,10 +433,7 @@ class BetaincTest(test_util.TestCase):
     space = np.logspace(-2., 2., 5).tolist()
     space_x = np.linspace(0.01, 0.99, 5).tolist()
     a, b, x = zip(*list(itertools.product(space, space, space_x)))
-
-    a = np.array(a, dtype=dtype)
-    b = np.array(b, dtype=dtype)
-    x = np.array(x, dtype=dtype)
+    a, b, x = [np.array(z, dtype=dtype) for z in [a, b, x]]
 
     def betainc_partials(a, b, x):
       return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -200,7 +200,10 @@ class BetaincTest(test_util.TestCase):
     space = np.logspace(-2., 2., 10).tolist()
     space_x = np.linspace(0.01, 0.99, 10).tolist()
     a, b, x = zip(*list(itertools.product(space, space, space_x)))
-    a, b, x = [np.array(z, dtype=dtype) for z in [a, b, x]]
+
+    a = np.array(a, dtype=dtype)
+    b = np.array(b, dtype=dtype)
+    x = np.array(x, dtype=dtype)
 
     # Wrap in tf.function and compile for faster computations.
     betainc = tf.function(tfp_math.betainc, autograph=False, jit_compile=True)
@@ -229,7 +232,10 @@ class BetaincTest(test_util.TestCase):
     space = np.logspace(np.log10(eps), 5.).tolist()
     space_x = np.linspace(eps, 1. - eps).tolist()
     a, b, x = zip(*list(itertools.product(space, space, space_x)))
-    a, b, x = [np.array(z, dtype=dtype) for z in [a, b, x]]
+
+    a = np.array(a, dtype=dtype)
+    b = np.array(b, dtype=dtype)
+    x = np.array(x, dtype=dtype)
 
     def betainc_partials(a, b, x):
       return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
@@ -433,7 +439,10 @@ class BetaincTest(test_util.TestCase):
     space = np.logspace(-2., 2., 5).tolist()
     space_x = np.linspace(0.01, 0.99, 5).tolist()
     a, b, x = zip(*list(itertools.product(space, space, space_x)))
-    a, b, x = [np.array(z, dtype=dtype) for z in [a, b, x]]
+
+    a = np.array(a, dtype=dtype)
+    b = np.array(b, dtype=dtype)
+    x = np.array(x, dtype=dtype)
 
     def betainc_partials(a, b, x):
       return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -15,9 +15,11 @@
 """Tests for special."""
 
 import functools
+import itertools
 
 from absl.testing import parameterized
 import numpy as np
+from mpmath import mp
 from scipy import special as scipy_special
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
@@ -194,27 +196,293 @@ class BetaincTest(test_util.TestCase):
     x = np.ones([7, 1, 1, 2], dtype=np.float32)
     self.assertAllEqual([7, 5, 3, 2], tfp_math.betainc(a, b, x).shape)
 
+  @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test
-  def testBetaincGradient(self):
-    a = np.logspace(-2., 2., 11)[..., np.newaxis]
-    b = np.logspace(-2., 2., 11)[..., np.newaxis]
-    # Avoid the end points where the gradient can veer off to infinity.
-    x = np.linspace(0.1, 0.7, 23)
+  def testBetaincGradient(self, dtype):
+    space = np.logspace(-2., 2., 10).tolist()
+    space_x = np.linspace(0.01, 0.99, 10).tolist()
+    a, b, x = zip(*list(itertools.product(space, space, space_x)))
+
+    a = np.array(a, dtype=dtype)
+    b = np.array(b, dtype=dtype)
+    x = np.array(x, dtype=dtype)
+
+    # Wrap in tf.function and compile for faster computations.
+    betainc = tf.function(tfp_math.betainc, autograph=False, jit_compile=True)
+
+    delta = 1e-4 if dtype == np.float64 else 1e-3
+    tolerance = 7e-3 if dtype == np.float64 else 7e-2
+    tolerance_x = 1e-3 if dtype == np.float64 else 0.1
+
+    err = self.compute_max_gradient_error(
+        lambda z: betainc(z, b, x), [a], delta=delta)
+    self.assertLess(err, tolerance)
+
+    err = self.compute_max_gradient_error(
+        lambda z: betainc(a, z, x), [b], delta=delta)
+    self.assertLess(err, tolerance)
+
+    err = self.compute_max_gradient_error(
+        lambda z: betainc(a, b, z), [x], delta=delta)
+    self.assertLess(err, tolerance_x)
+
+  @parameterized.parameters(np.float32, np.float64)
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeFinite(self, dtype):
+    eps = np.finfo(dtype).eps
+
+    space = np.logspace(np.log10(eps), 5.).tolist()
+    space_x = np.linspace(eps, 1. - eps).tolist()
+    a, b, x = zip(*list(itertools.product(space, space, space_x)))
+
+    a = np.array(a, dtype=dtype)
+    b = np.array(b, dtype=dtype)
+    x = np.array(x, dtype=dtype)
+
+    def betainc_partials(a, b, x):
+      return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
+
+    # Wrap in tf.function and compile for faster computations.
+    betainc_partials = tf.function(
+        betainc_partials, autograph=False, jit_compile=True)
+
+    self.assertAllFinite(self.evaluate(betainc_partials(a, b, x)))
+
+  @parameterized.parameters(np.float32, np.float64)
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeBounds(self, dtype):
+
+    def betainc_partials(a, b, x):
+      return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
+
+    # Wrap in tf.function and compile for faster computations.
+    betainc_partials = tf.function(
+        betainc_partials, autograph=False, jit_compile=True)
+
+    # Test out-of-range values (should return NaN output).
+    a = np.array([-1., 0., 0.4, 0.4, 0.4, 0.4], dtype=dtype)
+    b = np.array([0.6, 0.6, -1., 0., 0.6, 0.6], dtype=dtype)
+    x = np.array([0.5, 0.5, 0.5, 0.5, -1., 2.], dtype=dtype)
+
+    for partial in self.evaluate(betainc_partials(a, b, x)):
+      self.assertAllClose(np.full_like(a, np.nan), partial)
+
+    # Test partials when x is equal to 0 or 1.
+    a = np.array([0.4, 0.4], dtype=dtype)
+    b = np.array([0.6, 0.6], dtype=dtype)
+    x = np.array([0., 1.], dtype=dtype)
+
+    for partial in self.evaluate(betainc_partials(a, b, x)):
+      self.assertAllClose(np.zeros_like(a), partial)
+
+  def _testBetaincDerivative(self,
+                             a,
+                             b,
+                             x,
+                             rtol_a=1e-6,
+                             atol_a=1e-6,
+                             rtol_b=1e-6,
+                             atol_b=1e-6,
+                             rtol_x=1e-6,
+                             atol_x=1e-6):
+
+    def _mp_betainc_partial_a(a, b, x):
+      return mp.diff(lambda z: mp.betainc(z, b, 0., x, regularized=True), a)
+
+    def _mp_betainc_partial_b(a, b, x):
+      return mp.diff(lambda z: mp.betainc(a, z, 0., x, regularized=True), b)
+
+    def _mp_betainc_partial_x(a, b, x):
+      return mp.diff(lambda z: mp.betainc(a, b, 0., z, regularized=True), x)
+
+    mp_betainc_partial_a = np.frompyfunc(_mp_betainc_partial_a, 3, 1)
+    mp_betainc_partial_b = np.frompyfunc(_mp_betainc_partial_b, 3, 1)
+    mp_betainc_partial_x = np.frompyfunc(_mp_betainc_partial_x, 3, 1)
+    mp_betainc_partials = [
+        mp_betainc_partial_a, mp_betainc_partial_b, mp_betainc_partial_x]
+
+    with mp.workdps(25): # Set the decimal precision of mpmath.
+      mp_partials = [
+          mp_partial_fn(a, b, x).astype(a.dtype)
+          for mp_partial_fn in mp_betainc_partials]
+
+    def tfp_betainc_partials(a, b, x):
+      return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
+
+    # Wrap in tf.function and compile for faster computations.
+    tfp_betainc_partials = tf.function(
+        tfp_betainc_partials, autograph=False, jit_compile=True)
+
+    tfp_partials = self.evaluate(tfp_betainc_partials(a, b, x))
+
+    # Check that partials preserve dtype.
+    for partial in tfp_partials:
+      self.assertEqual(a.dtype, partial.dtype)
+
+    # Check that partials are accurate.
+    self.assertAllClose(
+        mp_partials[0], tfp_partials[0], rtol=rtol_a, atol=atol_a)
+    self.assertAllClose(
+        mp_partials[1], tfp_partials[1], rtol=rtol_b, atol=atol_b)
+    self.assertAllClose(
+        mp_partials[2], tfp_partials[2], rtol=rtol_x, atol=atol_x)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeVerySmallFloat(self):
+    strm = test_util.test_seed_stream()
+    a = tfp.distributions.HalfNormal(
+        scale=np.float32(1e-8)).sample(100, strm())
+    a = self.evaluate(a)
+    b = tfp.distributions.HalfNormal(
+        scale=np.float32(1e-8)).sample(100, strm())
+    b = self.evaluate(b)
+    x = tfp.distributions.Uniform(
+        high=np.float32(1.)).sample(100, strm())
+    x = self.evaluate(x)
+
+    self._testBetaincDerivative(
+        a, b, x, rtol_a=6e-3, rtol_b=4e-3, rtol_x=1e-5)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeSmallFloat(self):
+    strm = test_util.test_seed_stream()
+    a = tfp.distributions.Uniform(
+        high=np.float32(5.)).sample(100, strm())
+    a = self.evaluate(a)
+    b = tfp.distributions.Uniform(
+        high=np.float32(5.)).sample(100, strm())
+    b = self.evaluate(b)
+    x = tfp.distributions.Uniform(
+        high=np.float32(1.)).sample(100, strm())
+    x = self.evaluate(x)
+
+    self._testBetaincDerivative(
+        a, b, x,
+        atol_a=4e-5, atol_b=2e-4, atol_x=2e-4,
+        rtol_a=1e-5, rtol_b=1e-5, rtol_x=1e-5)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeFloat(self):
+    strm = test_util.test_seed_stream()
+    a = tfp.distributions.Uniform(
+        high=np.float32(100.)).sample(100, strm())
+    a = self.evaluate(a)
+    b = tfp.distributions.Uniform(
+        high=np.float32(100.)).sample(100, strm())
+    b = self.evaluate(b)
+    x = tfp.distributions.Uniform(
+        high=np.float32(1.)).sample(100, strm())
+    x = self.evaluate(x)
+
+    self._testBetaincDerivative(
+        a, b, x,
+        atol_a=7e-6, atol_b=9e-5, atol_x=4e-4,
+        rtol_a=1e-5, rtol_b=1e-5, rtol_x=1e-5)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeVerySmallDouble(self):
+    strm = test_util.test_seed_stream()
+    a = tfp.distributions.HalfNormal(
+        scale=np.float64(1e-16)).sample(100, strm())
+    a = self.evaluate(a)
+    b = tfp.distributions.HalfNormal(
+        scale=np.float64(1e-16)).sample(100, strm())
+    b = self.evaluate(b)
+    x = tfp.distributions.Uniform(
+        high=np.float64(1.)).sample(100, strm())
+    x = self.evaluate(x)
+
+    self._testBetaincDerivative(a, b, x)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeSmallDouble(self):
+    strm = test_util.test_seed_stream()
+    a = tfp.distributions.Uniform(
+        high=np.float64(10.)).sample(100, strm())
+    a = self.evaluate(a)
+    b = tfp.distributions.Uniform(
+        high=np.float64(10.)).sample(100, strm())
+    b = self.evaluate(b)
+    x = tfp.distributions.Uniform(
+        high=np.float64(1.)).sample(100, strm())
+    x = self.evaluate(x)
+
+    self._testBetaincDerivative(a, b, x)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeDouble(self):
+    strm = test_util.test_seed_stream()
+    a = tfp.distributions.Uniform(
+        high=np.float64(100.)).sample(100, strm())
+    a = self.evaluate(a)
+    b = tfp.distributions.Uniform(
+        high=np.float64(100.)).sample(100, strm())
+    b = self.evaluate(b)
+    x = tfp.distributions.Uniform(
+        high=np.float64(1.)).sample(100, strm())
+    x = self.evaluate(x)
+
+    self._testBetaincDerivative(a, b, x)
+
+  @parameterized.parameters(np.float32, np.float64)
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeChallengingPoints(self, dtype):
+    a = np.array([0.014, 5.90, 0.536, 0.836, 0.3, 9., 1.69], dtype=dtype)
+    b = np.array([3.467, 0.01, 2.315, 0.221, 9., 0.24, 0.117], dtype=dtype)
+    x = np.array(
+        [0.007, 0.99, 0.215, 0.782, 1e-16, 1. - 1e-6, 3.4e-4], dtype=dtype)
+
+    if dtype == np.float32:
+      self._testBetaincDerivative(
+          a, b, x,
+          atol_a=5e-5, atol_b=5e-4, atol_x=5e-4,
+          rtol_a=1e-5, rtol_b=1e-5, rtol_x=1e-5)
+    else:
+      self._testBetaincDerivative(a, b, x)
+
+  @parameterized.parameters(np.float32, np.float64)
+  @test_util.numpy_disable_gradient_test
+  def testBetaincSecondDerivativeFinite(self, dtype):
+    space = np.logspace(-2., 2., 5).tolist()
+    space_x = np.linspace(0.01, 0.99, 5).tolist()
+    a, b, x = zip(*list(itertools.product(space, space, space_x)))
+
+    a = np.array(a, dtype=dtype)
+    b = np.array(b, dtype=dtype)
+    x = np.array(x, dtype=dtype)
+
+    def betainc_partials(a, b, x):
+      return tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
+
+    def betainc_partials_of_partial_a(a, b, x):
+      return tfp_math.value_and_gradient(
+          lambda a, b, x: betainc_partials(a, b, x)[0],
+          [a, b, x])[1]
+
+    def betainc_partials_of_partial_b(a, b, x):
+      return tfp_math.value_and_gradient(
+          lambda a, b, x: betainc_partials(a, b, x)[1],
+          [a, b, x])[1]
+
+    def betainc_partials_of_partial_x(a, b, x):
+      return tfp_math.value_and_gradient(
+          lambda a, b, x: betainc_partials(a, b, x)[2],
+          [a, b, x])[1]
+
+    betainc_partials_of_partials = [
+        betainc_partials_of_partial_a,
+        betainc_partials_of_partial_b,
+        betainc_partials_of_partial_x]
 
     # Wrap in tf.function for faster computations.
-    betainc = tf.function(tfp_math.betainc)
+    betainc_partials_of_partials = [
+      tf.function(partial_fn, autograph=False, jit_compile=True)
+      for partial_fn in betainc_partials_of_partials]
 
-    err = self.compute_max_gradient_error(
-        lambda z: betainc(a, b, z), [x], delta=1e-4)
-    self.assertLess(err, 2e-5)
+    partials_of_partials = [
+        partial_fn(a, b, x) for partial_fn in betainc_partials_of_partials]
 
-    err = self.compute_max_gradient_error(
-        lambda z: betainc(z, b, x), [a], delta=1e-4)
-    self.assertLess(err, 8e-4)
-
-    err = self.compute_max_gradient_error(
-        lambda z: betainc(a, z, x), [b], delta=1e-4)
-    self.assertLess(err, 8e-4)
+    self.assertAllFinite(self.evaluate(partials_of_partials))
 
 
 @test_util.test_graph_and_eager_modes

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -178,13 +178,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.HalfCauchy(
         loc=np.float64(1.), scale=15.).sample(2000, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.HalfCauchy(
         loc=np.float64(1.), scale=15.).sample(2000, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float64(1.)).sample(2000, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self.assertAllClose(
         scipy_special.betainc(a, b, x),
@@ -332,13 +330,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.HalfNormal(
         scale=np.float32(1e-8)).sample(100, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.HalfNormal(
         scale=np.float32(1e-8)).sample(100, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float32(1.)).sample(100, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self._testBetaincDerivative(
         a, b, x, rtol_a=0.05, rtol_b=0.05, rtol_x=1e-5)
@@ -348,13 +344,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.Uniform(
         high=np.float32(5.)).sample(100, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.Uniform(
         high=np.float32(5.)).sample(100, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float32(1.)).sample(100, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self._testBetaincDerivative(
         a, b, x, atol_a=1e-3, atol_b=1e-3, atol_x=0.01)
@@ -364,13 +358,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.Uniform(
         high=np.float32(100.)).sample(100, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.Uniform(
         high=np.float32(100.)).sample(100, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float32(1.)).sample(100, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self._testBetaincDerivative(
         a, b, x, atol_a=1e-3, atol_b=1e-3, atol_x=1e-3)
@@ -380,13 +372,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.HalfNormal(
         scale=np.float64(1e-16)).sample(100, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.HalfNormal(
         scale=np.float64(1e-16)).sample(100, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float64(1.)).sample(100, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self._testBetaincDerivative(
         a, b, x, rtol_a=1e-11, rtol_b=1e-11, rtol_x=1e-13)
@@ -396,13 +386,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.Uniform(
         high=np.float64(10.)).sample(100, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.Uniform(
         high=np.float64(10.)).sample(100, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float64(1.)).sample(100, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self._testBetaincDerivative(
         a, b, x, atol_a=1e-12, atol_b=1e-12, atol_x=1e-11)
@@ -412,13 +400,11 @@ class BetaincTest(test_util.TestCase):
     strm = test_util.test_seed_stream()
     a = tfp.distributions.Uniform(
         high=np.float64(100.)).sample(100, strm())
-    a = self.evaluate(a)
     b = tfp.distributions.Uniform(
         high=np.float64(100.)).sample(100, strm())
-    b = self.evaluate(b)
     x = tfp.distributions.Uniform(
         high=np.float64(1.)).sample(100, strm())
-    x = self.evaluate(x)
+    a, b, x = self.evaluate([a, b, x])
 
     self._testBetaincDerivative(
         a, b, x, atol_a=1e-12, atol_b=1e-12, atol_x=1e-10)

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -469,8 +469,8 @@ class BetaincTest(test_util.TestCase):
 
     # Wrap in tf.function and compile for faster computations.
     betainc_partials_of_partials = [
-      tf.function(partial_fn, autograph=False, jit_compile=True)
-      for partial_fn in betainc_partials_of_partials]
+        tf.function(partial_fn, autograph=False, jit_compile=True)
+        for partial_fn in betainc_partials_of_partials]
 
     partials_of_partials = [
         partial_fn(a, b, x) for partial_fn in betainc_partials_of_partials]

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -426,18 +426,26 @@ class BetaincTest(test_util.TestCase):
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test
   def testBetaincDerivativeChallengingPoints(self, dtype):
-    a = np.array([0.014, 5.90, 0.536, 0.836, 0.3, 9., 1.69], dtype=dtype)
-    b = np.array([3.467, 0.01, 2.315, 0.221, 9., 0.24, 0.117], dtype=dtype)
+    a = np.array(
+        [0.014, 5.90, 0.536, 0.836, 0.3, 9., 1.69, 880.],
+        dtype=dtype)
+    b = np.array(
+        [3.467, 0.01, 2.315, 0.221, 9., 0.24, 0.117, 990.],
+        dtype=dtype)
     x = np.array(
-        [0.007, 0.99, 0.215, 0.782, 1e-16, 1. - 1e-6, 3.4e-4], dtype=dtype)
+        [0.007, 0.99, 0.215, 0.782, 1e-16, 1. - 1e-6, 3.4e-4, 0.47],
+        dtype=dtype)
 
     if dtype == np.float32:
       self._testBetaincDerivative(
           a, b, x,
-          atol_a=5e-5, atol_b=5e-4, atol_x=5e-4,
-          rtol_a=1e-5, rtol_b=1e-5, rtol_x=1e-5)
+          atol_a=5e-4, atol_b=5e-4, atol_x=5e-4,
+          rtol_a=5e-4, rtol_b=5e-4, rtol_x=5e-4)
     else:
-      self._testBetaincDerivative(a, b, x)
+      self._testBetaincDerivative(
+          a, b, x,
+          atol_a=1e-10, atol_b=1e-10, atol_x=1e-10,
+          rtol_a=1e-11, rtol_b=1e-11, rtol_x=1e-11)
 
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -481,7 +481,7 @@ class BetaincTest(test_util.TestCase):
         betainc_partials_of_partial_b,
         betainc_partials_of_partial_x]
 
-    # Wrap in tf.function for faster computations.
+    # Wrap in tf.function and compile for faster computations.
     betainc_partials_of_partials = [
       tf.function(partial_fn, autograph=False, jit_compile=True)
       for partial_fn in betainc_partials_of_partials]


### PR DESCRIPTION
This PR tries to improve the partial derivatives of ` tfp_math.betainc(a, b, x)` with respect to `a` and `b`.

Some of the improvement opportunities I identified in the current implementation of these partial derivatives are:
- When dtype is `float64`:
  - Moderate loss of accuracy when `a` and `b` are uniformly distributed in the interval (0, 10).
  - When `a` and `b` are very small, gradients contain a very high proportion of NaN.
- When dtype is `float32`:
  - Heavy loss of accuracy in all domains evaluated.
  - Gradients contain NaN (sometimes infinite as well) in all domains evaluated.
  - When `a` and `b` are very small, gradients contain only NaN.

Please see the following notebook:
https://gist.github.com/leandrolcampos/c5a77b0f24ee8d2a38c9ea2f8ddc3c77

The alternative implementation I propose addresses all these improvement opportunities. Please see the following notebook:
https://gist.github.com/leandrolcampos/776048810f9c4ae18fc9598f54543057