### PR TITLE
Update TensorFlow_Probability_on_JAX.ipynb

### DIFF
--- a/tensorflow_probability/examples/jupyter_notebooks/TensorFlow_Probability_on_JAX.ipynb
+++ b/tensorflow_probability/examples/jupyter_notebooks/TensorFlow_Probability_on_JAX.ipynb
@@ -1943,7 +1943,7 @@
     "id": "WOgYcS9zpJG3"
    },
    "source": [
-    "For more details about JAX's deterministic key splitting model, see [this guide](https://github.com/google/jax/blob/main/design_notes/prng.md)."
+    "For more details about JAX's deterministic key splitting model, see [this guide](https://github.com/google/jax/blob/main/docs/jep/263-prng.md)."
    ]
   }
  ],


### PR DESCRIPTION
Changed the broken link in line 1946 to "https://github.com/google/jax/blob/main/docs/jep/263-prng.md".