### PR TITLE
Fix layer.add_variable being deprecated

### DIFF
--- a/tensorflow_probability/python/layers/conv_variational.py
+++ b/tensorflow_probability/python/layers/conv_variational.py
@@ -185,28 +185,28 @@ class _ConvVariational(tf.keras.layers.Layer):
     # Must have a posterior kernel.
     self.kernel_posterior = self.kernel_posterior_fn(
         dtype, kernel_shape, 'kernel_posterior',
-        self.trainable, self.add_variable)
+        self.trainable, self.add_weight)
 
     if self.kernel_prior_fn is None:
       self.kernel_prior = None
     else:
       self.kernel_prior = self.kernel_prior_fn(
           dtype, kernel_shape, 'kernel_prior',
-          self.trainable, self.add_variable)
+          self.trainable, self.add_weight)
 
     if self.bias_posterior_fn is None:
       self.bias_posterior = None
     else:
       self.bias_posterior = self.bias_posterior_fn(
           dtype, (self.filters,), 'bias_posterior',
-          self.trainable, self.add_variable)
+          self.trainable, self.add_weight)
 
     if self.bias_prior_fn is None:
       self.bias_prior = None
     else:
       self.bias_prior = self.bias_prior_fn(
           dtype, (self.filters,), 'bias_prior',
-          self.trainable, self.add_variable)
+          self.trainable, self.add_weight)
 
     self.input_spec = tf.keras.layers.InputSpec(
         ndim=self.rank + 2, axes={channel_axis: input_dim})

--- a/tensorflow_probability/python/layers/dense_variational.py
+++ b/tensorflow_probability/python/layers/dense_variational.py
@@ -140,28 +140,28 @@ class _DenseVariational(tf.keras.layers.Layer):
     # Must have a posterior kernel.
     self.kernel_posterior = self.kernel_posterior_fn(
         dtype, [in_size, self.units], 'kernel_posterior',
-        self.trainable, self.add_variable)
+        self.trainable, self.add_weight)
 
     if self.kernel_prior_fn is None:
       self.kernel_prior = None
     else:
       self.kernel_prior = self.kernel_prior_fn(
           dtype, [in_size, self.units], 'kernel_prior',
-          self.trainable, self.add_variable)
+          self.trainable, self.add_weight)
 
     if self.bias_posterior_fn is None:
       self.bias_posterior = None
     else:
       self.bias_posterior = self.bias_posterior_fn(
           dtype, [self.units], 'bias_posterior',
-          self.trainable, self.add_variable)
+          self.trainable, self.add_weight)
 
     if self.bias_prior_fn is None:
       self.bias_prior = None
     else:
       self.bias_prior = self.bias_prior_fn(
           dtype, [self.units], 'bias_prior',
-          self.trainable, self.add_variable)
+          self.trainable, self.add_weight)
 
     self.built = True
 


### PR DESCRIPTION
This PR fixes a few warnings when using layers from `conv_variational.py` and `dense_variational.py`.
This PR is also related to #623, but the warnings mentioned there differ a bit from the ones fixed by this PR.

Fixes #1702