### PR TITLE
ci: add minimum GitHub token permissions for workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,9 @@
 # ============================================================================
 name: Tests
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   lints:
     name: Lints


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/tensorflow/probability/actions/runs/3154612754/jobs/5132400045#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflow:

- continuous-integration.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <kurmiashish@gmail.com>