### PR TITLE
Update TensorFlow_Probability_Case_Study_Covariance_Estimation.ipynb

### DIFF
--- a/tensorflow_probability/examples/jupyter_notebooks/TensorFlow_Probability_Case_Study_Covariance_Estimation.ipynb
+++ b/tensorflow_probability/examples/jupyter_notebooks/TensorFlow_Probability_Case_Study_Covariance_Estimation.ipynb
@@ -81,7 +81,7 @@
         "\n",
         "I found TensorFlow Probability appealing for my project for a few reasons:\n",
         "\n",
-        "* TensorFlow probability lets you prototype develop complex models interactively in a notebook.  You can break your code up into small pieces that you can test interactively and with unit tests.\n",
+        "* TensorFlow probability lets you prototype and develop complex models interactively in a notebook.  You can break your code up into small pieces that you can test interactively and with unit tests.\n",
         "* Once you're ready to scale up, you can take advantage of all of the infrastructure we have in place for making TensorFlow run on multiple, optimized processors on multiple machines.\n",
         "* Finally, while I really like Stan, I find it quite difficult to debug.  You have to write all your modeling code in a standalone language that has very few tools for letting you poke at your code, inspect intermediate states, and so on.\n",
         "\n",
@@ -394,7 +394,7 @@
         "id": "ROazOrWF6E3v"
       },
       "source": [
-        "Ok, our samples look reasonble.  Next step."
+        "Ok, our samples look reasonable.  Next step."
       ]
     },
     {
@@ -627,7 +627,7 @@
         "\n",
         "TFP has a collection of distribution classes that we'll use to generate our log probabilities.  One thing to note is that these classes work with tensors of samples rather than just single samples - this allows for vectorization and related speedups.\n",
         "\n",
-        "A distribution can work with a tensor of samples in 2 different ways.  It's simplest to illustrate these 2 ways with a concrete example involving a distribution with a single scalar paramter.  I'll use the [Poisson](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Poisson) distribution, which has a `rate` parameter. \n",
+        "A distribution can work with a tensor of samples in 2 different ways.  It's simplest to illustrate these 2 ways with a concrete example involving a distribution with a single scalar parameter.  I'll use the [Poisson](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Poisson) distribution, which has a `rate` parameter. \n",
         "* If we create a Poisson with a single value for the `rate` parameter, a call to its `sample()` method return a single value.  This value is called an **`event`**, and in this case the events are all scalars.\n",
         "* If we create a Poisson with a tensor of values for the `rate` parameter, a call to its `sample()`method now returns multiple values, one for each value in the rate tensor.  The object acts as a *collection* of independent Poissons, each with its own rate, and each of the values returned by a call to `sample()` corresponds to one of these Poissons.  This collection of independent *but not identically distributed* events is called a **`batch`**.\n",
         "* The `sample()` method takes a `sample_shape` parameter which defaults to an empty tuple.  Passing a non-empty value for `sample_shape` results in sample returning multiple batches.  This collection of batches is called a **`sample`**.\n",
@@ -1154,7 +1154,7 @@
       "source": [
         "### Reparameterization with bijectors\n",
         "\n",
-        "Our precision matrix must be real and symmetric; we want an alternative parameterization that doesn't have these constraints.  A starting point is a Cholesky factorization of the precision matrix.  The Cholesky factors are still constrained - they are lower triangular, and their diagonal elements must be positive.  However, if we take the log of the diagonals of the Cholesky factor, the logs are no longer are constrained to be positive, and then if we flatten the lower triangular portion into a 1-D vector, we no longer have the lower triangular constraint.  The result in our case will be a length 3 vector with no constraints.\n",
+        "Our precision matrix must be real and symmetric; we want an alternative parameterization that doesn't have these constraints.  A starting point is a Cholesky factorization of the precision matrix.  The Cholesky factors are still constrained - they are lower triangular, and their diagonal elements must be positive.  However, if we take the log of the diagonals of the Cholesky factor, the logs are no longer constrained to be positive, and then if we flatten the lower triangular portion into a 1-D vector, we no longer have the lower triangular constraint.  The result in our case will be a length 3 vector with no constraints.\n",
         "\n",
         "(The [Stan manual](http://mc-stan.org/users/documentation/) has a great chapter on using transformations to remove various types of constraints on parameters.)\n",
         "\n",
@@ -1177,7 +1177,7 @@
         "id": "M8deaPaGI6MZ"
       },
       "source": [
-        "The [`Bijector`](https://www.tensorflow.org/api_docs/python/tf/distributions/bijectors/Bijector) class is used to represent invertible, smooth functions used for changing variables in probability density functions.  Bijectors all have a `forward()` method that performs a transform, an `inverse()` method that inverts it, and `forward_log_det_jacobian()` and `inverse_log_det_jacobian()` methods that provide the Jacobian corrections we need when we reparaterize a pdf.\n",
+        "The [`Bijector`](https://www.tensorflow.org/probability/api_docs/python/tfp/bijectors/Bijector) class is used to represent invertible, smooth functions used for changing variables in probability density functions.  Bijectors all have a `forward()` method that performs a transform, an `inverse()` method that inverts it, and `forward_log_det_jacobian()` and `inverse_log_det_jacobian()` methods that provide the Jacobian corrections we need when we reparaterize a pdf.\n",
         "\n",
         "TFP provides a collection of useful bijectors that we can combine through composition via the [`Chain`](https://www.tensorflow.org/probability/api_docs/python/tfp/bijectors/Chain) operator to form quite complicated transforms.  In our case, we'll compose the following 3 bijectors (the operations in the chain are performed from right to left):\n",
         "\n",


### PR DESCRIPTION
Fixed broken link in line 1180 and fixed spellings in lines 397, 630.