### PR TITLE
Fix `scale_tril` argument in Gaussian_Copula example notebook

### DIFF
--- a/tensorflow_probability/examples/jupyter_notebooks/Gaussian_Copula.ipynb
+++ b/tensorflow_probability/examples/jupyter_notebooks/Gaussian_Copula.ipynb
@@ -166,7 +166,7 @@
         "\n",
         "pdf = GaussianCopulaTriL(\n",
         "    loc=[0., 0.],\n",
-        "    scale_tril=[[1., 0.8], [0., 0.6]],\n",
+        "    scale_tril=[[1., 0.], [0.8, 0.6]],\n",
         ").prob(coordinates)\n",
         "\n",
         "# Plot its density.\n",


### PR DESCRIPTION
Fix `scale_tril` argument, so marginals are actually uniform, as stated in the primer text.

See https://github.com/tensorflow/probability/issues/1591
