### PR TITLE
Add `tfp.math.betaincinv`

### DIFF
--- a/tensorflow_probability/python/math/__init__.py
+++ b/tensorflow_probability/python/math/__init__.py
@@ -69,6 +69,7 @@ from tensorflow_probability.python.math.scan_associative import scan_associative
 from tensorflow_probability.python.math.sparse import dense_to_sparse
 from tensorflow_probability.python.math.special import atan_difference
 from tensorflow_probability.python.math.special import betainc
+from tensorflow_probability.python.math.special import betaincinv
 from tensorflow_probability.python.math.special import dawsn
 from tensorflow_probability.python.math.special import erfcinv
 from tensorflow_probability.python.math.special import erfcx
@@ -96,6 +97,7 @@ random_rayleigh = deprecation.deprecated(
 _allowed_symbols = [
     'atan_difference',
     'betainc',
+    'betaincinv',
     'batch_interp_rectilinear_nd_grid',
     'batch_interp_regular_1d_grid',
     'batch_interp_regular_nd_grid',

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -567,17 +567,15 @@ def betainc(a, b, x, name=None):
 def _betaincinv_initial_approx(a, b, y, dtype):
   """Computes an initial approximation for `betaincinv(a, b, y)`."""
   numpy_dtype = dtype_util.as_numpy_dtype(dtype)
-  tiny = tf.constant(np.finfo(numpy_dtype).tiny, dtype=dtype)
-  eps = tf.constant(np.finfo(numpy_dtype).eps, dtype=dtype)
-  one = tf.constant(1., dtype=dtype)
-  two = tf.constant(2., dtype=dtype)
-  three = tf.constant(3., dtype=dtype)
-  five = tf.constant(5., dtype=dtype)
-  six = tf.constant(6., dtype=dtype)
-  min_log = tf.math.log(
-      tf.constant(2. ** np.finfo(numpy_dtype).minexp, dtype))
-  max_log = tf.math.log(
-      tf.constant(2. ** (np.finfo(numpy_dtype).maxexp - 1.), dtype))
+  tiny = np.finfo(numpy_dtype).tiny
+  eps = np.finfo(numpy_dtype).eps
+  one = numpy_dtype(1.)
+  two = numpy_dtype(2.)
+  three = numpy_dtype(3.)
+  five = numpy_dtype(5.)
+  six = numpy_dtype(6.)
+  min_log = numpy_dtype(np.finfo(numpy_dtype).minexp * np.log(2.))
+  max_log = numpy_dtype((np.finfo(numpy_dtype).maxexp - 1.) * np.log(2.))
 
   # When min(a, b) >= 1, we use the approximation proposed by [1].
 
@@ -652,14 +650,14 @@ def _betaincinv_computation(a, b, y):
   should_promote_dtype = (dtype_orig in _f16bit_dtypes)
   dtype = tf.float32 if should_promote_dtype else dtype_orig
   numpy_dtype = dtype_util.as_numpy_dtype(dtype)
-  zero = tf.constant(0., dtype=dtype)
-  tiny = tf.constant(np.finfo(numpy_dtype).tiny, dtype=dtype)
-  eps = tf.constant(np.finfo(numpy_dtype).eps, dtype=dtype)
-  half = tf.constant(0.5, dtype=dtype)
-  one = tf.constant(1., dtype=dtype)
-  two = tf.constant(2., dtype=dtype)
-  halley_correction_min = tf.constant(0.5, dtype=dtype)
-  halley_correction_max = tf.constant(1.5, dtype=dtype)
+  zero = numpy_dtype(0.)
+  tiny = np.finfo(numpy_dtype).tiny
+  eps = np.finfo(numpy_dtype).eps
+  half = numpy_dtype(0.5)
+  one = numpy_dtype(1.)
+  two = numpy_dtype(2.)
+  halley_correction_min = numpy_dtype(0.5)
+  halley_correction_max = numpy_dtype(1.5)
 
   a, b, y = [tf.convert_to_tensor(z, dtype=dtype_orig) for z in [a, b, y]]
   if should_promote_dtype:
@@ -696,10 +694,10 @@ def _betaincinv_computation(a, b, y):
   # max_iterations was taken from [4] and tolerance was set by experimentation.
   if numpy_dtype == np.float32:
     max_iterations = 10
-    tolerance = tf.constant(8., dtype=dtype) * eps
+    tolerance = numpy_dtype(8.) * eps
   else:
     max_iterations = 8
-    tolerance = tf.constant(4096., dtype=dtype) * eps
+    tolerance = numpy_dtype(4096.) * eps
 
   def root_finding_iteration(should_stop, low, high, candidate):
     error = betainc(a, b, candidate) - y

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -666,7 +666,8 @@ def _betaincinv_computation(a, b, y):
 
   a_minus_1 = a - one
   b_minus_1 = b - one
-  one_minus_eps = one - eps
+  lbeta_a_and_b = lbeta(a, b)
+  two_tiny = two * tiny
 
   # tolerance was set by experimentation and max_iterations was taken from [4].
   if numpy_dtype == np.float64:
@@ -681,7 +682,7 @@ def _betaincinv_computation(a, b, y):
     error_over_der = error / tf.math.exp(
         tf.math.xlogy(a_minus_1, candidate) +
         tf.math.xlog1py(b_minus_1, -candidate) -
-        lbeta(a, b))
+        lbeta_a_and_b)
     second_der_over_der = a_minus_1 / candidate - b_minus_1 / (one - candidate)
     # Following [2, section 9.4.2, page 463], we limit the influence of the
     # Halley's correction to the Newton's method, since this correction can
@@ -710,7 +711,7 @@ def _betaincinv_computation(a, b, y):
     new_low = tf.where(new_delta_is_negative, candidate, low)
     new_high = tf.where(new_delta_is_negative, high, candidate)
 
-    adjusted_tolerance = tf.maximum(tolerance * new_candidate, two * tiny)
+    adjusted_tolerance = tf.maximum(tolerance * new_candidate, two_tiny)
     should_stop = (should_stop | (tf.math.abs(new_delta) < adjusted_tolerance) |
         tf.math.equal(new_low, new_high))
 
@@ -739,7 +740,7 @@ def _betaincinv_computation(a, b, y):
   # input y and the solution.
   y = tf.where(use_symmetry_relation, one - y, y)
   result = tf.where(use_symmetry_relation, one - result, result)
-  result = tf.clip_by_value(result, tiny, one_minus_eps)
+  result = tf.clip_by_value(result, tiny, one - eps)
 
   # Handle trivial cases.
   result = tf.where(tf.equal(y, zero) | tf.equal(y, one), y, result)

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -619,7 +619,7 @@ def _betaincinv_initial_approx(a, b, y, dtype):
       y <= (integral_approx_part_a / integral_approx),
       tf.math.exp(tf.math.xlogy(inv_a, y) + tf.math.xlogy(inv_a, a) +
           tf.math.xlogy(inv_a, integral_approx)),
-      one - tf.math.exp(tf.math.xlog1py(inv_b, -y) + tf.math.xlogy(inv_b, b) +
+      -tf.math.expm1(tf.math.xlog1py(inv_b, -y) + tf.math.xlogy(inv_b, b) +
           tf.math.xlogy(inv_b, integral_approx)))
 
   # And when max(a, b) < 1, we use the approximation proposed by [3] for the

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -549,8 +549,8 @@ def betainc(a, b, x, name=None):
 # is based on ideas and equations available in the following references:
 # [1] Milton Abramowitz and Irene A. Stegun
 #     Handbook of Mathematical Functions with Formulas, Graphs, and
-#         Mathematical Tables.
-#     US Government Printing Office, 1964 (reprinted 1972).
+#         Mathematical Tables
+#     US Government Printing Office, 1964 (reprinted 1972)
 #     https://archive.org/details/AandS-mono600
 # [2] William Press, Saul Teukolsky, William Vetterling and Brian Flannery
 #     Numerical Recipes: The Art of Scientific Computing

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -521,6 +521,25 @@ def betainc(a, b, x, name=None):
     return _betainc_custom_gradient(a, b, x)
 
 
+# The implementation of the inverse of the regularized incomplete beta function
+# is based on ideas and equations available in the following references:
+# [1] Milton Abramowitz and Irene A. Stegun
+#     Handbook of Mathematical Functions with Formulas, Graphs, and
+#         Mathematical Tables.
+#     US Government Printing Office, 1964 (reprinted 1972).
+#     https://archive.org/details/AandS-mono600
+# [2] William Press, Saul Teukolsky, William Vetterling and Brian Flannery
+#     Numerical Recipes: The Art of Scientific Computing
+#     Cambridge University Press, 2007 (Third Edition)
+#     http://numerical.recipes/book/book.html
+# [3] John Maddock, Paul A. Bristow, et al.
+#     The Incomplete Beta Function Inverses
+#     https://www.boost.org/doc/libs/1_79_0/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html
+# [4] Stephen L. Moshier
+#     Cephes Mathematical Library
+#     https://netlib.org/cephes/
+
+
 def _dawsn_naive(x):
   """Returns the Dawson Integral computed at x elementwise."""
   dtype = dtype_util.common_dtype([x], tf.float32)

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -750,6 +750,29 @@ def _betaincinv_computation(a, b, y):
   return result
 
 
+def betaincinv(a, b, y, name=None):
+  """Computes the inverse of `tfp.math.betainc` with respect to `x`.
+
+  This function returns a value `x` such that `y = tfp.math.betainc(a, b, x)`.
+
+  Args:
+    a: Floating-point Tensor. Must be broadcastable with `b` and `y`.
+    b: Floating-point Tensor. Must be broadcastable with `a` and `y`.
+    y: Floating-point Tensor. Must be broadcastable with `a` and `b`.
+    name: A name for the operation (optional).
+
+  Returns:
+    betaincinv: Floating-point Tensor, inverse of the regularized incomplete
+    beta function computed element-wise.
+  """
+  with tf.name_scope(name or 'betaincinv'):
+    dtype = dtype_util.common_dtype([a, b, y], tf.float32)
+    a = tf.convert_to_tensor(a, dtype=dtype)
+    b = tf.convert_to_tensor(b, dtype=dtype)
+    y = tf.convert_to_tensor(y, dtype=dtype)
+    return _betaincinv_computation(a, b, y)
+
+
 def _dawsn_naive(x):
   """Returns the Dawson Integral computed at x elementwise."""
   dtype = dtype_util.common_dtype([x], tf.float32)

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -779,7 +779,7 @@ def _betaincinv_bwd(aux, g):
   # compute the gradients.
   pa, pb, py = _betaincinv_partials(a, b, x)
   return _fix_gradient_for_broadcasting(
-      [a, b, x], [pa * g, pb * g, py * g])
+      [a, b, y], [pa * g, pb * g, py * g])
 
 
 def _betaincinv_jvp(primals, tangents):

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -28,6 +28,7 @@ from tensorflow_probability.python.internal import tensorshape_util
 __all__ = [
     'atan_difference',
     'betainc',
+    'betaincinv',
     'dawsn',
     'erfcinv',
     'erfcx',

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -450,14 +450,14 @@ def _betainc_partials(a, b, x):
   grad_b = tf.where(use_power_series, ps_grad_b, cf_grad_b)
 
   # According to the code accompanying [1], grad_a = grad_b = 0 when x is
-  # equal to 0 or 1. Under the same condition, grad_x = 0 by its expression.
+  # equal to 0 or 1.
   # [1] R. Boik, J. Robinson-Cox,
   #     Derivatives of the Incomplete Beta Function
   #     https://www.jstatsoft.org/article/view/v003i01/beta.der.pdf
-  result_is_zero = tf.math.equal(x, zero) | tf.math.equal(x, one)
-  grad_a, grad_b, grad_x = [
-      tf.where(result_is_zero, zero, grad)
-      for grad in [grad_a, grad_b, grad_x]]
+  grads_a_and_b_should_be_zero = tf.math.equal(x, zero) | tf.math.equal(x, one)
+  grad_a, grad_b = [
+      tf.where(grads_a_and_b_should_be_zero, zero, grad)
+      for grad in [grad_a, grad_b]]
 
   # Determine if the inputs are out of range (should return NaN output).
   result_is_nan = (a <= zero) | (b <= zero) | (x < zero) | (x > one)

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -534,7 +534,7 @@ def betainc(a, b, x, name=None):
 #     http://numerical.recipes/book/book.html
 # [3] John Maddock, Paul A. Bristow, et al.
 #     The Incomplete Beta Function Inverses
-#     https://www.boost.org/doc/libs/1_79_0/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html
+#     https://www.boost.org/doc/libs/1_79_0/libs/math/doc/html/special.html
 # [4] Stephen L. Moshier
 #     Cephes Mathematical Library
 #     https://netlib.org/cephes/

--- a/tensorflow_probability/python/math/special.py
+++ b/tensorflow_probability/python/math/special.py
@@ -616,7 +616,7 @@ def _betaincinv_initial_approx(a, b, y, dtype):
   inv_a = tf.math.reciprocal(a)
   inv_b = tf.math.reciprocal(b)
   result_for_small_a_or_b = tf.where(
-      tf.math.less_equal(y, (integral_approx_part_a / integral_approx)),
+      y <= (integral_approx_part_a / integral_approx),
       tf.math.exp(tf.math.xlogy(inv_a, y) + tf.math.xlogy(inv_a, a) +
           tf.math.xlogy(inv_a, integral_approx)),
       one - tf.math.exp(tf.math.xlog1py(inv_b, -y) + tf.math.xlogy(inv_b, b) +
@@ -634,7 +634,7 @@ def _betaincinv_initial_approx(a, b, y, dtype):
 
   # Return the appropriate result for parameters a and b.
   result = tf.where(
-      tf.math.greater_equal(tf.math.minimum(a, b), one),
+      tf.math.minimum(a, b) >= one,
       result_for_large_a_and_b,
       tf.where(
           tf.math.maximum(a, b) < one,
@@ -723,10 +723,10 @@ def _betaincinv_computation(a, b, y):
     # Fall back to bisection if the current step would take the new candidate
     # out of bounds.
     new_candidate = tf.where(
-        tf.less_equal(halley_candidate, low),
+        halley_candidate <= low,
         half * (candidate + low),
         tf.where(
-            tf.greater_equal(halley_candidate, high),
+            halley_candidate >= high,
             half * (candidate + high),
             halley_candidate))
 

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -194,7 +194,7 @@ class BetaincTest(test_util.TestCase):
     x = np.ones([7, 1, 1, 2], dtype=np.float32)
     self.assertAllEqual([7, 5, 3, 2], tfp_math.betainc(a, b, x).shape)
 
-  def testBetaincHalfPrecision(self):
+  def testBetaincFloat16(self):
     a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.float16)
     b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.float16)
     x = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.float16)
@@ -210,8 +210,8 @@ class BetaincTest(test_util.TestCase):
 
   @test_util.disable_test_for_backend(
       disable_numpy=True, disable_jax=False,
-      reason="Numpy does not support brain floating point.")
-  def testBetaincBrain(self):
+      reason="Numpy does not support BFloat16.")
+  def testBetaincBFloat16(self):
     a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.bfloat16)
     b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.bfloat16)
     x = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.bfloat16)
@@ -294,7 +294,7 @@ class BetaincTest(test_util.TestCase):
     x = np.array([0.5, 0.5, 0.5, 0.5, -1., 2.], dtype=dtype)
 
     for partial in self.evaluate(betainc_partials(a, b, x)):
-      self.assertAllEqual(np.full_like(a, np.nan), partial)
+      self.assertAllNan(partial)
 
     # Test partials when x is equal to 0 or 1.
     a = np.array([0.4, 0.4], dtype=dtype)
@@ -485,7 +485,7 @@ class BetaincTest(test_util.TestCase):
           rtol_a=1e-11, rtol_b=1e-11, rtol_x=1e-11)
 
   @test_util.numpy_disable_gradient_test
-  def testBetaincDerivativeBrainAndHalfPrecision(self):
+  def testBetaincDerivativeFloat16AndBFloat16(self):
     for dtype in [tf.float16, tf.bfloat16]:
       a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=dtype)
       b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=dtype)
@@ -624,7 +624,7 @@ class BetaincinvTest(test_util.TestCase):
 
     betaincinv = self.evaluate(tfp_math.betaincinv(a, b, y))
     self.assertEqual(dtype, betaincinv.dtype)
-    self.assertAllEqual(np.full_like(a, np.nan), betaincinv)
+    self.assertAllNan(betaincinv)
 
     # Test tfp_math.betaincinv when y is equal to 0 or 1.
     a, b, y0, y1 = [np.array([z], dtype=dtype) for z in [0.4, 0.6, 0., 1.]]
@@ -634,7 +634,7 @@ class BetaincinvTest(test_util.TestCase):
       self.assertEqual(dtype, betaincinv.dtype)
       self.assertAllEqual(y, betaincinv)
 
-  def testBetaincinvHalfPrecision(self):
+  def testBetaincinvFloat16(self):
     a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.float16)
     b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.float16)
     y = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.float16)
@@ -650,8 +650,8 @@ class BetaincinvTest(test_util.TestCase):
 
   @test_util.disable_test_for_backend(
       disable_numpy=True, disable_jax=False,
-      reason="Numpy does not support brain floating point.")
-  def testBetaincinvBrain(self):
+      reason="Numpy does not support BFloat16.")
+  def testBetaincinvBFloat16(self):
     a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.bfloat16)
     b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.bfloat16)
     y = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.bfloat16)
@@ -692,11 +692,11 @@ class BetaincinvTest(test_util.TestCase):
 
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test
-  def _testBetaincinvGradientFinite(self, dtype):
+  def testBetaincinvGradientFinite(self, dtype):
     eps = np.finfo(dtype).eps
     small = np.sqrt(eps)
 
-    space = np.logspace(np.log10(eps), 4.).tolist()
+    space = np.logspace(np.log10(small), 4.).tolist()
     space_y = np.linspace(eps, 1. - small).tolist()
     a, b, y = [
         tf.constant(z, dtype=dtype)
@@ -729,7 +729,7 @@ class BetaincinvTest(test_util.TestCase):
       self.assertAllEqual(simple_partial.shape, betaincinv_partial.shape)
 
   @test_util.numpy_disable_gradient_test
-  def testBetaincinvGradientBrainAndHalfPrecision(self):
+  def testBetaincinvGradientFloat16AndBFloat16(self):
     for dtype in [tf.float16, tf.bfloat16]:
       a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=dtype)
       b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=dtype)

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -194,6 +194,37 @@ class BetaincTest(test_util.TestCase):
     x = np.ones([7, 1, 1, 2], dtype=np.float32)
     self.assertAllEqual([7, 5, 3, 2], tfp_math.betainc(a, b, x).shape)
 
+  def testBetaincHalfPrecision(self):
+    a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.float16)
+    b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.float16)
+    x = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.float16)
+    result = tfp_math.betainc(a, b, x)
+
+    self.assertEqual(a.dtype, result.dtype)
+
+    expected_result = tfp_math.betainc(
+        *[tf.cast(z, tf.float32) for z in [a, b, x]])
+    expected_result = tf.cast(expected_result, a.dtype)
+
+    self.assertAllEqual(*self.evaluate([expected_result, result]))
+
+  @test_util.disable_test_for_backend(
+      disable_numpy=True, disable_jax=False,
+      reason="Numpy does not support brain floating point.")
+  def testBetaincBrain(self):
+    a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.bfloat16)
+    b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.bfloat16)
+    x = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.bfloat16)
+    result = tfp_math.betainc(a, b, x)
+
+    self.assertEqual(a.dtype, result.dtype)
+
+    expected_result = tfp_math.betainc(
+        *[tf.cast(z, tf.float32) for z in [a, b, x]])
+    expected_result = tf.cast(expected_result, a.dtype)
+
+    self.assertAllEqual(*self.evaluate([expected_result, result]))
+
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test
   def testBetaincGradient(self, dtype):
@@ -453,6 +484,23 @@ class BetaincTest(test_util.TestCase):
           atol_a=1e-10, atol_b=1e-10, atol_x=1e-10,
           rtol_a=1e-11, rtol_b=1e-11, rtol_x=1e-11)
 
+  @test_util.numpy_disable_gradient_test
+  def testBetaincDerivativeBrainAndHalfPrecision(self):
+    for dtype in [tf.float16, tf.bfloat16]:
+      a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=dtype)
+      b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=dtype)
+      x = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=dtype)
+      grads = tfp_math.value_and_gradient(tfp_math.betainc, [a, b, x])[1]
+
+      for grad in grads:
+        self.assertEqual(a.dtype, grad.dtype)
+
+      expected_grads = tfp_math.value_and_gradient(
+          tfp_math.betainc, *[tf.cast(z, tf.float32) for z in [a, b, x]])[1]
+      expected_grads = [tf.cast(grad, a.dtype) for grad in expected_grads]
+
+      self.assertAllEqual(*self.evaluate([expected_grads, grads]))
+
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test
   def testBetaincSecondDerivativeFinite(self, dtype):
@@ -586,6 +634,37 @@ class BetaincinvTest(test_util.TestCase):
       self.assertEqual(dtype, betaincinv.dtype)
       self.assertAllEqual(y, betaincinv)
 
+  def testBetaincinvHalfPrecision(self):
+    a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.float16)
+    b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.float16)
+    y = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.float16)
+    result = tfp_math.betaincinv(a, b, y)
+
+    self.assertEqual(a.dtype, result.dtype)
+
+    expected_result = tfp_math.betaincinv(
+        *[tf.cast(z, tf.float32) for z in [a, b, y]])
+    expected_result = tf.cast(expected_result, a.dtype)
+
+    self.assertAllEqual(*self.evaluate([expected_result, result]))
+
+  @test_util.disable_test_for_backend(
+      disable_numpy=True, disable_jax=False,
+      reason="Numpy does not support brain floating point.")
+  def testBetaincinvBrain(self):
+    a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.bfloat16)
+    b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.bfloat16)
+    y = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=tf.bfloat16)
+    result = tfp_math.betaincinv(a, b, y)
+
+    self.assertEqual(a.dtype, result.dtype)
+
+    expected_result = tfp_math.betaincinv(
+        *[tf.cast(z, tf.float32) for z in [a, b, y]])
+    expected_result = tf.cast(expected_result, a.dtype)
+
+    self.assertAllEqual(*self.evaluate([expected_result, result]))
+
   @test_util.numpy_disable_gradient_test
   def testBetaincinvGradient(self):
     space = np.logspace(np.log10(0.5), 3., 5).tolist()
@@ -646,6 +725,23 @@ class BetaincinvTest(test_util.TestCase):
 
     for simple_partial, betaincinv_partial in pairs_of_partials:
       self.assertAllEqual(simple_partial.shape, betaincinv_partial.shape)
+
+  @test_util.numpy_disable_gradient_test
+  def testBetaincinvGradientBrainAndHalfPrecision(self):
+    for dtype in [tf.float16, tf.bfloat16]:
+      a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=dtype)
+      b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=dtype)
+      y = tf.constant([0.0, 0.1, 0.9, 1.0, 0.5, 0.5, -1.], dtype=dtype)
+      grads = tfp_math.value_and_gradient(tfp_math.betaincinv, [a, b, y])[1]
+
+      for grad in grads:
+        self.assertEqual(a.dtype, grad.dtype)
+
+      expected_grads = tfp_math.value_and_gradient(
+          tfp_math.betaincinv, *[tf.cast(z, tf.float32) for z in [a, b, y]])[1]
+      expected_grads = [tf.cast(grad, a.dtype) for grad in expected_grads]
+
+      self.assertAllEqual(*self.evaluate([expected_grads, grads]))
 
   @parameterized.parameters(np.float32, np.float64)
   @test_util.numpy_disable_gradient_test

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -263,15 +263,16 @@ class BetaincTest(test_util.TestCase):
     x = np.array([0.5, 0.5, 0.5, 0.5, -1., 2.], dtype=dtype)
 
     for partial in self.evaluate(betainc_partials(a, b, x)):
-      self.assertAllClose(np.full_like(a, np.nan), partial)
+      self.assertAllEqual(np.full_like(a, np.nan), partial)
 
     # Test partials when x is equal to 0 or 1.
     a = np.array([0.4, 0.4], dtype=dtype)
     b = np.array([0.6, 0.6], dtype=dtype)
     x = np.array([0., 1.], dtype=dtype)
 
-    for partial in self.evaluate(betainc_partials(a, b, x)):
-      self.assertAllClose(np.zeros_like(a), partial)
+    partial_a, partial_b, _ = self.evaluate(betainc_partials(a, b, x))
+    for partial in [partial_a, partial_b]:
+      self.assertAllEqual(np.zeros_like(a), partial)
 
   def _testBetaincDerivative(self,
                              a,

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -667,6 +667,8 @@ class BetaincinvTest(test_util.TestCase):
 
   @test_util.numpy_disable_gradient_test
   def testBetaincinvGradient(self):
+    # Avoid small values for parameters a and b where the gradient can veer off
+    # to infinity.
     space = np.logspace(np.log10(0.5), 3., 5).tolist()
     space_y = np.linspace(0.01, 0.99, 10).tolist()
     a, b, y = [

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -556,7 +556,7 @@ class BetaincinvTest(test_util.TestCase):
     self.assertAllEqual([7, 5, 3, 2], tfp_math.betaincinv(a, b, y).shape)
 
   def _test_betaincinv_value(self, a_high, b_high, dtype, atol, rtol):
-    tiny = tf.constant(np.finfo(dtype).tiny, dtype)
+    tiny = np.finfo(dtype).tiny
     n = [int(1e4)]
     strm = test_util.test_seed_stream()
     a = tfp.distributions.Uniform(

--- a/tensorflow_probability/python/math/special_test.py
+++ b/tensorflow_probability/python/math/special_test.py
@@ -210,7 +210,7 @@ class BetaincTest(test_util.TestCase):
 
   @test_util.disable_test_for_backend(
       disable_numpy=True, disable_jax=False,
-      reason="Numpy does not support BFloat16.")
+      reason="Numpy does not support bfloat16.")
   def testBetaincBFloat16(self):
     a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.bfloat16)
     b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.bfloat16)
@@ -650,7 +650,7 @@ class BetaincinvTest(test_util.TestCase):
 
   @test_util.disable_test_for_backend(
       disable_numpy=True, disable_jax=False,
-      reason="Numpy does not support BFloat16.")
+      reason="Numpy does not support bfloat16.")
   def testBetaincinvBFloat16(self):
     a = tf.constant([0.4, 0.4, 0.4, 0.4, -1., 0.4, 0.4], dtype=tf.bfloat16)
     b = tf.constant([0.6, 0.6, 0.6, 0.6, 0.6, -1., 0.6], dtype=tf.bfloat16)


### PR DESCRIPTION
This PR provides an implementation for `tfp.math.betaincinv`, the inverse of the regularized incomplete beta function (`tfp.math.betainc`) with respect to `x`. It addresses the issue #1581.

This implementation is based on ideas and equations available in the following references:
[1] Milton Abramowitz and Irene A. Stegun. Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical Tables. US Government Printing Office, 1964 (reprinted 1972). [[Link](https://archive.org/details/AandS-mono600)]
[2] William Press, Saul Teukolsky, William Vetterling and Brian Flannery. Numerical Recipes: The Art of Scientific Computing. Cambridge University Press, 2007 (Third Edition). [[Link](http://numerical.recipes/book/book.html)]
[3] John Maddock, Paul A. Bristow, et al. The Incomplete Beta Function Inverses. [[Link](https://www.boost.org/doc/libs/1_79_0/libs/math/doc/html/special.html)]
[4] Stephen L. Moshier. Cephes Mathematical Library. [[Link](https://netlib.org/cephes/)]

The expression of these ideas and equations as source code is my own.

In the following notebook, I measure and present the numerical accuracy of this implementation:
- [My implementation of `betaincinv`](https://gist.github.com/leandrolcampos/767818366dd8cbdffb6189aa00847d34)

As references (especially for single-precision results), I also measure and present the numerical accuracy of the following methods:
- [Cephes implementation of `betaincinv` for `float32` [my port]](https://gist.github.com/leandrolcampos/5dfbc66753310598ef531f59901a343b)
- [TFP implementation of `igammainv`](https://gist.github.com/leandrolcampos/b19177cac0e4f3f0b962edca265ec8ab)

In addition to implementing the function `tfp.math.betaincinv`, this PR also fixes a bug in the implementation of the partial derivative of `tfp.math.betainc` with respect to `x`: it's not true that this partial is equal to `0` whenever the parameter `x` is equal to `0` or `1`.