### PR TITLE
Fixing typo in TensorFlow_Distributions_Tutorial.ipynb

### DIFF
--- a/tensorflow_probability/examples/jupyter_notebooks/TensorFlow_Distributions_Tutorial.ipynb
+++ b/tensorflow_probability/examples/jupyter_notebooks/TensorFlow_Distributions_Tutorial.ipynb
@@ -1096,7 +1096,7 @@
         "id": "INu1viAVXz93"
       },
       "source": [
-        "## Batches of Multivariate Distirbutions"
+        "## Batches of Multivariate Distributions"
       ]
     },
     {


### PR DESCRIPTION
Fixes a small typo in a section heading in the Jupyter notebook of the distribution tutorial.