### PR TITLE
Add sdist tar creation when running setup.py

### DIFF
--- a/pip_pkg.sh
+++ b/pip_pkg.sh
@@ -45,7 +45,10 @@ echo >>tensorflow_probability/python/version.py \
 # specifies the output dir) to setup.py, e.g.,
 #  ./pip_pkg /tmp/tensorflow_probability_pkg --gpu --release
 # passes `--gpu --release` to setup.py.
-python setup.py bdist_wheel --universal ${@:2} --dist-dir="$DEST" >/dev/null
+python setup.py ${@:2} \
+  sdist --dist-dir="$DEST" \
+  bdist_wheel --universal --dist-dir="$DEST" \
+  >/dev/null
 
 set +x
 echo -e "\nBuild complete. Wheel files are in $DEST"


### PR DESCRIPTION
Besides creating a `wheel` package, we enable the creation of a `sdist` package alongside it.

This change only modifies the shell script used to automate the execution of `setup.py`, and hence introduces no changes to the Python configuration.