### PR TITLE
Add SkewGeneralizedNormal distribution (generalized normal v2)

### DIFF
--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -2110,6 +2110,29 @@ multi_substrate_py_library(
 )
 
 multi_substrate_py_library(
+    name = "skew_generalized_normal",
+    srcs = ["skew_generalized_normal.py"],
+    deps = [
+        ":distribution",
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/bijectors:chain",
+        "//tensorflow_probability/python/bijectors:exp",
+        "//tensorflow_probability/python/bijectors:scale",
+        "//tensorflow_probability/python/bijectors:shift",
+        "//tensorflow_probability/python/bijectors:softplus",
+        "//tensorflow_probability/python/internal:assert_util",
+        "//tensorflow_probability/python/internal:dtype_util",
+        "//tensorflow_probability/python/internal:parameter_properties",
+        "//tensorflow_probability/python/internal:prefer_static",
+        "//tensorflow_probability/python/internal:reparameterization",
+        "//tensorflow_probability/python/internal:samplers",
+        "//tensorflow_probability/python/internal:special_math",
+        "//tensorflow_probability/python/internal:tensor_util",
+    ],
+)
+
+multi_substrate_py_library(
     name = "stopping_ratio_logistic",
     srcs = ["stopping_ratio_logistic.py"],
     deps = [
@@ -4455,6 +4478,21 @@ multi_substrate_py_test(
         "//tensorflow_probability/python/internal:test_util",
         "//tensorflow_probability/python/math:gradient",
         # tensorflow/compiler/jit dep,
+    ],
+)
+
+multi_substrate_py_test(
+    name = "skew_generalized_normal_test",
+    size = "medium",
+    srcs = ["skew_generalized_normal_test.py"],
+    shard_count = 3,
+    deps = [
+        ":skew_generalized_normal",
+        # numpy dep,
+        # scipy dep,
+        # tensorflow dep,
+        "//tensorflow_probability/python/internal:test_util",
+        "//tensorflow_probability/python/math:gradient",
     ],
 )
 

--- a/tensorflow_probability/python/distributions/__init__.py
+++ b/tensorflow_probability/python/distributions/__init__.py
@@ -122,6 +122,7 @@ from tensorflow_probability.python.distributions.sample import Sample
 from tensorflow_probability.python.distributions.sigmoid_beta import SigmoidBeta
 from tensorflow_probability.python.distributions.sinh_arcsinh import SinhArcsinh
 from tensorflow_probability.python.distributions.skellam import Skellam
+from tensorflow_probability.python.distributions.skew_generalized_normal import SkewGeneralizedNormal
 from tensorflow_probability.python.distributions.spherical_uniform import SphericalUniform
 from tensorflow_probability.python.distributions.stopping_ratio_logistic import StoppingRatioLogistic
 from tensorflow_probability.python.distributions.student_t import StudentT
@@ -282,6 +283,7 @@ __all__ = [
     'SigmoidBeta',
     'SinhArcsinh',
     'Skellam',
+    'SkewGeneralizedNormal',
     'SphericalUniform',
     'StoppingRatioLogistic',
     'StudentT',

--- a/tensorflow_probability/python/distributions/hypothesis_testlib.py
+++ b/tensorflow_probability/python/distributions/hypothesis_testlib.py
@@ -317,6 +317,7 @@ CONSTRAINTS = {
     'Zipf': lambda d: dict(d, dtype=tf.float32),
     'FiniteDiscrete': fix_finite_discrete,
     'GeneralizedNormal.power': tfp_hps.softplus_plus_eps(),
+    'SkewGeneralizedNormal.peak': tfp_hps.softplus_plus_eps(1e-1),
     'TwoPieceNormal.skewness': tfp_hps.softplus_plus_eps(),
     'TwoPieceStudentT.skewness': tfp_hps.softplus_plus_eps(),
     'NoncentralChi2.noncentrality': tf.math.softplus,

--- a/tensorflow_probability/python/distributions/skew_generalized_normal.py
+++ b/tensorflow_probability/python/distributions/skew_generalized_normal.py
@@ -1,0 +1,348 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""The Skew Generalized Normal (Generalized Normal v2) distribution class."""
+
+import functools
+
+# Dependency imports
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python.bijectors import chain as chain_bijector
+from tensorflow_probability.python.bijectors import exp as exp_bijector
+from tensorflow_probability.python.bijectors import scale as scale_bijector
+from tensorflow_probability.python.bijectors import shift as shift_bijector
+from tensorflow_probability.python.bijectors import softplus as softplus_bijector
+from tensorflow_probability.python.distributions import distribution
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import parameter_properties
+from tensorflow_probability.python.internal import prefer_static as ps
+from tensorflow_probability.python.internal import reparameterization
+from tensorflow_probability.python.internal import samplers
+from tensorflow_probability.python.internal import special_math
+from tensorflow_probability.python.internal import tensor_util
+
+
+__all__ = [
+    'SkewGeneralizedNormal',
+]
+
+
+class SkewGeneralizedNormal(distribution.AutoCompositeTensorDistribution):
+  """The Skew Generalized Normal distribution.
+
+  This is the "generalized normal version 2" (the skew variant) described in
+  https://en.wikipedia.org/wiki/Generalized_normal_distribution. It is
+  parameterized by location `loc` (xi), scale `scale` (alpha > 0) and shape
+  `peak` (kappa, any nonzero real). It is constructed as a monotone transform of
+  a standard normal: if `Z ~ Normal(0, 1)` then
+
+  ```none
+  X = loc + (scale / peak) * (1 - exp(-peak * Z))
+  ```
+
+  is `SkewGeneralizedNormal(loc, scale, peak)` distributed.
+
+  #### Mathematical details
+
+  Define the standardizing transform
+
+  ```none
+  y(x) = (-1 / peak) * log(1 - peak * (x - loc) / scale).
+  ```
+
+  Then the probability density function (pdf), cumulative distribution function
+  (cdf) and quantile are
+
+  ```none
+  pdf(x; loc, scale, peak) = phi(y(x)) / (scale - peak * (x - loc))
+  cdf(x; loc, scale, peak) = Phi(y(x))
+  quantile(p; loc, scale, peak) = (
+      loc + scale * (1 - exp(-peak * Phi^{-1}(p))) / peak)
+  ```
+
+  where `phi` and `Phi` are the standard normal pdf and cdf.
+
+  #### Support and the mode
+
+  Unlike most location-scale families, the support is a parameter-dependent
+  half-line: `peak > 0` gives `x < loc + scale / peak` (bounded above,
+  left-skewed) and `peak < 0` gives `x > loc + scale / peak` (bounded below,
+  right-skewed). The distinguishing feature of this distribution is that the
+  mode sits at or near the support boundary `x_edge = loc + scale / peak`:
+
+  ```none
+  x_edge - mode = (scale / peak) * exp(-peak**2),
+  ```
+
+  so the gap between the mode and the boundary vanishes like `exp(-peak**2)` as
+  `|peak|` grows. Equivalently, `peak` is exactly the value of the standardized
+  coordinate `y` at the mode (`y(mode) = peak`), which is why it is named
+  `peak`. As `peak -> 0` the distribution converges to `Normal(loc, scale)`.
+
+  Outside the support, `log_prob`/`cdf` return `NaN`/`-inf` while `prob` returns
+  `0`.
+
+  #### Examples
+
+  ```python
+  import tensorflow_probability as tfp
+  tfd = tfp.distributions
+
+  dist = tfd.SkewGeneralizedNormal(loc=3.0, scale=2.0, peak=1.0)
+  dist2 = tfd.SkewGeneralizedNormal(
+      loc=0, scale=[3.0, 4.0], peak=[[2.0], [-3.0]])
+  ```
+  """
+
+  def __init__(self,
+               loc,
+               scale,
+               peak,
+               validate_args=False,
+               allow_nan_stats=True,
+               name='SkewGeneralizedNormal'):
+    """Construct Skew Generalized Normal distributions.
+
+    The parameters `loc`, `scale` and `peak` must be shaped in a way that
+    supports broadcasting (e.g. `loc + scale + peak` is a valid operation).
+
+    Args:
+      loc: Floating point tensor; the location(s) of the distribution(s).
+      scale: Floating point tensor; the scale(s) of the distribution(s). Must
+        contain only positive values.
+      peak: Floating point tensor; the shape parameter(s) of the
+        distribution(s). Must contain only nonzero values. `loc`, `scale` and
+        `peak` must have compatible shapes for broadcasting.
+      validate_args: Python `bool`, default `False`. When `True` distribution
+        parameters are checked for validity despite possibly degrading runtime
+        performance. When `False` invalid inputs may silently render incorrect
+        outputs.
+      allow_nan_stats: Python `bool`, default `True`. When `True`, statistics
+        (e.g., mean, mode, variance) use the value "`NaN`" to indicate the
+        result is undefined. When `False`, an exception is raised if one or more
+        of the statistic's batch members are undefined.
+      name: Python `str` name prefixed to Ops created by this class.
+
+    Raises:
+      TypeError: if `loc`, `scale`, and `peak` have different `dtype`.
+    """
+    parameters = dict(locals())
+    with tf.name_scope(name) as name:
+      dtype = dtype_util.common_dtype([loc, scale, peak],
+                                      dtype_hint=tf.float32)
+      self._loc = tensor_util.convert_nonref_to_tensor(
+          loc, dtype=dtype, name='loc')
+      self._scale = tensor_util.convert_nonref_to_tensor(
+          scale, dtype=dtype, name='scale')
+      self._peak = tensor_util.convert_nonref_to_tensor(
+          peak, dtype=dtype, name='peak')
+      super(SkewGeneralizedNormal, self).__init__(
+          dtype=dtype,
+          reparameterization_type=reparameterization.FULLY_REPARAMETERIZED,
+          validate_args=validate_args,
+          allow_nan_stats=allow_nan_stats,
+          parameters=parameters,
+          name=name)
+
+  @classmethod
+  def _parameter_properties(cls, dtype, num_classes=None):
+    # pylint: disable=g-long-lambda
+    return dict(
+        loc=parameter_properties.ParameterProperties(),
+        scale=parameter_properties.ParameterProperties(
+            default_constraining_bijector_fn=(
+                lambda: softplus_bijector.Softplus(low=dtype_util.eps(dtype)))),
+        peak=parameter_properties.ParameterProperties())
+    # pylint: enable=g-long-lambda
+
+  @property
+  def loc(self):
+    """Distribution parameter for the location."""
+    return self._loc
+
+  @property
+  def scale(self):
+    """Distribution parameter for scale."""
+    return self._scale
+
+  @property
+  def peak(self):
+    """Distribution parameter related to mode and skew."""
+    return self._peak
+
+  def _batch_shape_tensor(self, loc=None, scale=None, peak=None):
+    return functools.reduce(ps.broadcast_shape, (
+        ps.shape(self.loc if loc is None else loc),
+        ps.shape(self.scale if scale is None else scale),
+        ps.shape(self.peak if peak is None else peak)))
+
+  def _batch_shape(self):
+    return functools.reduce(tf.broadcast_static_shape, (
+        self.loc.shape, self.scale.shape, self.peak.shape))
+
+  def _event_shape_tensor(self):
+    return tf.constant([], dtype=tf.int32)
+
+  def _event_shape(self):
+    return tf.TensorShape([])
+
+  def _y(self, x, loc=None, scale=None, peak=None):
+    """Standardizes `x` to a unit normal variate `y`."""
+    loc = tf.convert_to_tensor(self.loc) if loc is None else loc
+    scale = tf.convert_to_tensor(self.scale) if scale is None else scale
+    peak = tf.convert_to_tensor(self.peak) if peak is None else peak
+    # y = (-1 / peak) * log(1 - peak * (x - loc) / scale).
+    return -tf.math.log1p(-peak * (x - loc) / scale) / peak
+
+  def _log_prob(self, x):
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    y = self._y(x, loc=loc, scale=scale, peak=peak)
+    log_normalization = tf.constant(
+        0.5 * np.log(2. * np.pi), dtype=self.dtype)
+    # log f(x) = log phi(y) - log(scale - peak * (x - loc)), where the second
+    # term is -log|dy/dx| (the change-of-variables Jacobian).
+    return (-0.5 * tf.square(y) - log_normalization
+            - tf.math.log(scale - peak * (x - loc)))
+
+  def _prob(self, x):
+    prob = tf.exp(self._log_prob(x))
+    # Outside the support `log_prob` is `NaN`; the density there is zero.
+    return tf.where(tf.math.is_nan(prob), tf.zeros_like(prob), prob)
+
+  def _log_cdf(self, x):
+    return special_math.log_ndtr(self._y(x))
+
+  def _cdf(self, x):
+    return special_math.ndtr(self._y(x))
+
+  def _log_survival_function(self, x):
+    return special_math.log_ndtr(-self._y(x))
+
+  def _survival_function(self, x):
+    return special_math.ndtr(-self._y(x))
+
+  def _quantile(self, p):
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    return loc + scale * (1. - tf.exp(-peak * tf.math.ndtri(p))) / peak
+
+  def _sample_n(self, n, seed=None):
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    shape = ps.concat(
+        [[n], self._batch_shape_tensor(loc=loc, scale=scale, peak=peak)],
+        axis=0)
+    probs = samplers.uniform(
+        shape, minval=0., maxval=1., dtype=self.dtype, seed=seed)
+    return loc + scale * (1. - tf.exp(-peak * tf.math.ndtri(probs))) / peak
+
+  def _mean(self):
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    mean = loc - scale * tf.math.expm1(0.5 * tf.square(peak)) / peak
+    return tf.broadcast_to(
+        mean, self._batch_shape_tensor(loc=loc, scale=scale, peak=peak))
+
+  def _stddev(self):
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    # stddev = (scale / |peak|) * exp(peak**2 / 2) * sqrt(exp(peak**2) - 1).
+    stddev = (scale / tf.abs(peak)) * tf.exp(0.5 * tf.square(peak)) * tf.sqrt(
+        tf.math.expm1(tf.square(peak)))
+    return tf.broadcast_to(
+        stddev, self._batch_shape_tensor(scale=scale, peak=peak))
+
+  def _variance(self):
+    return tf.square(self._stddev())
+
+  def _mode(self):
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    mode = loc - scale * tf.math.expm1(-tf.square(peak)) / peak
+    return tf.broadcast_to(
+        mode, self._batch_shape_tensor(loc=loc, scale=scale, peak=peak))
+
+  def _entropy(self):
+    scale = tf.convert_to_tensor(self.scale)
+    # H = H(Normal) + E[log|dx/dy|] = 0.5 * (1 + log(2*pi)) + log(scale).
+    entropy = tf.math.log(scale) + tf.constant(
+        0.5 * (1. + np.log(2. * np.pi)), dtype=self.dtype)
+    return tf.broadcast_to(entropy, self._batch_shape_tensor(scale=scale))
+
+  def _default_event_space_bijector(self):
+    # The inverse of the `y` transform,
+    # `x = loc + (scale / peak) * (1 - exp(-peak * y))`, is a monotone bijection
+    # from R onto the support for either sign of `peak` (the sign is carried by
+    # the `Scale` factors). Realized as the composition
+    # `Shift(edge) o Scale(-scale/peak) o Exp o Scale(-peak)`.
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    edge = loc + scale / peak
+    return chain_bijector.Chain([
+        shift_bijector.Shift(shift=edge, validate_args=self.validate_args),
+        scale_bijector.Scale(
+            scale=-scale / peak, validate_args=self.validate_args),
+        exp_bijector.Exp(validate_args=self.validate_args),
+        scale_bijector.Scale(scale=-peak, validate_args=self.validate_args),
+    ], validate_args=self.validate_args)
+
+  def _parameter_control_dependencies(self, is_init):
+    assertions = []
+    if is_init:
+      # _batch_shape() will raise error if it can statically prove that `loc`,
+      # `scale` and `peak` have incompatible shapes.
+      try:
+        self._batch_shape()
+      except ValueError as e:
+        raise ValueError(
+            'Arguments `loc`, `scale` and `peak` must have compatible shapes; '
+            'loc.shape={}, scale.shape={}, peak.shape={}.'.format(
+                self.loc.shape, self.scale.shape, self.peak.shape)) from e
+
+    if not self.validate_args:
+      assert not assertions  # Should never happen.
+      return []
+
+    if is_init != tensor_util.is_ref(self.scale):
+      assertions.append(assert_util.assert_positive(
+          self.scale, message='Argument `scale` must be positive.'))
+    if is_init != tensor_util.is_ref(self.peak):
+      assertions.append(assert_util.assert_none_equal(
+          self.peak,
+          tf.zeros([], dtype=self.dtype),
+          message='Argument `peak` must be nonzero.'))
+
+    return assertions
+
+  def _sample_control_dependencies(self, x):
+    assertions = []
+    if not self.validate_args:
+      return assertions
+    loc = tf.convert_to_tensor(self.loc)
+    scale = tf.convert_to_tensor(self.scale)
+    peak = tf.convert_to_tensor(self.peak)
+    assertions.append(assert_util.assert_less(
+        peak * (x - loc), scale,
+        message='Sample must be in the support: `peak * (x - loc) < scale`.'))
+    return assertions

--- a/tensorflow_probability/python/distributions/skew_generalized_normal_test.py
+++ b/tensorflow_probability/python/distributions/skew_generalized_normal_test.py
@@ -1,0 +1,429 @@
+# Copyright 2020 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import math
+
+# Dependency imports
+
+import numpy as np
+from scipy import stats as sp_stats
+import tensorflow.compat.v2 as tf
+from tensorflow_probability.python.distributions import skew_generalized_normal
+from tensorflow_probability.python.internal import test_util
+from tensorflow_probability.python.math import gradient
+
+from tensorflow.python.framework import test_util as tf_test_util  # pylint: disable=g-direct-tensorflow-import
+
+
+# Short alias for the distribution under test.
+SGN = skew_generalized_normal.SkewGeneralizedNormal
+
+
+# NumPy reference implementations of the skew generalized normal (generalized
+# normal v2). No reference distribution exists in scipy (`scipy.stats.gennorm`
+# is the *symmetric* v1), so we validate directly against the closed-form
+# formulas, against `Normal(loc, scale)` in the `peak -> 0` limit, and against
+# numerical moments.
+def _np_y(x, loc, scale, peak):
+  return -np.log1p(-peak * (x - loc) / scale) / peak
+
+
+def _np_log_prob(x, loc, scale, peak):
+  y = _np_y(x, loc, scale, peak)
+  return (-0.5 * y**2 - 0.5 * np.log(2. * np.pi)
+          - np.log(scale - peak * (x - loc)))
+
+
+def _np_mean(loc, scale, peak):
+  return loc - scale * np.expm1(0.5 * peak**2) / peak
+
+
+def _np_stddev(scale, peak):
+  return (scale / np.abs(peak)) * np.exp(0.5 * peak**2) * np.sqrt(
+      np.expm1(peak**2))
+
+
+def _np_mode(loc, scale, peak):
+  return loc - scale * np.expm1(-peak**2) / peak
+
+
+def _np_entropy(scale):
+  return np.log(scale) + 0.5 * (1. + np.log(2. * np.pi))
+
+
+@test_util.test_all_tf_execution_regimes
+class _SkewGeneralizedNormalTest(object):
+
+  def testSampleLikeArgsGetDistDType(self):
+    if self.dtype is np.float32:
+      # Raw Python literals should always be interpreted as fp32.
+      dist = SGN(0., 1., 2.)
+    else:
+      dist = SGN(self.make_input(0.), self.make_input(1.), self.make_input(2.))
+    self.assertEqual(self.dtype, dist.dtype)
+    for method in ('log_prob', 'prob', 'log_cdf', 'cdf'):
+      self.assertEqual(self.dtype, getattr(dist, method)(1).dtype)
+    for method in ('entropy', 'mean', 'variance'):
+      self.assertEqual(self.dtype, getattr(dist, method)().dtype)
+
+  def testSkewGeneralizedNormalLogPDF(self):
+    batch_size = 6
+    mu = tf.constant([3.] * batch_size, dtype=self.dtype)
+    sigma = tf.constant([math.sqrt(10.)] * batch_size, dtype=self.dtype)
+    peak = tf.constant([1.] * batch_size, dtype=self.dtype)
+    # All points lie inside the support `x < loc + scale / peak ~= 6.16`.
+    x = np.array([-2.5, 2.5, 4., 0., -1., 2.], dtype=self.dtype)
+    sgn = SGN(loc=mu, scale=sigma, peak=peak, validate_args=True)
+    log_pdf = sgn.log_prob(x)
+    self.assertAllEqual(
+        self.evaluate(sgn.batch_shape_tensor()), log_pdf.shape)
+    self.assertAllEqual(
+        self.evaluate(sgn.batch_shape_tensor()),
+        self.evaluate(log_pdf).shape)
+    self.assertAllEqual(sgn.batch_shape, log_pdf.shape)
+    self.assertAllEqual(sgn.batch_shape, self.evaluate(log_pdf).shape)
+
+    pdf = sgn.prob(x)
+    self.assertAllEqual(sgn.batch_shape, pdf.shape)
+
+    expected_log_pdf = _np_log_prob(x, 3., math.sqrt(10.), 1.)
+    self.assertAllClose(expected_log_pdf, self.evaluate(log_pdf))
+    self.assertAllClose(np.exp(expected_log_pdf), self.evaluate(pdf))
+
+  def testSkewGeneralizedNormalProbIsZeroOutsideSupport(self):
+    # peak > 0 => support is x < loc + scale / peak = 2.0.
+    sgn = SGN(loc=tf.constant(0., self.dtype),
+              scale=tf.constant(2., self.dtype),
+              peak=tf.constant(1., self.dtype),
+              validate_args=False)
+    x = np.array([5., 10., 100.], dtype=self.dtype)  # all > edge (2.0)
+    self.assertAllEqual(np.zeros([3]), self.evaluate(sgn.prob(x)))
+
+  def testSkewGeneralizedNormalCDF(self):
+    batch_size = 50
+    mu = self._rng.randn(batch_size)
+    sigma = self._rng.rand(batch_size) + 1.
+    peak = self._rng.rand(batch_size) + 0.5
+    # Generate in-support points by pushing a standard-normal grid through the
+    # quantile transform: x = loc + scale * (1 - exp(-peak * z)) / peak.
+    z = np.linspace(-3., 3., batch_size)
+    x = (mu + sigma * (1. - np.exp(-peak * z)) / peak).astype(np.float64)
+
+    sgn = SGN(loc=self.make_input(mu),
+              scale=self.make_input(sigma),
+              peak=self.make_input(peak),
+              validate_args=True)
+    cdf = sgn.cdf(x)
+    self.assertAllEqual(sgn.batch_shape, cdf.shape)
+    expected_cdf = sp_stats.norm.cdf(_np_y(x, mu, sigma, peak))
+    self.assertAllClose(expected_cdf, self.evaluate(cdf), atol=0, rtol=1e-5)
+
+  def testSkewGeneralizedNormalLogCDF(self):
+    if self.dtype is np.float32:
+      self.skipTest('32-bit precision not sufficient for LogCDF')
+    batch_size = 50
+    mu = self._rng.randn(batch_size)
+    sigma = self._rng.rand(batch_size) + 1.
+    peak = self._rng.rand(batch_size) + 0.5
+    z = np.linspace(-10., 3., batch_size)
+    x = (mu + sigma * (1. - np.exp(-peak * z)) / peak).astype(np.float64)
+
+    sgn = SGN(loc=self.make_input(mu),
+              scale=self.make_input(sigma),
+              peak=self.make_input(peak),
+              validate_args=True)
+    log_cdf = sgn.log_cdf(x)
+    self.assertAllEqual(sgn.batch_shape, log_cdf.shape)
+    expected_log_cdf = sp_stats.norm.logcdf(_np_y(x, mu, sigma, peak))
+    self.assertAllClose(expected_log_cdf, self.evaluate(log_cdf),
+                        atol=0, rtol=1e-3)
+
+  @test_util.numpy_disable_gradient_test
+  def testFiniteGradientAtDifficultPoints(self):
+    def make_fn(dtype, attr):
+      # peak = 2.1 => support is x < loc + scale / peak ~= 0.476. Probe the
+      # long negative tail and points right up against the boundary.
+      x = np.array([-100., -20., -5., 0., 0.4, 0.47]).astype(dtype)
+      return lambda m, s, p: getattr(  # pylint: disable=g-long-lambda
+          SGN(loc=m, scale=s, peak=p, validate_args=True), attr)(x)
+
+    for attr in ['log_prob', 'prob', 'cdf']:
+      value, grads = self.evaluate(gradient.value_and_gradient(
+          make_fn(self.dtype, attr),
+          [tf.constant(0, self.dtype),  # loc
+           tf.constant(1, self.dtype),  # scale
+           tf.constant(2.1, self.dtype)]))  # peak
+      self.assertAllFinite(value)
+      self.assertAllFinite(grads[0])  # d/d loc
+      self.assertAllFinite(grads[1])  # d/d scale
+      self.assertAllFinite(grads[2])  # d/d peak
+
+  def testSkewGeneralizedNormalEntropyWithScalarInputs(self):
+    loc_v = 2.34
+    scale_v = 4.56
+    peak_v = 7.89
+
+    sgn = SGN(loc=self.make_input(loc_v),
+              scale=self.make_input(scale_v),
+              peak=self.make_input(peak_v),
+              validate_args=True)
+    entropy = sgn.entropy()
+    self.assertAllEqual(sgn.batch_shape, entropy.shape)
+    # Entropy depends only on `scale`.
+    self.assertAllClose(_np_entropy(scale_v), self.evaluate(entropy))
+
+  def testSkewGeneralizedNormalEntropy(self):
+    loc_v = np.array([1., 1., 1.])
+    scale_v = np.array([[1., 2., 3.]]).T
+    peak_v = np.array([2.])
+    sgn = SGN(loc=self.make_input(loc_v),
+              scale=self.make_input(scale_v),
+              peak=self.make_input(peak_v),
+              validate_args=True)
+    expected_entropy = _np_entropy(scale_v) * np.ones_like(loc_v)
+    entropy = sgn.entropy()
+    self.assertAllClose(expected_entropy, self.evaluate(entropy))
+    self.assertAllEqual(sgn.batch_shape, entropy.shape)
+
+  def testSkewGeneralizedNormalMeanAndMode(self):
+    loc = np.array([7.], dtype=np.float64)
+    scale = np.array([11., 12., 13.], dtype=np.float64)
+    peak = np.array([[1.], [2.], [3.]], dtype=np.float64)
+
+    sgn = SGN(loc=self.make_input(loc),
+              scale=self.make_input(scale),
+              peak=self.make_input(peak),
+              validate_args=True)
+
+    self.assertAllEqual((3, 3), sgn.mean().shape)
+    self.assertAllClose(_np_mean(loc, scale, peak), self.evaluate(sgn.mean()))
+
+    self.assertAllEqual((3, 3), sgn.mode().shape)
+    self.assertAllClose(_np_mode(loc, scale, peak), self.evaluate(sgn.mode()))
+
+  def testSkewGeneralizedNormalVariance(self):
+    loc = np.array([[1., 2., 3.]]).T
+    scale = np.array([7.], dtype=np.float64)
+    peak = np.array([.5, 1., 3.], dtype=np.float64)
+
+    sgn = SGN(loc=self.make_input(loc),
+              scale=self.make_input(scale),
+              peak=self.make_input(peak),
+              validate_args=True)
+
+    self.assertAllEqual((3, 3), sgn.variance().shape)
+    reference = (_np_stddev(scale, peak)**2) * np.ones_like(loc)
+    self.assertAllClose(reference, self.evaluate(sgn.variance()),
+                        atol=0, rtol=1e-5)
+
+  def testSkewGeneralizedNormalStandardDeviation(self):
+    loc = np.array([1., 2., 3.], dtype=np.float64)
+    scale = np.array([7.], dtype=np.float64)
+    peak = np.array([1.5], dtype=np.float64)
+
+    sgn = SGN(loc=self.make_input(loc),
+              scale=self.make_input(scale),
+              peak=self.make_input(peak),
+              validate_args=True)
+
+    self.assertAllEqual((3,), sgn.stddev().shape)
+    reference = _np_stddev(scale, peak) * np.ones_like(loc)
+    self.assertAllClose(reference, self.evaluate(sgn.stddev()))
+
+  def testSkewGeneralizedNormalSample(self):
+    loc = tf.constant(3., self.dtype)
+    scale = tf.constant(math.sqrt(3.), self.dtype)
+    peak = tf.constant(0.5, self.dtype)  # mild skew, light tails for MC checks.
+    expected_mean = _np_mean(3., math.sqrt(3.), 0.5)
+    expected_std = _np_stddev(math.sqrt(3.), 0.5)
+    n = tf.constant(100000)
+    sgn = SGN(loc=loc, scale=scale, peak=peak, validate_args=True)
+    samples = sgn.sample(n, seed=test_util.test_seed())
+    sample_values = self.evaluate(samples)
+    self.assertEqual(sample_values.shape, (100000,))
+    self.assertAllClose(sample_values.mean(), expected_mean, atol=1e-1)
+    self.assertAllClose(sample_values.std(), expected_std, atol=2e-1)
+
+    expected_samples_shape = tf.TensorShape(
+        [self.evaluate(n)]).concatenate(
+            tf.TensorShape(
+                self.evaluate(sgn.batch_shape_tensor())))
+    self.assertAllEqual(expected_samples_shape, samples.shape)
+    self.assertAllEqual(expected_samples_shape, sample_values.shape)
+
+  @test_util.numpy_disable_gradient_test
+  def testSkewGeneralizedNormalFullyReparameterized(self):
+    loc = tf.constant(4., self.dtype)
+    scale = tf.constant(3., self.dtype)
+    peak = tf.constant(1.5, self.dtype)
+
+    def sample_fn(m, s, p):
+      sgn = SGN(loc=m, scale=s, peak=p, validate_args=True)
+      return sgn.sample(100, seed=test_util.test_seed())
+
+    _, [grad_loc, grad_scale, grad_peak] = gradient.value_and_gradient(
+        sample_fn, [loc, scale, peak])
+    grad_loc, grad_scale, grad_peak = self.evaluate([grad_loc, grad_scale,
+                                                     grad_peak])
+    self.assertIsNotNone(grad_loc)
+    self.assertIsNotNone(grad_scale)
+    self.assertIsNotNone(grad_peak)
+
+  def testNegativePeakIsValid(self):
+    # peak < 0 mirrors the distribution: support is x > loc + scale / peak,
+    # i.e. x > -0.5 for the parameters below.
+    loc, scale, peak = 0., 1., -2.
+    sgn = SGN(loc=tf.constant(loc, self.dtype),
+              scale=tf.constant(scale, self.dtype),
+              peak=tf.constant(peak, self.dtype),
+              validate_args=True)
+    # In-support points (x > -0.5).
+    x_in = np.array([-0.4, 0., 1., 5.], dtype=self.dtype)
+    log_prob = self.evaluate(sgn.log_prob(x_in))
+    self.assertAllFinite(log_prob)
+    self.assertAllClose(_np_log_prob(x_in, loc, scale, peak), log_prob)
+    # Out-of-support points (x < -0.5) => prob 0.
+    x_out = np.array([-1., -5., -100.], dtype=self.dtype)
+    self.assertAllEqual(np.zeros([3]), self.evaluate(sgn.prob(x_out)))
+    # CDF is monotone increasing over the support.
+    x_sorted = np.array([-0.49, -0.2, 0.5, 2., 20.], dtype=self.dtype)
+    cdf = self.evaluate(sgn.cdf(x_sorted))
+    self.assertAllEqual(np.ones([4], dtype=bool), np.diff(cdf) >= 0.)
+
+  def testNegativeScaleFails(self):
+    with self.assertRaisesOpError('Argument `scale` must be positive.'):
+      sgn = SGN(loc=[1.], scale=[-5.], peak=[1.],
+                validate_args=True, name='G')
+      self.evaluate(sgn.mean())
+
+  def testZeroPeakFails(self):
+    with self.assertRaisesOpError('Argument `peak` must be nonzero.'):
+      sgn = SGN(self.make_input(1.),
+                self.make_input(5.),
+                self.make_input(0.),
+                validate_args=True)
+      self.evaluate(sgn.mean())
+
+  def testSkewGeneralizedNormalShape(self):
+    mu = tf.constant([-3.] * 5, self.dtype)
+    sigma = tf.constant(11., self.dtype)
+    peak = tf.constant(1., self.dtype)
+    sgn = SGN(loc=mu, scale=sigma, peak=peak, validate_args=True)
+
+    self.assertEqual(self.evaluate(sgn.batch_shape_tensor()), [5])
+    self.assertEqual(sgn.batch_shape, tf.TensorShape([5]))
+    self.assertAllEqual(self.evaluate(sgn.event_shape_tensor()), [])
+    self.assertEqual(sgn.event_shape, tf.TensorShape([]))
+
+  @test_util.jax_disable_variable_test
+  @test_util.numpy_disable_test_missing_functionality(
+      'NumpyVariable does not handle unknown shapes')
+  def testSkewGeneralizedNormalShapeWithPlaceholders(self):
+    mu = tf.Variable(np.float32(5), shape=tf.TensorShape(None))
+    scale = tf.Variable(np.float32([1., 2.]), shape=tf.TensorShape(None))
+    peak = tf.Variable(np.float32([[1., 2.]]).T, shape=tf.TensorShape(None))
+    self.evaluate([mu.initializer, scale.initializer, peak.initializer])
+    sgn = SGN(loc=mu, scale=scale, peak=peak, validate_args=True)
+
+    self.assertEqual(sgn.event_shape, ())
+    self.assertEqual(sgn.batch_shape, tf.TensorShape(None))
+    self.assertAllEqual(self.evaluate(sgn.event_shape_tensor()), [])
+    self.assertAllEqual(self.evaluate(sgn.batch_shape_tensor()), [2, 2])
+
+  def testVariableScale(self):
+    x = tf.Variable(1., dtype=self.dtype)
+    d = SGN(loc=self.make_input(0.),
+            scale=x,
+            peak=self.make_input(3.),
+            validate_args=True)
+    self.evaluate([v.initializer for v in d.variables])
+    self.assertIs(x, d.scale)
+    with self.assertRaisesOpError('Argument `scale` must be positive.'):
+      with tf.control_dependencies([x.assign(-1.)]):
+        self.evaluate(d.mean())
+
+  def testIncompatibleArgShapesGraph(self):
+    peak = tf.Variable(tf.ones([2, 3], dtype=self.dtype),
+                       shape=tf.TensorShape(None), name='peak')
+    self.evaluate(peak.initializer)
+    with self.assertRaisesRegexp(Exception, r'compatible shapes'):
+      d = SGN(loc=tf.zeros([4, 1], dtype=self.dtype),
+              scale=tf.ones([4, 1], dtype=self.dtype),
+              peak=peak, validate_args=True)
+      self.evaluate(d.mean())
+
+
+class SkewGeneralizedNormalEagerGCTest(test_util.TestCase):
+
+  @tf_test_util.run_in_graph_and_eager_modes(assert_no_eager_garbage=True)
+  def testSkewGeneralizedNormalMeanAndMode(self):
+    loc = np.array([7.], dtype=np.float64)
+    scale = np.array([11., 12., 13.], dtype=np.float64)
+    peak = np.array([1., 2., 3.], dtype=np.float64)
+
+    sgn = SGN(loc=loc, scale=scale, peak=peak, validate_args=True)
+
+    self.assertAllEqual((3,), sgn.mean().shape)
+    self.assertAllClose(_np_mean(loc, scale, peak), self.evaluate(sgn.mean()))
+
+    self.assertAllEqual((3,), sgn.mode().shape)
+    self.assertAllClose(_np_mode(loc, scale, peak), self.evaluate(sgn.mode()))
+
+
+@test_util.test_all_tf_execution_regimes
+class SkewGeneralizedNormalTestStaticShapeFloat32(test_util.TestCase,
+                                                  _SkewGeneralizedNormalTest):
+  dtype = np.float32
+  use_static_shape = True
+
+  def setUp(self):
+    self._rng = np.random.RandomState(123)
+    super(SkewGeneralizedNormalTestStaticShapeFloat32, self).setUp()
+
+
+@test_util.test_all_tf_execution_regimes
+class SkewGeneralizedNormalTestDynamicShapeFloat32(test_util.TestCase,
+                                                   _SkewGeneralizedNormalTest):
+  dtype = np.float32
+  use_static_shape = False
+
+  def setUp(self):
+    self._rng = np.random.RandomState(123)
+    super(SkewGeneralizedNormalTestDynamicShapeFloat32, self).setUp()
+
+
+@test_util.test_all_tf_execution_regimes
+class SkewGeneralizedNormalTestStaticShapeFloat64(test_util.TestCase,
+                                                  _SkewGeneralizedNormalTest):
+  dtype = np.float64
+  use_static_shape = True
+
+  def setUp(self):
+    self._rng = np.random.RandomState(123)
+    super(SkewGeneralizedNormalTestStaticShapeFloat64, self).setUp()
+
+
+@test_util.test_all_tf_execution_regimes
+class SkewGeneralizedNormalTestDynamicShapeFloat64(test_util.TestCase,
+                                                   _SkewGeneralizedNormalTest):
+  dtype = np.float64
+  use_static_shape = False
+
+  def setUp(self):
+    self._rng = np.random.RandomState(123)
+    super(SkewGeneralizedNormalTestDynamicShapeFloat64, self).setUp()
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Adds the skew generalized normal distribution (the "version 2" / skew variant of the generalized normal), parameterized by location `loc`, scale `scale` (> 0) and shape `peak` (any nonzero real). It is the change-of-variables of a standard normal under
y = (-1/peak) * log(1 - peak * (x - loc) / scale), giving a parameter-dependent half-line support whose mode sits at or near the support boundary (the gap shrinks like exp(-peak**2) as |peak| grows).

Includes log_prob / cdf / log_cdf / survival / quantile / sampling, entropy, mean / variance / mode, and a support-respecting default event-space bijector built as a single Chain (valid for either sign of `peak`). Full unit tests validate against the closed-form v2 formulas and the peak -> 0 Normal limit, since no v2 reference exists in scipy (scipy.stats.gennorm is the symmetric v1). Registered in distributions `__init__`, BUILD, and hypothesis_testlib.