### PR TITLE
Correct a misleading comment in linear_gaussian_ssm.py

### DIFF
--- a/tensorflow_probability/python/distributions/linear_gaussian_ssm.py
+++ b/tensorflow_probability/python/distributions/linear_gaussian_ssm.py
@@ -1831,7 +1831,7 @@ def linear_gaussian_update(
   #  P* = P - K * H * P
   # but this is prone to numerical issues because it subtracts a
   # value from a PSD matrix.  We choose instead to use the more
-  # expensive Jordan form update
+  # expensive Joseph form update
   #  P* = (I - K H) * P * (I - K H)' + K R K'
   # which always produces a PSD result. This uses
   #  tmp_term = (I - K * H)'


### PR DESCRIPTION
The equation in updating the posterior variance is called "Joseph form" instead of "Jordan form". Jordan form has nothing to do with this equation, reading the comment causes quite a bit of confusion.