### PR TITLE
Only run affected tests in the GitHub workflow.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ by adding a commit, rebasing etc.
 
 We test against TensorFlow nightly on Python 3.7. We shard our tests
 across several build jobs (identified by the `SHARD` environment variable).
-Lints are also done in a separate job.
+Lints are also done in a separate job. The scripts will attempt to only run the
+tests affected by your change, so don't be alarmed by relatively few tests
+running if you've changed a rarely used file.
 
 All pull-requests will need to pass the automated lint and unit-tests before
 being merged. As the tests can take a bit of time, see the following sections

--- a/testing/get_github_changed_py_files.sh
+++ b/testing/get_github_changed_py_files.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2018 The TensorFlow Probability Authors.
+# Copyright 2022 The TensorFlow Probability Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,10 @@
 set -v  # print commands as they are executed
 set -e  # fail and exit on any command erroring
 
-DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-
-python -m pip install --upgrade 'pip>=19.2'
-python -m pip install --upgrade setuptools
-python -m pip install --quiet pylint
-
-# Run lints on added/changed python files.
-changed_py_files=$(${DIR}/get_github_changed_py_files.sh)
-if [[ -n "${changed_py_files}" ]]; then
-  echo "Running pylint on ${changed_py_files}"
-  pylint -j2 --rcfile=testing/pylintrc ${changed_py_files}
-else
-  echo "No files to lint."
+if [ $GITHUB_BASE_REF ]; then
+#  git fetch origin ${GITHUB_BASE_REF} --depth=1
+  git diff \
+      --name-only \
+      --diff-filter=AM origin/${GITHUB_BASE_REF} \
+    | { grep '^tensorflow_probability.*\.py$' || true; }
 fi

--- a/testing/install_test_dependencies.sh
+++ b/testing/install_test_dependencies.sh
@@ -83,7 +83,9 @@ else
 fi
 
 has_tensorflow_packages() {
-  python -m pip list | grep -v tensorflow-metadata | grep tensorflow &> /dev/null
+  python -m pip list \
+    | grep -v tensorflow-metadata \
+    | grep -v tensorflow-io-gcs-filesystem | grep tensorflow &> /dev/null
 }
 
 has_tf_nightly_cpu_package() {

--- a/testing/run_github_tests.sh
+++ b/testing/run_github_tests.sh
@@ -24,12 +24,12 @@ set -u  # fail and exit on any undefined variable reference
 DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 # Make sure the environment variables are set.
-if [ -z "${SHARD}" ]; then
+if [ -z "${SHARD+x}" ]; then
   echo "SHARD is unset."
   exit -1
 fi
 
-if [ -z "${NUM_SHARDS}" ]; then
+if [ -z "${NUM_SHARDS+x}" ]; then
   echo "NUM_SHARDS is unset."
   exit -1
 fi
@@ -59,16 +59,27 @@ install_python_packages() {
 which bazel || install_bazel
 install_python_packages
 
-# You can alter this test_target to some smaller subset of TFP tests in case
-# you need to reproduce something on the CI workers.
-test_target="//tensorflow_probability/..."
-test_tags_to_skip="(gpu|requires-gpu-nvidia|notap|no-oss-ci|tfp_jax|tf2-broken|tf2-kokoro-broken)"
+changed_py_files="$(${DIR}/get_github_changed_py_files.sh | \
+  sed -r 's#(.*)/([^/]+).py#//\1:\2.py#')"
+
+if [[ -n "${changed_py_files}" ]]; then
+  test_targets=$(bazel query --universe_scope=//tensorflow_probability/... \
+    "tests(allrdeps(set(${changed_py_files})))")
+else
+  # For pushes, test all targets.
+  test_targets=$(bazel query 'tests(//tensorflow_probability/...)')
+fi
+
+test_targets=$(echo "${test_targets}" | tr -s '\n' ' ')
+test_targets="$(echo "${test_targets}" | sed -r 's#(.*) #\1#')"
+test_tags_to_skip="(gpu|requires-gpu-nvidia|notap|no-oss-ci|tfp_jax|\
+tfp_numpy|tf2-broken|tf2-kokoro-broken)"
 
 # Given a test size (small, medium, large), a number of shards and a shard ID,
 # query and print a list of tests of the given size to run in the given shard.
 query_and_shard_tests_by_size() {
   size=$1
-  bazel_query="attr(size, ${size}, tests(${test_target})) \
+  bazel_query="attr(size, ${size}, set(${test_targets})) \
                except \
                attr(tags, \"${test_tags_to_skip}\", \
                     tests(//tensorflow_probability/...))"


### PR DESCRIPTION
Also:
- Correctly detect unset environment variables
- Ignore another non-nightly-but-safe TF package.
- Skip testing numpy tests (it doesn't look like they were skipped before, but that was definitely the intention... whoops)