### PR TITLE
docs(readme): fix examples list formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ for end-to-end examples. It includes tutorial notebooks such as:
 
 It also includes example scripts such as:
 
-  Representation learning with a latent code and variational inference.
 * [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/main/tensorflow_probability/examples/vq_vae.py).
   Discrete representation learning with vector quantization.
-* [Disentangled Sequential Variational Autoencoder](https://github.com/tensorflow/probability/tree/main/tensorflow_probability/examples/disentangled_vae.py)
+* [Disentangled Sequential Variational Autoencoder](https://github.com/tensorflow/probability/tree/main/tensorflow_probability/examples/disentangled_vae.py).
   Disentangled representation learning over sequences with variational inference.
 * [Bayesian Neural Networks](https://github.com/tensorflow/probability/tree/main/tensorflow_probability/examples/bayesian_neural_network.py).
   Neural networks with uncertainty over their weights.


### PR DESCRIPTION
Summary
- Remove an orphaned example description line from the README examples list.
- Add the missing sentence-ending period to the Disentangled Sequential Variational Autoencoder entry.

Why this helps
- Keeps the README examples section easier to scan and avoids a dangling description that no longer has a linked example script.

Changes made
- Updated the example scripts list in README.md.

Testing
- git diff --check
- Verified README example list structure with a focused Python check.
- Verified linked example script files exist locally.

Related issue
- None.