### PR TITLE
Correct a typo in the doc of joint_distribution_sequential.py

### DIFF
--- a/tensorflow_probability/python/distributions/joint_distribution_sequential.py
+++ b/tensorflow_probability/python/distributions/joint_distribution_sequential.py
@@ -116,7 +116,7 @@ class JointDistributionSequential(joint_distribution_lib.JointDistribution):
                    tfd.Exponential(rate=[100, 120]),           # e
       lambda    e: tfd.Gamma(concentration=e[0], rate=e[1]),    # g
                    tfd.Normal(loc=0, scale=2.),                 # n
-      lambda n, g: tfd.Normal(loc=n, scale=g)                   # m
+      lambda n, g: tfd.Normal(loc=n, scale=g),                  # m
       lambda    m: tfd.Sample(tfd.Bernoulli(logits=m), 12)      # x
   ], batch_ndims=0, use_vectorized_map=True)
   ```


### PR DESCRIPTION
There is a `,` missing in the example codes in the doc of `joint_distribution_sequential.py`.