### PR TITLE
Add get_config and from_config methods

### DIFF
--- a/tensorflow_probability/python/layers/dense_variational_v2.py
+++ b/tensorflow_probability/python/layers/dense_variational_v2.py
@@ -104,6 +104,7 @@ class DenseVariational(tf.keras.layers.Layer):
           last_dim * self.units,
           self.units if self.use_bias else 0,
           dtype)
+
     with tf.name_scope('prior'):
       self._prior = self._make_prior_fn(
           last_dim * self.units,
@@ -157,10 +158,25 @@ class DenseVariational(tf.keras.layers.Layer):
     input_shape = input_shape.with_rank_at_least(2)
     if input_shape[-1] is None:
       raise ValueError(
-          f'The innermost dimension of input_shape must be defined, but saw: {input_shape}'
+          f'The innermost dimension of input_shape must be defined, '
+          f'but saw: {input_shape}'
       )
     return input_shape[:-1].concatenate(self.units)
 
+  def get_config(self):
+    base_config = super(DenseVariational, self).get_config()
+    config = {
+      'units': self.units,
+      'make_posterior_fn': self._make_posterior_fn,
+      'make_prior_fn': self._make_prior_fn,
+      'activation': self.activation,
+      'use_bias': self.use_bias,
+    }
+    return dict(list(base_config.items()) + list(config.items()))
+
+  @classmethod
+  def from_config(cls, config):
+    return cls(**config)
 
 def _make_kl_divergence_penalty(
     use_exact_kl=False,


### PR DESCRIPTION
Fixes the issue #1627:
`NotImplementedError: Layer DenseVariational has arguments in __init__ and therefore must override get_config`

Some unit tests are failing due to an internal issue in TF-Nightly as of 17/02/2023. Please find the [gist here](https://colab.research.google.com/gist/Frightera/215873a55536ee88f5123a068270cd23/fix-1627.ipynb) to see the fix. 

Thanks!