### PR TITLE
Field name checks for StructTuple

### DIFF
--- a/tensorflow_probability/python/internal/structural_tuple.py
+++ b/tensorflow_probability/python/internal/structural_tuple.py
@@ -51,6 +51,9 @@ def _validate_field_names(field_names):
     if name.startswith('_'):
       raise ValueError(
           'Field names cannot start with an underscore: {}'.format(name))
+    if name in dir(tuple):
+      raise ValueError(
+          'Field name {} is already a member of StructTuple'.format(name))
     if name in seen:
       raise ValueError('Encountered duplicate field name: {}'.format(name))
     seen.add(name)


### PR DESCRIPTION
This PR introduces a new check for field names in a StructTuple, preventing any that over-ride existing members of the tuple base class.  It is intended to trap a gotcha in JointDistributionCoroutine if a user names a variable "index" or "count".