### PR TITLE
Update required_packages.py

### DIFF
--- a/required_packages.py
+++ b/required_packages.py
@@ -25,7 +25,7 @@ REQUIRED_PACKAGES = [
     'decorator',
     'cloudpickle>=1.3',
     'gast>=0.3.2',  # For autobatching
-    'dm-tree',  # For NumPy/JAX backends (hence, also for prefer_static)
+    'dm-tree==0.1.7',  # For NumPy/JAX backends (hence, also for prefer_static)
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
`dm-tree` library was updated 18.12.22 and new version 0.1.8 has a bag and doesn't work with python3.6