### PR TITLE
Recommend 'tensorflow-probability[tf]' extra on tf-keras import failure

### DIFF
--- a/tensorflow_probability/python/__init__.py
+++ b/tensorflow_probability/python/__init__.py
@@ -83,7 +83,9 @@ def _validate_tf_environment(package):
             'installed by default when you install TensorFlow Probability. '
             'This is so that JAX-only users do not have to install TensorFlow '
             'or TF-Keras. To use TensorFlow Probability with TensorFlow, '
-            'please install the tf-keras or tf-keras-nightly package.\n\n')
+            'please install the tf-keras or tf-keras-nightly package.\n'
+            'This can be be done through installing the '
+            'tensorflow-probability[tf] extra.\n\n')
       raise
 
 


### PR DESCRIPTION
* In addition to recommending users install TensorFlow dependencies piecemeal, also recommend using the 'tf' extra to install all required dependencies to use tensorflow-probability with tensorflow.
* Split this off from the rest of the error message as it is already too long.

As this amends https://github.com/tensorflow/probability/commit/988f02323f16419086d761cc6cdd50b94aa03257 tagging @jburnim for review.