### PR TITLE
issue 1587 pass anomaly_threshold parameter

### DIFF
--- a/tensorflow_probability/python/sts/anomaly_detection/anomaly_detection_lib.py
+++ b/tensorflow_probability/python/sts/anomaly_detection/anomaly_detection_lib.py
@@ -133,6 +133,7 @@ def detect_anomalies(series,
   lower_limit, upper_limit, mean, tail_probabilities = inner_fn(
       observed_time_series,
       seasonal_structure=seasonal_structure,
+      anomaly_threshold=anomaly_threshold,
       use_gibbs_predictive_dist=use_gibbs_predictive_dist,
       num_warmup_steps=num_warmup_steps,
       num_samples=num_samples,


### PR DESCRIPTION
In order to override the default value of anomaly_threshold variable, we are to pass this value as a parameter

Fixes https://github.com/tensorflow/probability/issues/1587