### PR TITLE
(backport) Add requires-python metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     url='http://github.com/tensorflow/probability',
     license='Apache 2.0',
     packages=find_packages(),
+    python_requires = ">=3.8",
     install_requires=REQUIRED_PACKAGES,
     # Add in any packaged data.
     include_package_data=True,


### PR DESCRIPTION
Backport of PR #1724 needed for Issue #1723.

* Add requires-python metadata through the addition of setuptools's python_requires in setup.py.
   - c.f. https://peps.python.org/pep-0621/#requires-python

* The addition of requires-python is to provide guards to keep older CPython versions from installing releases that could contain unrunnable code.