### PR TITLE
Fix doc of `windowed_mean|variance` to match implementation

### DIFF
--- a/tensorflow_probability/python/stats/sample_stats.py
+++ b/tensorflow_probability/python/stats/sample_stats.py
@@ -712,7 +712,7 @@ def windowed_variance(
 
   Computes variances among data in the Tensor `x` along the given windows:
 
-    result[i] = variance(x[low_indices[i]:high_indices[i]+1])
+    result[i] = variance(x[low_indices[i]:high_indices[i]])
 
   accurately and efficiently.  To wit, if K is the size of
   `low_indices` and `high_indices`, and `N` is the size of `x` along

--- a/tensorflow_probability/python/stats/sample_stats.py
+++ b/tensorflow_probability/python/stats/sample_stats.py
@@ -829,7 +829,7 @@ def windowed_mean(
 
   Computes means among data in the Tensor `x` along the given windows:
 
-    result[i] = mean(x[low_indices[i]:high_indices[i]+1])
+    result[i] = mean(x[low_indices[i]:high_indices[i]])
 
   efficiently.  To wit, if K is the size of `low_indices` and
   `high_indices`, and `N` is the size of `x` along the given `axis`,


### PR DESCRIPTION
Subsumed by https://github.com/tensorflow/probability/pull/1600

Hi, I got confused with the results of `windowed_variance`, it seems the documentation is wrong (same applies for `windowed_mean`).

```python
low = np.maximum(np.arange(10) - 5, 0)
high = np.arange(10) + 5
x = np.arange(20, dtype=np.float32)
a = tfp.stats.windowed_variance(x, low_indices=low, high_indices=high)
b = [np.var(x[low[i]: high[i]+1]) for i in range(len(low))]
c = [np.var(x[low[i]: high[i]]) for i in range(len(low))]

np.testing.assert_almost_equal(a, c, decimal=5) # Ok
np.testing.assert_almost_equal(a, b, decimal=5) # Not Ok
```
